### PR TITLE
Makes translation path absolute (to fix issues when changing language on a zone)

### DIFF
--- a/web/src/helpers/i18n.js
+++ b/web/src/helpers/i18n.js
@@ -58,7 +58,7 @@ i18n
     fallbackLng: 'en',
     debug: isProduction() ? false : true,
     backend: {
-      loadPath: 'locales/{{lng}}.json',
+      loadPath: '/locales/{{lng}}.json',
       crossDomain: true,
       request: requestWithXmlHttpRequest,
     },


### PR DESCRIPTION
I made a mistake and made the locales-path relative, which means it only works when language is changed on the root path (/map) 😬 

This will fix it!