### PR TITLE
Skips building world.json during build step

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -2577,6 +2577,16 @@
     "timezone": "America/Guyana"
   },
   "HK": {
+    "bounding_box": [
+      [
+        113.337331576,
+        21.677069403000075
+      ],
+      [
+        114.90129642000011,
+        23.06394603200009
+      ]
+    ],
     "flag_file_name": "hk.png",
     "timezone": "Asia/Hong_Kong"
   },
@@ -2690,7 +2700,17 @@
   },
   "ID": {
     "flag_file_name": "id.png",
-    "timezone": "Asia/Jakarta"
+    "timezone": "Asia/Jakarta",
+    "bounding_box": [
+      [
+        94.51270592500003,
+        -11.422621351999908
+      ],
+      [
+        141.47762699400005,
+        6.410101630000042
+      ]
+    ]
   },
   "IE": {
     "_comment": "hydro incl. 292 MW pumped storage",

--- a/web/BUILD.yaml
+++ b/web/BUILD.yaml
@@ -25,7 +25,7 @@ steps:
       - ./{.babelrc,.eslintrc.js,server.js,webpack.config.js}
     commands:
       - mkdir -p public/dist
-      - bash geo/topogen.sh
+      - bash geo/topogen.sh --ignore-world
       - yarn update-version
       - yarn build-release
     outputs:

--- a/web/geo/generate-geometries.js
+++ b/web/geo/generate-geometries.js
@@ -60,7 +60,12 @@ const topo = topojson.topology(zones);
 const topoDetails = topojson.topology(zonesMoreDetails);
 const mergedTopo = shrinkAndMergeTopoJson(topo, topoDetails);
 
-fs.writeFileSync(`${SRC_FOLDER}/world.json`, JSON.stringify(mergedTopo));
+// If script was called with argument '--ignore-world', let's not write the file to disk
+if (process.argv[2] === '--ignore-world') {
+  console.log('Skipping creation of world.json due to flag');
+} else {
+  fs.writeFileSync(`${SRC_FOLDER}/world.json`, JSON.stringify(mergedTopo));
+}
 
 // The following data includes complex shapes and should only be used in the backend to query by lon/lat
 const backendGeos = countryGeos.concat(stateGeos, thirdpartyGeos, USOriginalGeos);

--- a/web/geo/topogen.sh
+++ b/web/geo/topogen.sh
@@ -77,4 +77,8 @@ echo 'Parsing 3rd party..'
 )> $BUILD_PATH/tmp_thirdparty.json
 
 # Generate final geometries
-node $CURRENT_PATH/generate-geometries.js
+if [[ $# -eq 1 ]] && [[ $1 == '--ignore-world' ]] ; then
+    node $CURRENT_PATH/generate-geometries.js --ignore-world
+else
+    node $CURRENT_PATH/generate-geometries.js
+fi


### PR DESCRIPTION
Adds a `--ignore-world` flag to the script, which we then use during build. 
Since `world.json` is committed and in the code, building it all the time (and breaking builds if it changes) does not make sense :)

Also,  this is currently blocking new releases..