### PR TITLE
Added Japan (Kyūshū) Capacities

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -264,6 +264,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - (Punjab): [PUNJABSLDC](http://www.punjabsldc.org/realtimepbGen.aspx)
 - Japan:
   - Tokyo: [Power-Plants](http://agora.ex.nii.ac.jp/earthquake/201103-eastjapan/energy/electrical-japan/operator/3.html.ja)
+  - Kyūshū: [Electrical Japan](https://agora-ex-nii-ac-jp.translate.goog/earthquake/201103-eastjapan/energy/electrical-japan/operator/9.html.ja?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp&_x_tr_sch=http)
 - Kosovo: [TSO](https://www.kostt.com/Content/ViewFiles/Transparency/BasicMarketDataOnGeneration/EN/Installed%20capacity%20of%20production%20units.pdf)
 - Kuwait
   - Gas & oil: [KAPSARC](https://datasource.kapsarc.org/api/datasets/1.0/kuwait-power-plants-database/attachments/power_plants_xlsx/)

--- a/config/zones.json
+++ b/config/zones.json
@@ -3742,9 +3742,18 @@
         35.11
       ]
     ],
+    "capacity": {
+      "geothermal": 210.2,
+      "hydro": 1247,
+      "hydro storage": 2350,
+      "nuclear": 5258,
+      "wind": 3.25,
+      "unknown": 9976.94
+    },
     "contributors": [
       "https://github.com/tmslaine",
-      "https://github.com/lorrieq"
+      "https://github.com/lorrieq",
+      "https://github.com/nessie2013"
     ],
     "parsers": {
       "consumptionForecast": "JP.fetch_consumption_forecast",


### PR DESCRIPTION
Found a database of power plants and added up the capacities. All thermal plants were lumped under "thermal" and not seperated to coal, gas and such so the "thermal" total has been put in unknown for now