### PR TITLE
improve: Optimize contributors avatar size

### DIFF
--- a/web/src/components/contributorlist.js
+++ b/web/src/components/contributorlist.js
@@ -3,17 +3,26 @@ import { useParams } from 'react-router-dom';
 
 import zonesConfig from '../../../config/zones.json';
 
+const getContributorId = (contributor) => {
+  const contributorSplitted = contributor.split('/');
+  return contributorSplitted[contributorSplitted.length-1];
+}
+
 const ContributorList = () => {
   const { zoneId } = useParams();
   const contributors = (zonesConfig[zoneId] || {}).contributors || [];
 
   return (
     <div className="contributors">
-      {contributors.map(contributor => (
-        <a key={contributor} href={contributor} rel="noopener noreferrer" target="_blank">
-          <img src={`${contributor}.png`} alt={contributor} />
-        </a>
-      ))}
+      {contributors.map(contributor => {
+        const contributorId = getContributorId(contributor);
+    
+        return (
+          <a key={contributorId} href={contributor} rel="noopener noreferrer" target="_blank">
+            <img src={`https://avatars.githubusercontent.com/${contributorId}?s=40`} alt={contributorId} />
+          </a>
+        )
+      })}
     </div>
   );
 };


### PR DESCRIPTION
It replaces the contributor's avatar `URL` to get the avatar image in a smaller size when it's possible and avoid the redirection, as mentioned in the issue attached.

Closes: #3300