### PR TITLE
Added and fixed capacities for SE exchanges

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -909,14 +909,8 @@
     "rotation": 90
   },
   "DE->SE": {
-    "capacity": [
-      -600,
-      600
-    ],
-    "lonlat": [
-      13.552264,
-      54.925814
-    ],
+    "capacity": [-615, 615],
+    "lonlat": [13.552264, 54.925814],
     "parsers": {
       "exchange": "statnett.fetch_exchange",
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
@@ -1003,14 +997,8 @@
     "rotation": 70
   },
   "DK-DK1->SE": {
-    "capacity": [
-      -680,
-      740
-    ],
-    "lonlat": [
-      11.556268,
-      56.857802
-    ],
+    "capacity": [-715, 715],
+    "lonlat": [11.556268, 56.857802],
     "parsers": {
       "exchange": "DK.fetch_exchange"
     },
@@ -1192,10 +1180,8 @@
     "rotation": 135
   },
   "FI->SE": {
-    "lonlat": [
-      20.979206,
-      63.441789
-    ],
+    "capacity": [-2700, 2300],
+    "lonlat": [20.979206, 63.441789],
     "parsers": {
       "exchange": "statnett.fetch_exchange",
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
@@ -2180,14 +2166,8 @@
     "rotation": -90
   },
   "NO-NO1->SE": {
-    "capacity": [
-      -2100,
-      2150
-    ],
-    "lonlat": [
-      12.254138,
-      61.008235
-    ],
+    "capacity": [-2095, 2145],
+    "lonlat": [12.254138, 61.008235],
     "_comment": "statnett doesn't work. See for example 2018-05-14 which is off by a factor two",
     "parsers": {
       "exchange": "ENTSOE.fetch_exchange",
@@ -2274,10 +2254,8 @@
     }
   },
   "NO-NO4->SE": {
-    "lonlat": [
-      15.462856,
-      66.273628
-    ],
+    "capacity": [-900, 950],
+    "lonlat": [15.462856, 66.273628],
     "_comment": "statnett doesn't work. See for example 2018-05-14 which is off by a factor two",
     "parsers": {
       "exchange": "ENTSOE.fetch_exchange"

--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -918,6 +918,7 @@
     "rotation": 0
   },
   "DE->SE-SE4": {
+    "capacity": [-615, 615],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }
@@ -983,14 +984,8 @@
     "rotation": -25
   },
   "DK-DK1->SE-SE3": {
-    "capacity": [
-      -680,
-      740
-    ],
-    "lonlat": [
-      11.556268,
-      56.857802
-    ],
+    "capacity": [-715, 715],
+    "lonlat": [11.556268, 56.857802],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     },
@@ -1189,11 +1184,13 @@
     "rotation": -50
   },
   "FI->SE-SE1": {
+    "capacity": [-1500, 1100],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }
   },
   "FI->SE-SE3": {
+    "capacity": [-1200, 1200],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }
@@ -1849,6 +1846,7 @@
     "rotation": -90
   },
   "LT->SE-SE4": {
+    "capacity": [-700, 700],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }
@@ -2176,10 +2174,7 @@
     "rotation": 90
   },
   "NO-NO1->SE-SE3": {
-    "capacity": [
-      -2100,
-      2150
-    ],
+    "capacity": [-2095, 2145],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }
@@ -2320,6 +2315,7 @@
     "rotation": -20
   },
   "PL->SE-SE4": {
+    "capacity": [-600, 600],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }
@@ -2421,16 +2417,19 @@
     "rotation": -90
   },
   "SE-SE1->SE-SE2": {
+    "capacity": [-3300, 3300],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }
   },
   "SE-SE2->SE-SE3": {
+    "capacity": [-7300, 7300],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }
   },
   "SE-SE3->SE-SE4": {
+    "capacity": [-2000, 5400],
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"
     }


### PR DESCRIPTION
I have added or fixed current exchanges with Sweden as a whole and added and fixed the capacities for Sweden's bidding zones in preparation for #1397.

A noticeable difference that will show up right away is the added capacities for FI->SE and NO-NO4->SE that where completely missing before.

I used this image as the source from a SVK power balance [report.](https://www.svk.se/siteassets/om-oss/rapporter/2021/kraftbalansen-pa-den-svenska-elmarknaden-rapport-2021.pdf)
![image](https://user-images.githubusercontent.com/30777521/161040281-cd5a8e01-68fd-4101-b108-282831bc7ebe.png)
