### PR TITLE
Update Panama Generation Capacities

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -4885,7 +4885,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 1018.393,
-      "solar": 197.872,
+      "solar": 317.872,
       "unknown": 0,
       "wind": 270
     },


### PR DESCRIPTION
https://www.pv-magazine.com/2022/01/07/central-americas-largest-pv-plant-goes-online/

> Central America’s largest PV plant goes online

> Avanzalia Panama, a subsidiary of Spanish developer Avanzalia Solar, secured permission in late December [2021] to operate its 120 MW Penonomé solar plant.

> The project was fully built by the end of 2020, but the company then conducted numerous power supply tests throughout 2021. The solar plant has since been certified by the National Dispatch Center of Panama.

https://app.electricitymap.org/zone/PA?wind=false&solar=false

![Screen Shot 2022-01-09 at 2 17 23 PM](https://user-images.githubusercontent.com/350893/148697285-1545d0d0-15ea-4967-b1dd-2343e30e4641.png)