### PR TITLE
Nicaragua generation capacity update

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -282,7 +282,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - List of PowerStations: [PowerStations](https://en.wikipedia.org/wiki/List_of_power_stations_in_Nepal)
   - GIS Map of Reservoir Projects: [GIS_Reservoir](https://www.doed.gov.np/download/GIS-map-of-reservoir-projects.pdf)
 - Netherlands: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
-- Nicaragua: [Climatescope](http://global-climatescope.org/en/country/nicaragua/)
+- Nicaragua: [INE](https://www.ine.gob.ni/index.php/electricidad/estadisticas-anuales)
 - Nigeria
   - [USAID](https://www.usaid.gov/powerafrica/nigeria)
   - [SO Grid](https://www.niggrid.org)

--- a/config/zones.json
+++ b/config/zones.json
@@ -4463,11 +4463,12 @@
       ]
     ],
     "capacity": {
-      "biomass": 133,
-      "geothermal": 154,
-      "hydro": 138,
-      "oil": 732,
-      "wind": 186
+      "biomass": 218.20,
+      "geothermal": 153.24,
+      "hydro": 157.42,
+      "solar": 16.36,
+      "oil": 888.31,
+      "wind": 186.20
     },
     "contributors": [
       "https://github.com/corradio",

--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -17,9 +17,11 @@ PRICE_URL = 'http://www.cndc.org.ni/consultas/infoRelevanteSIN/consultaCostoMarg
 # as of 2017-07-08.
 # It was obtained by matching each generation value to the graphic and name on the map,
 # by changing the formatter function in JS source to print the index along with the value.
-# Per http://global-climatescope.org/en/country/nicaragua/ "Installed capacity" section
-# and Wikipedia https://en.wikipedia.org/wiki/Electricity_sector_in_Nicaragua#Installed_capacity
-# (the latter quoting a 2006 report), all of "thermal" / fossil fuel generation is using oil/diesel.
+# Per the following sources:
+# - https://global-climatescope.org/markets/ni, "Installed capacity" section,
+# - https://www.cndc.org.ni/Publicaciones/InformeDiarioSIN/Informe_Ejecutivo.pdf,
+# - Wikipedia: https://en.wikipedia.org/wiki/Electricity_sector_in_Nicaragua#Installed_capacity (quoting a 2006 report),
+# all of "thermal" / fossil fuel generation is using oil/diesel.
 # Geothermal and biomass classification of Momotombo, San Jacinto, and Monte Rosa
 # is also per https://en.wikipedia.org/wiki/Electricity_sector_in_Nicaragua
 PLANT_CLASSIFICATIONS = [
@@ -204,7 +206,7 @@ def fetch_production(zone_key='NI', session=None, target_datetime=None, logger=g
     production, data_datetime = get_production_from_summary(requests_obj)
 
     # Explicitly report types that are not used in Nicaragua as zero.
-    # Source is Climatescope installed capacity for Nicaragua, see link above.
+    # Sources for installed capacity for Nicaragua is INE (Nicaraguan Institute of Energy -- see link in the DATA_SOURCES.md).
     production.update({
         'nuclear': 0,
         'coal': 0,

--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -206,7 +206,7 @@ def fetch_production(zone_key='NI', session=None, target_datetime=None, logger=g
     production, data_datetime = get_production_from_summary(requests_obj)
 
     # Explicitly report types that are not used in Nicaragua as zero.
-    # Sources for installed capacity for Nicaragua is INE (Nicaraguan Institute of Energy -- see link in the DATA_SOURCES.md).
+    # Source for installed capacity for Nicaragua is INE (Nicaraguan Institute of Energy -- see link in the DATA_SOURCES.md).
     production.update({
         'nuclear': 0,
         'coal': 0,

--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -206,7 +206,7 @@ def fetch_production(zone_key='NI', session=None, target_datetime=None, logger=g
     production, data_datetime = get_production_from_summary(requests_obj)
 
     # Explicitly report types that are not used in Nicaragua as zero.
-    # Source for installed capacity for Nicaragua is INE (Nicaraguan Institute of Energy -- see link in the DATA_SOURCES.md).
+    # Source for the installed capacity of Nicaragua is INE (Nicaraguan Institute of Energy -- see link in DATA_SOURCES.md).
     production.update({
         'nuclear': 0,
         'coal': 0,


### PR DESCRIPTION
I noticed a while ago that generation exceeded capacity for some of the generation types of Nicaragua.

I found a new source (official) for the installed capacities here:
- [https://www.ine.gob.ni/index.php/electricidad/estadisticas-anuales/](url)
- [https://www.ine.gob.ni/wp-content/uploads/2021/10/capacidad_instalada_dic20_actfeb21.pdf](url).