### PR TITLE
Update installed capacity data for Ontario

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1157,13 +1157,13 @@
       ]
     ],
     "capacity": {
-      "biomass": 295,
+      "biomass": 296,
       "coal": 0,
-      "gas": 11317,
+      "gas": 10515,
       "hydro": 8918,
-      "nuclear": 13009,
+      "nuclear": 13089,
       "solar": 478,
-      "wind": 4786
+      "wind": 4783
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
Updates the installed capacity for Ontario according to Table 4-1 in the latest [IESO Reliability Outlook](https://www.ieso.ca/-/media/Files/IESO/Document-Library/planning-forecasts/reliability-outlook/ReliabilityOutlook2021Dec.ashx) dated December 2021.