### PR TITLE
Update solar & wind capacity for Netherlands

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -4563,8 +4563,8 @@
       "hydro storage": 0,
       "nuclear": 485,
       "oil": 0,
-      "solar": 16074,
-      "wind": 7303
+      "solar": 14300,
+      "wind": 7800
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
2021 data from CBS : https://www.cbs.nl/en-gb/news/2022/10/more-electricity-from-renewable-sources-less-from-fossil-sources

Replacing inaccurate ENTSO-E data.