### PR TITLE
Update Slovenia Solar to 504,4MW(31.12.2021)

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -5651,7 +5651,7 @@
       "hydro storage": 180,
       "nuclear": 696,
       "oil": 0,
-      "solar": 289,
+      "solar": 504.4,
       "wind": 3
     },
     "contributors": [


### PR DESCRIPTION
Source is http://pv.fe.uni-lj.si/SEvSLO.aspx which is owned by Faculty of Electrical Engineering and keeps track of solar installations and updates numbers every year.

Existing number is from 2018.