### PR TITLE
Change "natural gas" to "gas" 

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -124,7 +124,7 @@
     "biomass": "biomass",
     "nuclear": "nuclear",
     "geothermal": "geothermal",
-    "gas": "natural gas",
+    "gas": "gas",
     "coal": "coal",
     "oil": "oil",
     "unknown": "unknown",


### PR DESCRIPTION
After internal discussions, we have decided to go back to calling methane gas just "gas" in the English translation (instead of the current "natural gas").

[This paper from October](https://www.sciencedirect.com/science/article/abs/pii/S0272494421001249) researched how the naming changes perception, and the following highlights why we're changing to what is perceived as a more neutral name:
<img width="646" alt="Screenshot 2022-03-23 at 17 24 53" src="https://user-images.githubusercontent.com/3296643/159748422-f4a37f49-2b0b-4efe-9f1f-8bd8a36a0b10.png">



This reverts electricitymap/electricitymap-contrib#2730