### PR TITLE
Fixed PA, RU, RU-AS parsers and updated German capacities

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1563,23 +1563,24 @@
     ],
     "capacity": {
       "battery storage": 280,
-      "biomass": 8560,
-      "coal": 43950,
+      "biomass": 8570,
+      "coal": 43960,
       "gas": 30500,
       "geothermal": 47,
-      "hydro": 4850,
+      "hydro": 4860,
       "hydro storage": 9810,
       "nuclear": 8114,
       "oil": 4380,
-      "solar": 56040,
+      "solar": 58410,
       "unknown": 3700,
-      "wind": 63170
+      "wind": 64040
     },
     "contributors": [
       "https://github.com/corradio",
       "https://github.com/bohne13",
       "https://github.com/chiefymuc",
-      "https://github.com/nessie2013"
+      "https://github.com/nessie2013",
+      "https://github.com/IV1T3"
     ],
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",

--- a/parsers/PA.py
+++ b/parsers/PA.py
@@ -40,7 +40,7 @@ def fetch_production(zone_key='PA', session=None, target_datetime=None, logger: 
       'Hídrica': 'hydro',
       'Eólica': 'wind',
       'Solar': 'solar',
-      'Biogas': 'biomass',
+      'Biogás': 'biomass',
       'Térmica': 'unknown'
     }
     data = {

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -195,7 +195,11 @@ def fetch_production_2nd_synchronous_zone(zone_key='RU-AS', session=None, target
 
         # Date
         hour = datapoint['fHour']
-        datetime = arrow.get('%s %s' % (date, hour), 'YYYY.MM.DD HH:mm', tzinfo=tz)
+
+        if len(hour) == 1:
+            hour = '0' + hour
+
+        datetime = arrow.get('%s %s' % (date, hour), 'YYYY.MM.DD HH', tzinfo=tz)
         row['datetime'] = datetime.datetime
         last_dt = arrow.now(tz).shift(minutes=-30).datetime
 


### PR DESCRIPTION
This PR resolves issue #3608. Instead of `Biogás`, `Biogas` was used as a key for translation. Thus, resulting in a KeyError.

This PR resolves the issues #3583 and #3584. 
The API at [br.so-ups.ru](https://br.so-ups.ru/webapi/api/CommonInfo/GenEquipOptions_Z2?oesTerritory[]=540000&startDate=2021.12.24) returns the key `fHour` as a string without a leading 0 in case fHour < 10 as shown below. 

```python
[   
    {   
        ...
        'fHour': '0',
        ...
    },
    {   ...
        'fHour': '1',
        ...
    },
    ...,
]
```

Thus,`arrow.get('%s %s' % (date, hour), 'YYYY.MM.DD HH', tzinfo=tz)` failed due to a ParserMatchError:
`arrow.parser.ParserMatchError: Failed to match 'YYYY.MM.DD HH:mm' when parsing '2021.12.24 0'`

Additionally, I updated the German capacities.