### PR TITLE
Bump mobile version number after breaking cordova changes

### DIFF
--- a/mobileapp/config.xml
+++ b/mobileapp/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.tmrow.electricitymap" version="1.2.3" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.tmrow.electricitymap" version="1.3.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>electricityMap</name>
     <description>
         electricityMap is a live visualization of where your electricity comes from and how much CO2 was emitted to produce it.


### PR DESCRIPTION
Hypothesis: The cordova upgrades done in https://github.com/electricityMap/electricitymap-contrib/pull/3574 potentially introduced a breaking change that requires a new native build.

At least what we observed: if a user upgrades an existing app (using codepush) the app would be stuck on a white screen after the splash screen. We rolled back the codepush update, so new users opening the app should not be affected. 

**Users opening the app the last 40 hours would need to reinstall the app.** :(

In this PR we bump the native version number, which should ensure that the new codepush bundle (that requires a new native release) will not be pushed to existing app installations.