### PR TITLE
Fixes crash on specific, small zones 

### DIFF
--- a/web/src/helpers/map.js
+++ b/web/src/helpers/map.js
@@ -1,6 +1,6 @@
 import { max, min, mean, isArray } from 'lodash';
 
-export function getCenteredLocationViewport([longitude, latitude]) {''
+export function getCenteredLocationViewport([longitude, latitude]) {
   return {
     width: window.innerWidth,
     height: window.innerHeight,

--- a/web/src/helpers/map.js
+++ b/web/src/helpers/map.js
@@ -1,6 +1,6 @@
-import { max, min, mean } from 'lodash';
+import { max, min, mean, isArray } from 'lodash';
 
-export function getCenteredLocationViewport([longitude, latitude]) {
+export function getCenteredLocationViewport([longitude, latitude]) {''
   return {
     width: window.innerWidth,
     height: window.innerHeight,
@@ -18,7 +18,8 @@ export function getCenteredZoneViewport(zone) {
   const latitudes = [];
 
   zone.geometry.coordinates.forEach((geojson) => {
-    geojson[0].forEach(([longitude, latitude]) => {
+    const data = isArray(geojson[0][0]) ? geojson[0] : geojson;
+    data.forEach(([longitude, latitude]) => {
       longitudes.push(longitude);
       latitudes.push(latitude);
     });

--- a/web/src/helpers/map.js
+++ b/web/src/helpers/map.js
@@ -13,11 +13,13 @@ export function getCenteredLocationViewport([longitude, latitude]) {
 // If the panel is open the zoom doesn't appear perfectly centered because
 // it centers on the whole window and not just the visible map part, which
 // is something one could fix in the future.
+// TODO: this could be done build time instead of runtime
 export function getCenteredZoneViewport(zone) {
   const longitudes = [];
   const latitudes = [];
 
   zone.geometry.coordinates.forEach((geojson) => {
+    // There seems to be an inconsistency in the generate-topojson script:
     const data = isArray(geojson[0][0]) ? geojson[0] : geojson;
     data.forEach(([longitude, latitude]) => {
       longitudes.push(longitude);


### PR DESCRIPTION
### Description

After the new geojson setup, clicking on some zones crashes the app: https://app.electricitymap.org/zone/US-SW-SRP
<img width="483" alt="Screenshot 2022-01-11 at 10 21 53" src="https://user-images.githubusercontent.com/3296643/148915897-3b4d7cf1-9fba-4257-9939-eb5f730543ae.png">

This happens due to the structure we're expecting, which apparently now may differ depending on the zone. I've only experienced the issue on certain US zones, but hopefully this will catch all of these errors :)