### PR TITLE
Adds support for using feature-query-parameters

### DIFF
--- a/web/src/hooks/fetch.js
+++ b/web/src/hooks/fetch.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { isEmpty } from 'lodash';
+import { isArray, isNull } from 'lodash';
 
 import { DATA_FETCH_INTERVAL } from '../helpers/constants';
 

--- a/web/src/hooks/fetch.js
+++ b/web/src/hooks/fetch.js
@@ -5,13 +5,15 @@ import { isEmpty } from 'lodash';
 
 import { DATA_FETCH_INTERVAL } from '../helpers/constants';
 
-import { useCustomDatetime, useWindEnabled, useSolarEnabled } from './router';
+import { useCustomDatetime, useWindEnabled, useSolarEnabled, useFeatureToggle } from './router';
 import { useCurrentZoneHistory } from './redux';
 
 export function useConditionalZoneHistoryFetch() {
   const { zoneId } = useParams();
   const historyData = useCurrentZoneHistory();
   const customDatetime = useCustomDatetime();
+  const features = useFeatureToggle();
+
   const dispatch = useDispatch();
 
   // Fetch zone history data only if it's not there yet (and custom timestamp is not used).
@@ -21,22 +23,23 @@ export function useConditionalZoneHistoryFetch() {
     } else if (zoneId && isArray(historyData) && historyData.length === 0) {
       console.error('No history data available right now!');
     } else if (zoneId && isNull(historyData)) {
-      dispatch({ type: 'ZONE_HISTORY_FETCH_REQUESTED', payload: { zoneId } });
+      dispatch({ type: 'ZONE_HISTORY_FETCH_REQUESTED', payload: { zoneId, features } });
     }
   }, [zoneId, historyData, customDatetime]);
 }
 
 export function useGridDataPolling() {
   const datetime = useCustomDatetime();
+  const features = useFeatureToggle();
   const dispatch = useDispatch();
 
   // After initial request, do the polling only if the custom datetime is not specified.
   useEffect(() => {
     let pollInterval;
-    dispatch({ type: 'GRID_DATA_FETCH_REQUESTED', payload: { datetime } });
+    dispatch({ type: 'GRID_DATA_FETCH_REQUESTED', payload: { datetime, features } });
     if (!datetime) {
       pollInterval = setInterval(() => {
-        dispatch({ type: 'GRID_DATA_FETCH_REQUESTED', payload: { datetime } });
+        dispatch({ type: 'GRID_DATA_FETCH_REQUESTED', payload: { datetime, features } });
       }, DATA_FETCH_INTERVAL);
     }
     return () => clearInterval(pollInterval);

--- a/web/src/hooks/fetch.js
+++ b/web/src/hooks/fetch.js
@@ -18,7 +18,9 @@ export function useConditionalZoneHistoryFetch() {
   useEffect(() => {
     if (customDatetime) {
       console.error('Can\'t fetch history when a custom date is provided!');
-    } else if (zoneId && isEmpty(historyData)) {
+    } else if (zoneId && isArray(historyData) && historyData.length === 0) {
+      console.error('No history data available right now!');
+    } else if (zoneId && isNull(historyData)) {
       dispatch({ type: 'ZONE_HISTORY_FETCH_REQUESTED', payload: { zoneId } });
     }
   }, [zoneId, historyData, customDatetime]);

--- a/web/src/hooks/redux.js
+++ b/web/src/hooks/redux.js
@@ -13,13 +13,13 @@ export function useCurrentZoneHistory() {
   const { zoneId } = useParams();
   const histories = useSelector((state) => state.data.histories);
 
-  return useMemo(() => histories[zoneId] || [], [histories, zoneId]);
+  return useMemo(() => histories[zoneId] || null, [histories, zoneId]);
 }
 
 export function useCurrentZoneHistoryDatetimes() {
   const zoneHistory = useCurrentZoneHistory();
 
-  return useMemo(() => zoneHistory.map((d) => moment(d.stateDatetime).toDate()), [zoneHistory]);
+  return useMemo(() => !zoneHistory ? [] : zoneHistory.map((d) => moment(d.stateDatetime).toDate()), [zoneHistory]);
 }
 
 // Use current time as the end time of the graph time scale explicitly
@@ -51,7 +51,7 @@ export function useCurrentZoneData() {
   const grid = useSelector((state) => state.data.grid);
 
   return useMemo(() => {
-    if (!zoneId || !grid) {
+    if (!zoneId || !grid || !zoneHistory) {
       return null;
     }
     if (zoneTimeIndex === null) {
@@ -71,7 +71,7 @@ export function useCurrentZoneExchangeKeys() {
   );
 
   return useMemo(() => {
-    if (!isConsumption) {
+    if (!isConsumption || !zoneHistory) {
       return [];
     }
     const exchangeKeys = new Set();

--- a/web/src/hooks/router.js
+++ b/web/src/hooks/router.js
@@ -5,6 +5,15 @@ export function useSearchParams() {
   return new URLSearchParams(useLocation().search);
 }
 
+export function useFeatureToggle() {
+  const searchParams = useSearchParams();
+
+  return useMemo(() => {
+    const featureToggles = searchParams.get('feature');
+    return featureToggles ? featureToggles.split(',') : [];
+  }, [searchParams]);
+}
+
 export function useCustomDatetime() {
   return useSearchParams().get('datetime');
 }

--- a/web/src/sagas/index.js
+++ b/web/src/sagas/index.js
@@ -18,7 +18,7 @@ function* fetchZoneHistory(action) {
   const { zoneId, features } = action.payload;
   let queryParamString = `?countryCode=${zoneId}&preview=1`;
 
-  if (features) {
+  if (features.length > 0) {
     queryParamString += `&feature=${features.join(',')}`;
   }
 
@@ -33,9 +33,9 @@ function* fetchZoneHistory(action) {
 
 function* fetchGridData(action) {
   const { features } = action.payload || {};
-
   let queryParamString = '?preview=1';
-  if (features) {
+
+  if (features.length > 0) {
     queryParamString += `&feature=${features.join(',')}`;
   }
   try {

--- a/web/src/sagas/index.js
+++ b/web/src/sagas/index.js
@@ -15,9 +15,15 @@ import {
 } from '../helpers/gfs';
 
 function* fetchZoneHistory(action) {
-  const { zoneId } = action.payload;
+  const { zoneId, features } = action.payload;
+  let queryParamString = `?countryCode=${zoneId}&preview=1`;
+
+  if (features) {
+    queryParamString += `&feature=${features.join(',')}`;
+  }
+
   try {
-    const payload = yield call(protectedJsonRequest, `/v3/history?countryCode=${zoneId}&preview=1`);
+    const payload = yield call(protectedJsonRequest, `/v3/history${queryParamString}`);
     yield put({ type: 'ZONE_HISTORY_FETCH_SUCCEEDED', zoneId, payload });
   } catch (err) {
     yield put({ type: 'ZONE_HISTORY_FETCH_FAILED' });
@@ -25,9 +31,15 @@ function* fetchZoneHistory(action) {
   }
 }
 
-function* fetchGridData() {
+function* fetchGridData(action) {
+  const { features } = action.payload || {};
+
+  let queryParamString = '?preview=1';
+  if (features) {
+    queryParamString += `&feature=${features.join(',')}`;
+  }
   try {
-    const payload = yield call(protectedJsonRequest, '/v3/state?preview=1');
+    const payload = yield call(protectedJsonRequest, `/v3/state${queryParamString}`);
     yield put({ type: 'TRACK_EVENT', payload: { eventName: 'pageview' } });
     yield put({ type: 'APPLICATION_STATE_UPDATE', key: 'callerLocation', value: payload.callerLocation });
     yield put({ type: 'APPLICATION_STATE_UPDATE', key: 'callerZone', value: payload.callerZone });


### PR DESCRIPTION
### Description

_Part of #3575_

This will make it possible to try out new features before they are publicly released.

For now, this will be possible by setting a query-parameter which can both be used in frontend and will also be sent to the app-backend.

#### Usage

Add a `?feature=XXX` parameter to the URL. I have also added support for a comma-separated list, so one can test multiple features simultaneously :)

- http://localhost:9000/zone/IS?feature=estimations
- http://localhost:9000/zone/IS?feature=estimations,otherfeature


#### Preview

<img width="983" alt="Screenshot 2021-12-02 at 13 33 32" src="https://user-images.githubusercontent.com/3296643/144432195-2bb6cfc3-f12a-4d31-a7af-f0b0a4752b91.png">


#### NOTE

While at it, I also fixed a bug, where the app would get caught in a loop constantly calling the backend - it only happens if the backend returns empty data, which shouldn't happen unless something is down (but it happens more frequently when developing locally). 
