### PR TITLE
chore: Flag missing space between header on country tooltip

### DIFF
--- a/web/src/components/tooltips/common.js
+++ b/web/src/components/tooltips/common.js
@@ -10,11 +10,11 @@ export const CarbonIntensity = ({ intensity }) => {
   const co2ColorScale = useCo2ColorScale();
 
   return (
-    <React.Fragment>
+    <>
       <div className="emission-rect" style={{ backgroundColor: co2ColorScale(intensity) }} />
       {' '}
       <b>{Math.round(intensity) || '?'}</b> gCO₂eq/kWh
-    </React.Fragment>
+    </>
   );
 };
 
@@ -22,11 +22,13 @@ export const MetricRatio = ({ value, total, format }) => (
   <small>{`(${isFinite(value) ? format(value) : '?'} / ${isFinite(total) ? format(total) : '?'})`}</small>
 );
 
-const Flag = styled.img``;
+const Flag = styled.img`
+  margin-right: 4px;
+`;
 
 export const ZoneName = ({ zone }) => (
-  <React.Fragment>
-    <Flag className="flag" alt="" src={flagUri(zone)} />
+  <>
+    <Flag className="flag" alt={`flag-${zone}`} src={flagUri(zone)} />
     {getShortenedZoneNameWithCountry(zone)}
-  </React.Fragment>
+  </>
 );


### PR DESCRIPTION
It improves the country's tooltip header by adding a margin between the flag and the country title. Also adds missing alt on the flag `<img />`.
### before
<img width="277" alt="Screen Shot 2022-04-16 at 11 10 53" src="https://user-images.githubusercontent.com/27704687/163678187-5d3e4a12-ac5a-44a6-b5d7-902f704e14b9.png">

### after
<img width="277" alt="Screen Shot 2022-04-16 at 11 10 04" src="https://user-images.githubusercontent.com/27704687/163678154-295230be-fd6e-4789-86ec-97a5c6bc12e3.png">
