### PR TITLE
Change Kosovo/XK parser to ENTSOE

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -8973,7 +8973,12 @@
       "production": 48
     },
     "parsers": {
-      "production": "XK.fetch_production"
+      "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
+      "production": "ENTSOE.fetch_production",
+      "productionPerModeForecast": "ENTSOE.fetch_wind_solar_forecasts",
+      "productionPerUnit": "ENTSOE.fetch_production_per_units"
     },
     "timezone": "Europe/Belgrade"
   },


### PR DESCRIPTION
Changes the parser for Kosovo to ENTSOE.py for all available data (= all but fetch_price).
I left the old parser XK.py untouched, just in case it is needed in the future.

![grafik](https://user-images.githubusercontent.com/25743609/153553946-458badef-e1a9-4707-82ec-30ca18bd37c2.png)
