### PR TITLE
Brazil capacity update

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -791,10 +791,10 @@
       ]
     ],
     "capacity": {
-      "hydro": 58142,
+      "hydro": 58171,
       "nuclear": 1990,
-      "solar": 923,
-      "unknown": 19446,
+      "solar": 1181,
+      "unknown": 21193,
       "wind": 28
     },
     "contributors": [
@@ -821,9 +821,9 @@
       ]
     ],
     "capacity": {
-      "hydro": 22261,
-      "solar": 3,
-      "unknown": 3641,
+      "hydro": 22251,
+      "solar": 5,
+      "unknown": 3645,
       "wind": 426
     },
     "contributors": [
@@ -850,10 +850,10 @@
       ]
     ],
     "capacity": {
-      "hydro": 11021,
-      "solar": 2128,
-      "unknown": 8243,
-      "wind": 14278
+      "hydro": 11032,
+      "solar": 3215,
+      "unknown": 8290,
+      "wind": 16744
     },
     "contributors": [
       "https://github.com/alexanmtz",
@@ -879,10 +879,10 @@
       ]
     ],
     "capacity": {
-      "hydro": 17166,
-      "solar": 8,
-      "unknown": 4227,
-      "wind": 2018
+      "hydro": 17252,
+      "solar": 9,
+      "unknown": 4252,
+      "wind": 2022
     },
     "contributors": [
       "https://github.com/alexanmtz",


### PR DESCRIPTION
I updated the capacities for Brazil. The north-east zone reports more solar than capacity for a few weeks already, so it's about time. I used the same source as before.