### PR TITLE
update capacities USA January 2022

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -5972,7 +5972,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 72.2,
-      "solar": 322.1,
+      "solar": 326.1,
       "unknown": 0,
       "wind": 0
     },
@@ -6007,18 +6007,18 @@
       ]
     ],
     "capacity": {
-      "battery storage": 1384.8,
-      "biomass": 1174.8,
+      "battery storage": 2283.9,
+      "biomass": 1179.8,
       "coal": 62.5,
-      "gas": 33011.8,
+      "gas": 33077,
       "geothermal": 2103.5,
-      "hydro": 6704.3,
+      "hydro": 6705.6,
       "hydro storage": 2094.4,
       "nuclear": 2323,
       "oil": 391.5,
-      "solar": 15006.4,
+      "solar": 15842.4,
       "unknown": 99.7,
-      "wind": 6022.5
+      "wind": 6140.2
     },
     "comment": "California Independent System Operator",
     "contributors": [
@@ -6187,7 +6187,7 @@
       "hydro storage": 0,
       "nuclear": 3722.7,
       "oil": 282.1,
-      "solar": 1562.1,
+      "solar": 1749.1,
       "unknown": 54,
       "wind": 0
     },
@@ -6272,10 +6272,10 @@
       "gas": 10719,
       "geothermal": 0,
       "hydro": 1180.7,
-      "hydro storage": 2070,
+      "hydro storage": 2166,
       "nuclear": 7517.5,
       "oil": 143.4,
-      "solar": 2241.5,
+      "solar": 2252.8,
       "unknown": 0,
       "wind": 0
     },
@@ -6482,18 +6482,18 @@
       ]
     ],
     "capacity": {
-      "battery storage": 26.4,
+      "battery storage": 27.9,
       "biomass": 344.2,
       "coal": 22064.3,
-      "gas": 36306.1,
+      "gas": 36281.3,
       "geothermal": 0,
       "hydro": 3104.1,
       "hydro storage": 259.2,
       "nuclear": 2068.7,
       "oil": 2185.4,
-      "solar": 404.8,
+      "solar": 409.8,
       "unknown": 62,
-      "wind": 26150.3
+      "wind": 29163.9
     },
     "comment": "Southwest Power Pool",
     "contributors": [
@@ -6575,7 +6575,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 1329.7,
-      "solar": 596.3,
+      "solar": 745.3,
       "unknown": 18.8,
       "wind": 0
     },
@@ -6610,7 +6610,7 @@
       ]
     ],
     "capacity": {
-      "battery storage": 24,
+      "battery storage": 493,
       "biomass": 622.4,
       "coal": 0,
       "gas": 23743.6,
@@ -6619,7 +6619,7 @@
       "hydro storage": 0,
       "nuclear": 3797.2,
       "oil": 261.5,
-      "solar": 2945.8,
+      "solar": 3542.6,
       "unknown": 0,
       "wind": 0
     },
@@ -6657,7 +6657,7 @@
       "battery storage": 0,
       "biomass": 116.1,
       "coal": 250.7,
-      "gas": 377.9,
+      "gas": 373.4,
       "geothermal": 0,
       "hydro": 0,
       "hydro storage": 0,
@@ -6905,14 +6905,14 @@
     "capacity": {
       "battery storage": 0,
       "biomass": 71.6,
-      "coal": 1124.4,
+      "coal": 678.9,
       "gas": 5535.7,
       "geothermal": 0,
       "hydro": 0,
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 133.4,
-      "solar": 659.7,
+      "solar": 895.3,
       "unknown": 335.3,
       "wind": 0
     },
@@ -7052,7 +7052,7 @@
       "geothermal": 0,
       "hydro": 0,
       "oil": 1528.9,
-      "solar": 198,
+      "solar": 201.1,
       "unknown": 0,
       "wind": 126.6
     },
