### PR TITLE
www.ssen.co.uk -> distribution.ssen.co.uk

### DIFF
--- a/parsers/GB_ORK.py
+++ b/parsers/GB_ORK.py
@@ -12,8 +12,8 @@ from bs4 import BeautifulSoup
 # http://www.oref.co.uk/orkneys-energy/innovations-2/
 
 TZ = 'Europe/London'
-DATETIME_LINK = 'https://www.ssen.co.uk/anm/orkney/'
-GENERATION_LINK = 'https://www.ssen.co.uk/Sse_Components/Views/Controls/FormControls/Handlers/ActiveNetworkManagementHandler.ashx?action=graph&contentId=14973&_=1537467858726'
+DATETIME_LINK = 'https://distribution.ssen.co.uk/anm/orkney/'
+GENERATION_LINK = 'https://distribution.ssen.co.uk/Sse_Components/Views/Controls/FormControls/Handlers/ActiveNetworkManagementHandler.ashx?action=graph&contentId=14973&_=1537467858726'
 
 GENERATION_MAPPING = {"Live Demand": "Demand",
                       "Orkney ANM": "ANM Renewables",


### PR DESCRIPTION
was able to repro #3827 with just "poetry run test_parser", after this fix we get:

```
Parser result:
{'datetime': datetime.datetime(2022, 3, 5, 16, 5, 8, tzinfo=tzfile('/usr/share/zoneinfo/Europe/London')),
 'production': {'unknown': 8.643999},
 'source': 'ssen.co.uk',
 'storage': {'battery': None},
 'zoneKey': 'GB-ORK'}
---------------------
took 1.50s
min returned datetime: 2022-03-05T16:05:08+00:00 UTC
max returned datetime: 2022-03-05T16:05:08+00:00 UTC  -- OK, <2h from now :) (now=2022-03-05T16:05:08.356888+00:00 UTC)
```

so it definitely fixes something, teh above still looks fishy to me so maybe they changed more things tahn just the domain (but also i have no experience reading these outputs)