### PR TITLE
Add series ID to error log for EIA parser

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -490,7 +490,7 @@ def _fetch_series(zone_key, series_id, session=None, target_datetime=None, logge
 
     eia_error_message = raw_data.get("data", {}).get("error")
     if eia_error_message:
-        logger.error(f"EIA error: {eia_error_message}")
+        logger.error(f"EIA error, for series_id [{series_id}]: {eia_error_message}")
         return []
 
     # UTC timestamp with no offset returned.


### PR DESCRIPTION
## Issue

#3648 

## Description

the EIA production parser fetches data for multiple series (e.g total production, nuclear, oil etc) when fetching all production. Error logs can be generated if the series is invalid for a given zone. We don't specify in the error log which series triggered the error, meaning that if a zone has multiple invalid series requested, we will have duplicates logs showing the same error, while they should instead specify which series generated the error.

Later down the line, it could be interesting to create a config where we specify the available series for all EIA zones so we don't query useless series. 