@@ -7080,18 +7080,18 @@
       ]
     ],
     "capacity": {
-      "battery storage": 310.7,
-      "biomass": 2332.3,
-      "coal": 48944,
-      "gas": 99523,
+      "battery storage": 306.7,
+      "biomass": 2328.8,
+      "coal": 49012.9,
+      "gas": 102052.7,
       "geothermal": 0,
-      "hydro": 3308.7,
+      "hydro": 3311.2,
       "hydro storage": 5103.3,
       "nuclear": 34466.6,
-      "oil": 6082.6,
-      "solar": 5114.7,
+      "oil": 6088.6,
+      "solar": 6570.3,
       "unknown": 133.2,
-      "wind": 10420.7
+      "wind": 10662.2
     },
     "comment": "Pjm Interconnection, Llc",
     "contributors": [
@@ -7263,18 +7263,18 @@
       ]
     ],
     "capacity": {
-      "battery storage": 57.9,
+      "battery storage": 68.2,
       "biomass": 2487.4,
-      "coal": 58976.5,
-      "gas": 83309.2,
+      "coal": 57162.9,
+      "gas": 83349.6,
       "geothermal": 0,
-      "hydro": 2463,
+      "hydro": 2467.3,
       "hydro storage": 2416.8,
       "nuclear": 13080.8,
-      "oil": 5023.5,
-      "solar": 2304,
-      "unknown": 624.7,
-      "wind": 27159.1
+      "oil": 5025.3,
+      "solar": 3414.8,
+      "unknown": 605.8,
+      "wind": 29061
     },
     "comment": "Midcontinent Independent Transmission System Operator, Inc..",
     "contributors": [
@@ -7308,7 +7308,7 @@
       ]
     ],
     "capacity": {
-      "battery storage": 159,
+      "battery storage": 192.2,
       "biomass": 1613.9,
       "coal": 559.2,
       "gas": 19886,
@@ -7316,10 +7316,10 @@
       "hydro": 1918.6,
       "hydro storage": 1799,
       "nuclear": 3404.9,
-      "oil": 6069,
-      "solar": 1637.1,
+      "oil": 5444.9,
+      "solar": 1831.3,
       "unknown": 0,
-      "wind": 1504.4
+      "wind": 1519.7
     },
     "comment": "Iso New England Inc.",
     "contributors": [
@@ -7432,7 +7432,7 @@
       "oil": 0,
       "solar": 87.9,
       "unknown": 0,
-      "wind": 3377.5
+      "wind": 3397.5
     },
     "comment": "Bonneville Power Administration",
     "contributors": [
@@ -7706,7 +7706,7 @@
       ]
     ],
     "capacity": {
-      "battery storage": 0,
+      "battery storage": 100,
       "biomass": 35.2,
       "coal": 809,
       "gas": 7828.2,
@@ -7715,7 +7715,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 21,
-      "solar": 2046.7,
+      "solar": 2346.7,
       "unknown": 7.5,
       "wind": 150
     },
@@ -7796,16 +7796,16 @@
     "capacity": {
       "battery storage": 0,
       "biomass": 15.3,
-      "coal": 7841.5,
-      "gas": 3409.9,
+      "coal": 5015.6,
+      "gas": 3792.1,
       "geothermal": 83.8,
       "hydro": 271.7,
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 30.4,
-      "solar": 1466.4,
+      "solar": 1627.9,
       "unknown": 52.8,
-      "wind": 2690.1
+      "wind": 3193.3
     },
     "comment": "Pacificorp - East",
     "contributors": [
@@ -7840,7 +7840,7 @@
     "capacity": {
       "battery storage": 0,
       "biomass": 161,
-      "coal": 0,
+      "coal": 2441.9,
       "gas": 621.2,
       "geothermal": 3.7,
       "hydro": 1127.6,
@@ -7928,14 +7928,14 @@
     "capacity": {
       "battery storage": 2,
       "biomass": 30.8,
-      "coal": 1311.3,
+      "coal": 2946.6,
       "gas": 6510,
       "geothermal": 0,
       "hydro": 55.2,
-      "hydro storage": 150,
+      "hydro storage": 300,
       "nuclear": 0,
       "oil": 33.2,
-      "solar": 628.5,
+      "solar": 876,
       "unknown": 0,
       "wind": 4490.8
     },
@@ -8104,16 +8104,16 @@
     "capacity": {
       "battery storage": 8.2,
       "biomass": 3.2,
-      "coal": 5929.6,
+      "coal": 4294.3,
       "gas": 1931.8,
       "geothermal": 0,
       "hydro": 704.3,
       "hydro storage": 208.5,
       "nuclear": 0,
       "oil": 158.8,
-      "solar": 192.2,
+      "solar": 199.2,
       "unknown": 11.5,
-      "wind": 885.6
+      "wind": 1091.2
     },
     "comment": "Western Area Power Administration - Rocky Mountain Region",
     "contributors": [
@@ -8230,18 +8230,18 @@
       ]
     ],
     "capacity": {
-      "battery storage": 51.6,
+      "battery storage": 65.6,
       "biomass": 517.7,
       "coal": 0,
-      "gas": 27105.7,
+      "gas": 27101.2,
       "geothermal": 0,
       "hydro": 4690.2,
       "hydro storage": 1240,
       "nuclear": 3398.4,
       "oil": 3853.7,
-      "solar": 701.4,
+      "solar": 749.1,
       "unknown": 20,
-      "wind": 1989.2
+      "wind": 2192.9
     },
     "comment": "New York Independent System Operator",
     "contributors": [
@@ -8354,16 +8354,16 @@
       ]
     ],
     "capacity": {
-      "battery storage": 2.2,
-      "biomass": 1991.1,
+      "battery storage": 42.2,
+      "biomass": 1979.5,
       "coal": 16164.8,
-      "gas": 34930.1,
+      "gas": 34941.7,
       "geothermal": 0,
       "hydro": 3310.4,
       "hydro storage": 1306.6,
       "nuclear": 6054.4,
       "oil": 1284.8,
-      "solar": 2764.4,
+      "solar": 3662,
       "unknown": 0,
       "wind": 0
     },
