### PR TITLE
Update installed capacity data for Manitoba

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -191,6 +191,9 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   [wikipedia.org](https://en.wikipedia.org/wiki/List_of_generating_stations_in_Canada)
 - Canada (Alberta): [AESO](http://ets.aeso.ca/ets_web/ip/Market/Reports/CSDReportServlet),
   [wikipedia.org](https://en.wikipedia.org/wiki/List_of_generating_stations_in_Alberta)
+- Canada (Manitoba)
+  - Hydro & Gas: [Manitoba Hydro-Electric Board](https://www.hydro.mb.ca/corporate/ar/pdf/annual_report_2020_21.pdf), [Manitoba Hydro](https://www.hydro.mb.ca/corporate/facilities/generating_stations/#selkirk)
+  - Wind: [Province of Manitoba](https://gov.mb.ca/sd/environment_and_biodiversity/energy/wind/windfarms.html)
 - Canada (Ontario): [IESO](http://www.ieso.ca/en/Power-Data/Supply-Overview/Transmission-Connected-Generation)
 - Canada (Québec): [Hydro-Québec](https://www.hydroquebec.com/generation/generating-stations.html)
 - Canada (Saskatchewan): [SaskPower](http://www.saskpower.com/our-power-future/our-electricity/)

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -187,7 +187,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Bulgaria:
   - Hydro: [NEK](https://nek.bg/index.php/en/our-business/electricity-generation)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
-- Canada (British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Nova Scotia, Prince Edward Island):
+- Canada (British Columbia, New Brunswick, Newfoundland and Labrador, Nova Scotia, Prince Edward Island):
   [wikipedia.org](https://en.wikipedia.org/wiki/List_of_generating_stations_in_Canada)
 - Canada (Alberta): [AESO](http://ets.aeso.ca/ets_web/ip/Market/Reports/CSDReportServlet),
   [wikipedia.org](https://en.wikipedia.org/wiki/List_of_generating_stations_in_Alberta)

--- a/config/zones.json
+++ b/config/zones.json
@@ -1020,12 +1020,15 @@
       ]
     ],
     "capacity": {
-      "coal": 110,
-      "gas": 342,
-      "hydro": 5249,
-      "oil": 10,
-      "wind": 237
+      "coal": 0,
+      "gas": 237,
+      "hydro": 5234,
+      "oil": 13,
+      "wind": 258
     },
+    "contributors": [
+      "https://github.com/felixvanoost"
+    ],
     "flag_file_name": "ca.png",
     "timezone": null
   },

--- a/config/zones.json
+++ b/config/zones.json
@@ -1009,6 +1009,7 @@
     "timezone": null
   },
   "CA-MB": {
+    "_comment": "Coal capacity is 0MW after decomissioning of Selkirk in April 2021 (not reflected in latest report from March 2021)",
     "bounding_box": [
       [
         -102.50159786704786,
@@ -1030,7 +1031,7 @@
       "https://github.com/felixvanoost"
     ],
     "flag_file_name": "ca.png",
-    "timezone": null
+    "timezone": "America/Winnipeg"
   },
   "CA-NB": {
     "_comment": "gas includes an 88 MW cogeneration plant",


### PR DESCRIPTION
Updates the installed capacity for Manitoba according to the Manitoba Hydro-Electric Board [70th Annual Report](https://www.hydro.mb.ca/corporate/ar/pdf/annual_report_2020_21.pdf) and the [Province of Manitoba](https://gov.mb.ca/sd/environment_and_biodiversity/energy/wind/windfarms.html).

The Selkirk generation station was decomissioned in April 2021 according to [Manitoba Hydro](https://www.hydro.mb.ca/corporate/facilities/generating_stations/#selkirk), which was not reflected in the annual report released in March. As far as I can tell it was the last coal-fired generating station in the province, so the total coal capacity should be 0MW.