### PR TITLE
Supports file:// protocol on iOS

### DIFF
--- a/mobileapp/config.xml
+++ b/mobileapp/config.xml
@@ -38,6 +38,10 @@
         <!-- <preference name="CodePushDeploymentKey" value="EgyH71oYOglC8w-se8f-EDACw0KtEJ-bjzkpG" /> -->
         <preference name="StatusBarStyle" value="default" />
         <preference name="DisallowOverscroll" value="true" />
+        <preference name="AllowUntrustedCerts"  value="true" />
+        <preference name="InterceptRemoteRequests" value="all" />
+        <preference name="allowUniversalAccessFromFileURLs" value="true" />
+        <preference name="allowFileAccessFromFileURLs" value="true" />
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <splash src="res/screen/ios/Default@2x~universal~anyany.png" />

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -36,7 +36,8 @@
       },
       "cordova-universal-links-plugin": {},
       "cordova-plugin-whitelist": {},
-      "cordova-plugin-code-push": {}
+      "cordova-plugin-code-push": {},
+      "@globules-io/cordova-plugin-ios-xhr": {}
     },
     "platforms": [
       "android",


### PR DESCRIPTION
_Part of https://github.com/electricitymap/electricitymap-contrib/issues/3837, and splitting up my huge PR in https://github.com/electricitymap/electricitymap-contrib/pull/3825_

### Description

Makes it possible to use the `file://` protocol in Cordova, which currently fails on `iOS`.
This is a prerequisite for switching to https://github.com/i18next/i18next-http-backend later on :)

