### PR TITLE
more robust CA_PE default when 'data' is missing

### DIFF
--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -29,7 +29,7 @@ def _get_pei_info(requests_obj):
     headers = {'Content-Type': 'application/json'}
     response = requests_obj.post(url, data=json.dumps(request), headers=headers)
 
-    raw_data = response.json().get('data', [])
+    raw_data = response.json().get('data') or []
 
     datetime_item = [item['data']['text'] for item in raw_data
                      if 'text' in item['data']]


### PR DESCRIPTION
there's currently an issue ([see logs](https://storage.googleapis.com/electricitymap-parser-logs/CA-PE.html) and pasted below) where we are trying to iterate through a None-typed object. We already "support" the data returning empty (by calling `.get("data", [])` but this means that if the data is returned like `{"data": null}` we'll hit this NPE. This is just a slightly more robust way of doing that.

Please let me know if tihs is unhelpful!

```
'NoneType' object is not iterable

  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 771, in get
    raise self._value

  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))

  File "/home/contrib/parsers/CA_PE.py", line 65, in fetch_production
    pei_info = _get_pei_info(requests_obj)

  File "/home/contrib/parsers/CA_PE.py", line 34, in _get_pei_info
    datetime_item = [item['data']['text'] for item in raw_data          
```

