### PR TITLE
Add a retry mechanism in the IS parser

### DIFF
--- a/parsers/IS.py
+++ b/parsers/IS.py
@@ -27,6 +27,17 @@ def fetch_production(
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
     res = r.get(url)
+    
+    retry_count = 0
+    while res.status_code in [522]:
+        retry_count += 1
+        if retry_count > 5:
+            raise Exception('Retried too many times..')
+        # Wait and retry
+        logger.warn('Retrying..')
+        time.sleep(5 ** retry_count)
+        res = r.get(url)
+    
     assert res.status_code == 200, (
         "Exception when fetching production for "
         "{}: error when calling url={}".format(zone_key, url)

--- a/parsers/IS.py
+++ b/parsers/IS.py
@@ -1,6 +1,7 @@
 #!python3
 import logging
 import datetime
+import time
 
 # The arrow library is used to handle datetimes
 import arrow


### PR DESCRIPTION
https://github.com/electricitymap/electricitymap-contrib/issues/3707 is due to the IS parser API experiencing timeout issues. I was able to get data by F5ing the API url.