### PR TITLE
chore(parser): enable cert verification in GB-ORK

### DIFF
--- a/parsers/GB_ORK.py
+++ b/parsers/GB_ORK.py
@@ -26,7 +26,7 @@ def get_json_data(session):
     Returns a dictionary.
     """
     s = session or requests.Session()
-    req = s.get(GENERATION_LINK, verify=False)
+    req = s.get(GENERATION_LINK)
     raw_json_data = req.json()
 
     generation_data = raw_json_data['data']['datasets']
@@ -51,7 +51,7 @@ def get_datetime(session):
     Returns an arrow object.
     """
     s = session or requests.Session()
-    req = s.get(DATETIME_LINK, verify=False)
+    req = s.get(DATETIME_LINK)
     soup = BeautifulSoup(req.text, 'html.parser')
 
     data_table = soup.find("div", {"class": "Widget-Base Widget-ANMGraph"})


### PR DESCRIPTION
Certificate verification was disabled in #2504 to work around a
server-side SSL/TLS issue. The situation appears to have improved, and
verification can now be re-enabled.

Refs: #2462, #2504