### PR TITLE
Fixes bug with emission-factors after changing to yearly co2eq-parameters

### DIFF
--- a/parsers/test/test_config.py
+++ b/parsers/test/test_config.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+"""Tests for config/__init__.py."""
+import unittest
+
+from electricitymap.contrib.config import emission_factors
+
+
+class EmissionFactorTestCase(unittest.TestCase):
+    """Tests for emission_factor."""
+
+    def test_emission_factors(self):
+        """Test that emission_factors handles yearly defaults correctly."""
+        expected = {
+            "battery charge": 0,
+            "battery discharge": 391.33,
+            "biomass": 230,
+            "coal": 820,
+            "gas": 490,
+            "geothermal": 38,
+            "hydro": 24,
+            "hydro charge": 0,
+            "hydro discharge": 391.33,
+            "nuclear": 12,
+            "oil": 650,
+            "solar": 45,
+            "unknown": 644,
+            "wind": 11,
+        }
+        self.assertEqual(emission_factors("KR"), expected)  # type: ignore
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This fixes the issue that is currently causing a lot of parsers to fail.
See comments by @jarek here: https://github.com/electricitymap/electricitymap-contrib/issues/3890

I also added a small test to verify the expected outcome of `emission_factors()`



