### PR TITLE
Use Paris' time zone for GB's price parser

### DIFF
--- a/parsers/GB.py
+++ b/parsers/GB.py
@@ -21,7 +21,7 @@ from parsers.lib.config import refetch_frequency
 def fetch_price(zone_key, session=None, target_datetime=None,
                 logger=logging.getLogger(__name__)) -> list:
     if target_datetime:
-        now = arrow.get(target_datetime, tz='Europe/London')
+        now = arrow.get(target_datetime, tz='Europe/Paris')
     else:
         now = arrow.now(tz='Europe/London')
 
@@ -39,7 +39,7 @@ def fetch_price(zone_key, session=None, target_datetime=None,
         if donnesMarche.tag != 'donneesMarche':
             continue
 
-        start_date = arrow.get(arrow.get(donnesMarche.attrib['date']).datetime, 'Europe/London')
+        start_date = arrow.get(arrow.get(donnesMarche.attrib['date']).datetime, 'Europe/Paris')
 
         for item in donnesMarche:
             if item.get('granularite') != 'Global':


### PR DESCRIPTION
GB's price parser uses data from rte-france so the time zone should be Paris' one. It can be verified with Portugal's price, which is also available in rte-france's data.