### PR TITLE
Fix GB wind being None

### DIFF
--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -238,7 +238,7 @@ def _fetch_wind(target_datetime=None):
 
     # line up with B1620 (main production report) search range
     d = target_datetime.date()
-    start = d - dt.timedelta(hours=24)
+    start = d - dt.timedelta(hours=48)
     end = dt.datetime.combine(d + dt.timedelta(days=1), dt.time(0))
 
     session = requests.session()

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -12,18 +12,18 @@ https://www.elexon.co.uk/wp-content/uploads/2017/06/
 bmrs_api_data_push_user_guide_v1.1.pdf
 """
 
-import os
-import arrow
-import logging
-import requests
 import datetime as dt
-import pandas as pd
+import logging
 from io import StringIO
+
+import arrow
+import pandas as pd
+import requests
 
 from parsers.lib.config import refetch_frequency
 
-from .lib.validation import validate
 from .lib.utils import get_token
+from .lib.validation import validate
 
 ELEXON_ENDPOINT = 'https://api.bmreports.com/BMRS/{}/v1'
 

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -303,11 +303,12 @@ def fetch_production(zone_key='GB', session=None, target_datetime=None,
             else:
                 entry['production']['wind'] = None
 
-    required = ['coal', 'gas', 'nuclear']
+    required = ['coal', 'gas', 'nuclear', 'wind']
     expected_range = {
         'coal': (0, 10000),
         'gas': (100, 30000),
-        'nuclear': (100, 20000)
+        'nuclear': (100, 20000),
+        'wind': (0, 30000),
     }
     data = [x for x in data
             if validate(


### PR DESCRIPTION
### Issue

Quite regularly, the wind production for edge hours (23:00 UTC which is 00:00 Europe/London) would be converted to None. This happens because there is a temporal gap between the data original fetched, and the wind fetched ad-hoc, meaning that we loose data for that half hour. 

Reproduce:

`poetry run python test_parser.py GB production --target_datetime 2019-09-20`

### Description

Makes sure to fetch enough data to match wind production against the other production modes, and add fail safe fallback by making wind required. 