### PR TITLE
fix(parser): fix the NG parser

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -95,6 +95,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
   - [Siesa](https://www.southlanddc.govt.nz/my-southland/siesa-2/what-sieasa-does/)
   - [Energy Market Services](https://em6live.co.nz)
 - Nicaragua: [CNDC](http://www.cndc.org.ni/)
+- Nigeria: [TCN ISO grid data portal](https://www.niggrid.com/GenerationProfile)
 - Northern Ireland: [SONI](http://www.soni.ltd.uk/InformationCentre/)
 - Norway: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
 - Oman: [GCCIA](https://www.gccia.com.sa/)
@@ -290,7 +291,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Nicaragua: [INE](https://www.ine.gob.ni/index.php/electricidad/estadisticas-anuales)
 - Nigeria
   - [USAID](https://www.usaid.gov/powerafrica/nigeria)
-  - [SO Grid](https://www.niggrid.org)
+  - [TCN ISO grid data portal](https://www.niggrid.org)
 - North Macedonia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Norway: [NVE](https://www.nve.no/energiforsyning/kraftproduksjon/?ref=mainmenu)
 - Northern Ireland: [ENTSO-E](https://m-transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/config/zones.json
+++ b/config/zones.json
@@ -4461,6 +4461,7 @@
     },
     "contributors": [
       "https://github.com/byronwilliams",
+      "https://github.com/kruschk",
       "https://github.com/nessie2013"
     ],
     "parsers": {

--- a/parsers/NG.py
+++ b/parsers/NG.py
@@ -1,76 +1,88 @@
 #!/usr/bin/env python3
 
-"""Parser for the electricity grid of Nigeria"""
+"""Parser for the Nigerian electricity grid"""
 
-import arrow
+# Standard library imports
+import datetime
 import logging
+import re
+import urllib.parse
+
+# Third-party library imports
+import arrow
+import bs4
 import requests
-from bs4 import BeautifulSoup
+
+# Local library imports
+from parsers.lib import config, validation
+
+API_URL = urllib.parse.urlparse("https://niggrid.org/GenerationProfile")
+API_URL_STRING = API_URL.geturl()
+NORMALISE = {
+    "gas": "gas",
+    "gas/steam": "gas",
+    "hydro": "hydro",
+    # Per the "Electricity generation by source" plot at
+    # https://www.iea.org/countries/nigeria, the majority of Nigeria's
+    # generation comes from natural gas, so "steam" most likely implies "gas";
+    # therefore, we do not map "steam" to "unknown" (coal/gas/oil). See issues
+    # #2570 and #3651 for more information.
+    "steam": "gas",
+}
+PATTERN = re.compile(r"\((.*)\)")
 
 
-LIVE_PRODUCTION_API_URL = "https://www.niggrid.org/GenerationLoadProfileBinary?readingDate={0}&readingTime={1}"
-TYPE_MAPPING = {"hydro": "hydro", "gas": "gas", "gas/steam": "gas", "steam": "gas"}
-
-
-def extract_name_tech(company):
-    parts = company.split("(")
-    tech = parts[1].strip(")").lower()
-
-    return parts[0], TYPE_MAPPING[tech]
-
-
-def template_response(zone_key, datetime, source) -> dict:
-    return {
-        "zoneKey": zone_key,
-        "datetime": datetime,
-        "production": {
-            "gas": 0.0,
-            "hydro": 0.0,
-        },
-        "storage": {},
-        "source": source,
-    }
-
-
-def fetch_production(
-    zone_key=None,
-    session=None,
-    target_datetime=None,
-    logger=logging.getLogger(__name__),
-) -> list:
+# The data is hourly, but it takes a few minutes after the turn of each hour
+# for the server to populate it. Setting the re-fetch frequency to 45 min will
+# ensure that if the live data is missing for a given hour when it's first
+# fetched, it will be fetched again during the same hour. (As far as I can
+# tell, the table is always populated within 15 min of the turn of the hour).
+@config.refetch_frequency(datetime.timedelta(minutes=45))
+def fetch_production(zone_key="NG",
+                     session=None,
+                     target_datetime=None,
+                     logger=logging.getLogger(__name__)) -> dict:
     """Requests the last known production mix (in MW) of a given zone."""
+    timestamp = arrow.get(target_datetime) \
+                     .to("Africa/Lagos") \
+                     .replace(minute=0, second=0, microsecond=0)
 
-    if target_datetime is not None:
-        timestamp = arrow.get(target_datetime).to("Africa/Lagos").replace(minute=0)
-    else:
-        timestamp = arrow.now(tz="Africa/Lagos").replace(minute=0)
+    # GET the landing page (HTML) and scrape some form data from it.
+    session = session or requests.Session()
+    response = session.get(API_URL_STRING)
+    soup = bs4.BeautifulSoup(response.text, "html.parser")
+    data = {tag["name"]: tag["value"] for tag in soup.find_all("input")}
+    data["ctl00$MainContent$txtReadingDate"] = timestamp.format("DD/MM/YYYY")
+    data["ctl00$MainContent$ddlTime"] = timestamp.format("HH:mm")
 
-    dt_day = timestamp.format("DD/MM/YYYY")
-    dt_hm = timestamp.format("HH:mm")
-    fullUrl = LIVE_PRODUCTION_API_URL.format(dt_day, dt_hm)
-
-    r = session or requests.session()
-    resp = r.get(fullUrl)
-
-    try:
-        soup = BeautifulSoup(resp.text, "html.parser")
-        table = soup.find("table", {"id": "MainContent_gvGencoLoadProfiles"})
-        rows = table.find_all("tr")[1:-1]  # ignore header and footer rows
-    except AttributeError:
-        raise LookupError("No data currently available for Nigeria.")
-
-    result = template_response(zone_key, timestamp.datetime, "niggrid.org")
-
+    # Send a POST request for the desired grid data using parameters from the
+    # landing page form. The grid data is presented as an HTML table; we ignore
+    # its header and footer rows.
+    response = session.post(API_URL_STRING, data=data)
+    rows = bs4.BeautifulSoup(response.text, "html.parser").find_all("tr")[1:-1]
+    production_mix = {technology: 0.0 for technology in NORMALISE.values()}
     for row in rows:
-        _, company, mw, _ = map(lambda row: row.text.strip(), row.find_all("td"))
-        _, tech = extract_name_tech(company)
+        _, source, power, _ = (tag.text for tag in row.find_all("td"))
+        try:
+            technology = NORMALISE[PATTERN.search(source).group(1).casefold()]
+        except (AttributeError, KeyError) as error:
+            logger.warning(f"Unexpected source '{source.strip()}' encountered")
+            continue
+        production_mix[technology] += float(power)
 
-        result["production"][tech] += float(mw)
-
-    return [result]
+    # Return the production mix.
+    return validation.validate({
+                                   "zoneKey": zone_key,
+                                   "datetime": timestamp.datetime,
+                                   "production": production_mix,
+                                   "source": API_URL.netloc,
+                               },
+                               logger,
+                               floor=10.0,
+                               remove_negative=True)
 
 
 if __name__ == "__main__":
-    """Main method, never used by the Electricity Map backend, but handy for testing."""
+    """Never used by the Electricity Map backend, but handy for testing."""
     print(fetch_production())
-    print(fetch_production(target_datetime=arrow.get("20210110", "YYYYMMDD")))
+    print(fetch_production(target_datetime="2022-03-09T15:00:00"))


### PR DESCRIPTION
A server-side API change broke the NG parser. Before, data could be
requested with a simple GET request, but now it is necessary to send a
GET request, scrape some magic values from the response, then send a
POST request with those magic values.

- Fix issue #3651.
- Overhaul the parser to accomodate the new API.
- Update data sources and zones accordingly.

Refs: #3651