### PR TITLE
Make it clear that we're looking for sharp minds to join the team⚡ 

### DIFF
--- a/web/src/components/openpositionsbadge.js
+++ b/web/src/components/openpositionsbadge.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const OpenPositionsBadgeWrapper = styled.div`
+  background-color: #f20050;
+  border-radius: 50px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: bold;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin-left: 4px;
+  transition: width 0.2s ease-in-out;
+  width: ${(props) => (props.shouldShow ? '20px' : '0px')};
+  && {
+    text-shadow: none;
+  }
+`;
+
+const OpenPositionsBadge = () => {
+  const [positions, setPositions] = React.useState(null);
+
+  // Fetch the RSS feed to get the number of open positions
+  React.useEffect(() => {
+      fetch('https://electricitymap.org/jobs/rss.xml')
+      .then((res) => res.text())
+      .then((str) => new window.DOMParser().parseFromString(str, 'text/xml'))
+      .then((data) => {
+        const items = data.getElementsByTagName('item');
+        const openPositions = items ? items.length : null;
+        setPositions(openPositions);
+      })
+      .catch(() => console.log('Failed fetching open positions count'));
+  }, []);
+
+  return (
+    <OpenPositionsBadgeWrapper shouldShow={positions > 0}>{positions}</OpenPositionsBadgeWrapper>
+  );
+};
+
+
+
+  export default OpenPositionsBadge;

--- a/web/src/layout/header.js
+++ b/web/src/layout/header.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import SharedHeader from '../components/sharedheader';
+import OpenPositionsBadge from '../components/openpositionsbadge';
 
 const logo = resolvePath('images/electricitymap-logo.svg');
 
@@ -11,7 +12,7 @@ const headerLinks = [
     active: true,
   },
   {
-    label: <React.Fragment>We&apos;re hiring!</React.Fragment>,
+    label: <React.Fragment>We&apos;re hiring!<OpenPositionsBadge /></React.Fragment>,
     href: 'https://electricitymap.org/jobs?utm_source=app.electricitymap.org&utm_medium=referral',
   },
 

--- a/web/src/layout/header.js
+++ b/web/src/layout/header.js
@@ -11,6 +11,11 @@ const headerLinks = [
     active: true,
   },
   {
+    label: <React.Fragment>We&apos;re hiring!</React.Fragment>,
+    href: 'https://electricitymap.org/jobs?utm_source=app.electricitymap.org&utm_medium=referral',
+  },
+
+  {
     label: 'Open Source',
     href: 'https://electricitymap.org/open-source?utm_source=app.electricitymap.org&utm_medium=referral',
   },

--- a/web/src/layout/header.js
+++ b/web/src/layout/header.js
@@ -13,7 +13,7 @@ const headerLinks = [
   },
   {
     label: <React.Fragment>We&apos;re hiring!<OpenPositionsBadge /></React.Fragment>,
-    href: 'https://electricitymap.org/jobs?utm_source=app.electricitymap.org&utm_medium=referral',
+    href: 'https://electricitymap.org/jobs#joboffers?utm_source=app.electricitymap.org&utm_medium=referral',
   },
 
   {


### PR DESCRIPTION
### Description

This adds a "We're hiring!" link to the header in the hope that we can reach some of the awesome people using the map.
There's also a small badge with the number of open positions, which is using the [rss.xml feed](https://electricitymap.org/jobs/rss.xml) to count the number.

#### Preview

<img width="612" alt="Screenshot 2022-02-23 at 07 14 11" src="https://user-images.githubusercontent.com/3296643/155288707-8ad2581c-fa71-46ad-a549-ad74a3d557e3.png">

