### PR TITLE
Makes the "no data available" work again

### DIFF
--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -253,7 +253,7 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
     return <Redirect to={parentPage} />;
   }
 
-  const { hasData, estimationMethod } = data;
+  const { hasData, hasParser, estimationMethod } = data;
   const isDataEstimated = !isNil(estimationMethod);
 
   const co2Intensity = electricityMixMode === 'consumption'
@@ -334,7 +334,7 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
       </div>
 
       <CountryPanelWrap>
-        {hasData ? (
+        {hasData || hasParser ? (
           <React.Fragment>
             <BySource>
               {__('country-panel.bysource')}

--- a/web/src/reducers/dataReducer.js
+++ b/web/src/reducers/dataReducer.js
@@ -169,8 +169,8 @@ const reducer = (state = initialDataState, action) => {
           ...state.histories,
           [action.zoneId]: action.payload.map(datapoint => ({
             ...datapoint,
-            hasParser: true,
-            hasData: true
+            hasParser: zones[action.zoneId].hasParser,
+            hasData: !Object.values(datapoint.production).every(v => v === null)
           })),
         },
       };


### PR DESCRIPTION
Fixes issue where left panel would always show "data temporarily unavailable" no matter what.

Closes #3988

We now have all 3 states back:
<img width="362" alt="Screenshot 2022-04-25 at 20 13 07" src="https://user-images.githubusercontent.com/3296643/165149287-7f0c7215-0686-440e-a63b-a3d15f3c675e.png">
<img width="367" alt="Screenshot 2022-04-25 at 20 13 17" src="https://user-images.githubusercontent.com/3296643/165149305-2fd0c01d-d63c-4c07-b005-c72a8178e70d.png">
<img width="367" alt="Screenshot 2022-04-25 at 20 13 27" src="https://user-images.githubusercontent.com/3296643/165149318-fecadab8-9e15-40ae-b7bb-e1f5baebeed5.png">

