### PR TITLE
Adds an error boundary to avoid showing a blank page

### DIFF
--- a/web/src/components/errorboundary.js
+++ b/web/src/components/errorboundary.js
@@ -57,7 +57,7 @@ class ErrorBoundary extends React.Component {
           <h1>Oh no, something went terribly wrong...</h1>
           <p>
             Please let us know{' '}
-            <a href="https://github.com/tmrowco/electricitymap-contrib/">on Github</a> so we can fix
+            <a href="https://github.com/electricitymap/electricitymap-contrib">on Github</a> so we can fix
             this!
           </p>
           <ErrorMessage>

--- a/web/src/components/errorboundary.js
+++ b/web/src/components/errorboundary.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const ErrorBox = styled.div`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const ErrorMessage = styled.pre`
+  font-size: 0.8rem;
+  background: #e0e0e0;
+  border-radius: 8px;
+  padding: 8px;
+  font-family: monospace;
+`;
+
+const BackToStartButton = styled.a`
+    background: #fafafa;
+    color: #000;
+    border: 1px solid #eee;
+
+    font-size: 1rem;
+    border-radius: 8px;
+    padding: 8px;
+    margin-top: 16px;
+    cursor: pointer;
+    &:hover {
+        background: #eee;
+        text-decoration: none;
+    }
+`;
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // TODO: Send this to Sentry
+    console.error(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const url = window.location.href;
+      return (
+        <ErrorBox>
+          <h1>Oh no, something went terribly wrong...</h1>
+          <p>
+            Please let us know{' '}
+            <a href="https://github.com/tmrowco/electricitymap-contrib/">on Github</a> so we can fix
+            this!
+          </p>
+          <ErrorMessage>
+            Error message: {this.state.error.message}
+            <br />
+            Url: {url}
+          </ErrorMessage>
+          <BackToStartButton href="/map">Back to map</BackToStartButton>
+        </ErrorBox>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/web/src/components/errorboundary.js
+++ b/web/src/components/errorboundary.js
@@ -54,7 +54,7 @@ class ErrorBoundary extends React.Component {
       const url = window.location.href;
       return (
         <ErrorBox>
-          <h1>Oh no, something went terribly wrong...</h1>
+          <h1>Oh no, something went wrong...</h1>
           <p>
             Please let us know{' '}
             <a href="https://github.com/electricitymap/electricitymap-contrib">on Github</a> so we can fix

--- a/web/src/layout/main.js
+++ b/web/src/layout/main.js
@@ -30,6 +30,7 @@ import OnboardingModal from '../components/onboardingmodal';
 import LoadingOverlay from '../components/loadingoverlay';
 import Toggle from '../components/toggle';
 import useSWR from 'swr';
+import ErrorBoundary from '../components/errorboundary';
 
 const CLIENT_VERSION_CHECK_INTERVAL = 60 * 60 * 1000; // 1 hour
 
@@ -95,24 +96,26 @@ const Main = ({
       >
         {headerVisible && <Header />}
         <div id="inner">
+          <ErrorBoundary>
           <LoadingOverlay visible={showLoadingOverlay} />
           <LeftPanel />
-          <MapContainer pathname={location.pathname} id="map-container">
-            <Map />
-            <Legend />
-            <div className="controls-container">
-              <Toggle
-                infoHTML={__('tooltips.cpinfo')}
-                onChange={value => dispatchApplication('electricityMixMode', value)}
-                options={[
-                  { value: 'production', label: __('tooltips.production') },
-                  { value: 'consumption', label: __('tooltips.consumption') },
-                ]}
-                value={electricityMixMode}
-              />
-            </div>
-            <LayerButtons />
-          </MapContainer>
+            <MapContainer pathname={location.pathname} id="map-container">
+              <Map />
+              <Legend />
+              <div className="controls-container">
+                <Toggle
+                  infoHTML={__('tooltips.cpinfo')}
+                  onChange={value => dispatchApplication('electricityMixMode', value)}
+                  options={[
+                    { value: 'production', label: __('tooltips.production') },
+                    { value: 'consumption', label: __('tooltips.consumption') },
+                  ]}
+                  value={electricityMixMode}
+                />
+              </div>
+              <LayerButtons />
+            </MapContainer>
+          </ErrorBoundary>
 
           <div id="connection-warning" className={`flash-message ${hasConnectionWarning ? 'active' : ''}`}>
             <div className="inner">


### PR DESCRIPTION
### Description

This catches errors and shows them in a nicer way to users (instead of a blank page), while allowing users to return to the map.

#### Preview

<img width="878" alt="Screenshot 2022-01-11 at 10 04 43" src="https://user-images.githubusercontent.com/3296643/148915710-c7a10816-380f-4956-911c-fd921969fd8c.png">

