### PR TITLE
Changes CircleCI to use newer Ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
   build_test:
     machine:
-      image: circleci/classic:201808-01
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     steps:
       - checkout


### PR DESCRIPTION
We currently use Ubuntu v14 and it's deprecated and will soon stop working in CircleCI.

<img width="723" alt="Screenshot 2022-04-25 at 20 44 40" src="https://user-images.githubusercontent.com/3296643/165153914-4b18ba35-7d3e-40bc-801b-479950826e1e.png">

This upgrades the machine to a newer version (v20) :)