### PR TITLE
update PEI request with param now required

### DIFF
--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -25,7 +25,7 @@ def _find_pei_key(pei_list, sought_key):
 
 def _get_pei_info(requests_obj):
     url = 'https://wdf.princeedwardisland.ca/workflow'
-    request = {'featureName': 'WindEnergy'}
+    request = {'featureName': 'WindEnergy', 'queryName': 'WindEnergy'}
     headers = {'Content-Type': 'application/json'}
     response = requests_obj.post(url, data=json.dumps(request), headers=headers)
 
@@ -112,7 +112,7 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
     # In case of wind, some is paper-"exported" even if there is a net import,
     # and 'pei_wind_used'/'data5' indicates their accounting of part of the load
     # served by non-exported wind.
-    # # http://www.gov.pe.ca/windenergy/chart.php says:
+    # https://www.princeedwardisland.ca/en/feature/pei-wind-energy says:
     # "Wind Power Exported Off-Island is that portion of wind generation that is supplying
     # contracts elsewhere. The actual electricity from this portion of wind generation
     # may stay within PEI but is satisfying a contractual arrangement in another jurisdiction."


### PR DESCRIPTION
Should hopefully fix #3677, with the change it works for me locally now (and without the change it didn't):

```
(venv) jarek@x1:~/projects/electricitymap/parsers$ python CA_PE.py 
fetch_production() ->
{'datetime': datetime.datetime(2022, 1, 17, 21, 30, tzinfo=tzfile('/usr/share/zoneinfo/Canada/Atlantic')), 'zoneKey': 'CA-PE', 'production': {'wind': 113, 'oil': 0, 'coal': 0, 'hydro': 0, 'nuclear': 0, 'geothermal': 0}, 'storage': {}, 'source': 'princeedwardisland.ca'}
fetch_exchange("CA-PE", "CA-NB") ->
{'datetime': datetime.datetime(2022, 1, 17, 21, 30, tzinfo=tzfile('/usr/share/zoneinfo/Canada/Atlantic')), 'sortedZoneKeys': 'CA-NB->CA-PE', 'netFlow': 99, 'source': 'princeedwardisland.ca'}
```

Also update source URL in a comment.