@@ -8407,9 +8407,9 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 123.8,
-      "solar": 757,
+      "solar": 756.6,
       "unknown": 0,
-      "wind": 174.3
+      "wind": 374.3
     },
     "comment": "Arizona Public Service Company",
     "contributors": [
@@ -8491,9 +8491,9 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 0,
-      "solar": 127.3,
+      "solar": 130.3,
       "unknown": 0,
-      "wind": 50.4
+      "wind": 0
     },
     "comment": "El Paso Electric Company",
     "contributors": [
@@ -8648,16 +8648,16 @@
     "capacity": {
       "battery storage": 1.8,
       "biomass": 14.6,
-      "coal": 924,
+      "coal": 1128,
       "gas": 1833.9,
       "geothermal": 19.2,
       "hydro": 0,
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 30.4,
-      "solar": 369.9,
+      "solar": 419.9,
       "unknown": 1.1,
-      "wind": 1372
+      "wind": 2424
     },
     "comment": "Public Service Company Of New Mexico",
     "contributors": [
@@ -8699,7 +8699,7 @@
       "hydro storage": 154.1,
       "nuclear": 4209.6,
       "oil": 0,
-      "solar": 360,
+      "solar": 460,
       "unknown": 0,
       "wind": 63
     },
@@ -8737,15 +8737,15 @@
       "battery storage": 50,
       "biomass": 0,
       "coal": 1765.8,
-      "gas": 965.7,
+      "gas": 1584.7,
       "geothermal": 0,
       "hydro": 0,
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 0,
-      "solar": 455,
+      "solar": 458.9,
       "unknown": 0,
-      "wind": 279.8
+      "wind": 379.8
     },
     "comment": "Tucson Electric Power Company",
     "contributors": [
@@ -8778,16 +8778,16 @@
       ]
     ],
     "capacity": {
-      "battery storage": 0,
+      "battery storage": 90,
       "biomass": 0,
-      "coal": 204,
+      "coal": 0,
       "gas": 2407.3,
       "geothermal": 0,
       "hydro": 5610.5,
       "hydro storage": 65.2,
       "nuclear": 0,
       "oil": 4.5,
-      "solar": 142.2,
+      "solar": 302.2,
       "unknown": 0,
       "wind": 350
     },
@@ -8831,7 +8831,7 @@
       "hydro storage": 1808.6,
       "nuclear": 8474.8,
       "oil": 74.6,
-      "solar": 520,
+      "solar": 670,
       "unknown": 0,
       "wind": 28.8
     },
@@ -8866,18 +8866,18 @@
       ]
     ],
     "capacity": {
-      "battery storage": 342.9,
+      "battery storage": 780,
       "biomass": 189.5,
       "coal": 15217.2,
-      "gas": 64745.5,
+      "gas": 65534.7,
       "geothermal": 0,
       "hydro": 569.7,
       "hydro storage": 0,
       "nuclear": 5138.6,
-      "oil": 113.1,
-      "solar": 7261,
+      "oil": 117,
+      "solar": 10047.2,
       "unknown": 234.7,
-      "wind": 29401.1
+      "wind": 32699.2
     },
     "comment": "Electric Reliability Council Of Texas, Inc.",
     "contributors": [


### PR DESCRIPTION
I updated all capacities in the USA zones to January 2022. The source is still the same.

Lots of new solar and wind capacity and EIA finally updated some of the power plants to the correct zones. The coal capacity of US-NW-PACW was missing so far but that's fixed now.