### PR TITLE
Update CH emission factor

### DIFF
--- a/config/co2eq_parameters_direct.json
+++ b/config/co2eq_parameters_direct.json
@@ -1565,7 +1565,12 @@
             "source": "electricityMap, 2021 average",
             "value": 205.82553856340994
           }
-        ]
+        ],
+        "unknown": {
+          "_comment": "Source ENTSOE, Swiss government and electricitymap: https://github.com/tmrowco/electricitymap-contrib/pull/2898 and https://docs.google.com/spreadsheets/d/1FLHQ6e9Es08BIqX654BM3SEb_fuAk4k4O-6cmRXyw_E/",
+          "source": "52% hydro storage, 48% unknown thermal",
+          "value": 288
+        }
       },
       "CL-SEN": {
         "battery discharge": [

--- a/config/co2eq_parameters_lifecycle.json
+++ b/config/co2eq_parameters_lifecycle.json
@@ -1576,9 +1576,9 @@
           }
         ],
         "unknown": {
-          "_comment": "Source ENTSOE and Swiss government: https://github.com/tmrowco/electricitymap-contrib/pull/2898",
-          "source": "assumes 64% hydro, 13% hydro storage, 12% unknown thermal, 7% solar, 3% unknown renewable",
-          "value": 131
+          "_comment": "Source ENTSOE, Swiss government and electricitymap: https://github.com/tmrowco/electricitymap-contrib/pull/2898 and https://docs.google.com/spreadsheets/d/1FLHQ6e9Es08BIqX654BM3SEb_fuAk4k4O-6cmRXyw_E/",
+          "source": "52% hydro storage, 48% unknown thermal",
+          "value": 383
         }
       },
       "CL-SEN": {
@@ -3865,9 +3865,7 @@
         ],
         "unknown": {
           "_comment": "Source: Souther Regional Load Dispatch Center Allocation Limits",
-          "_url": [
-            "http://srldc.org/2018-19srallocation.aspx"
-          ],
+          "_url": ["http://srldc.org/2018-19srallocation.aspx"],
           "source": "calculated 20% nuclear, 80% thermal (coal)",
           "value": 658.4
         }


### PR DESCRIPTION
To roll out the estimation model for CH we need to update the emission factor of the unknown mode in CH. The estimation model indeeds splits out most of the unknown production into adequate production mode, changing the makeup of the remaining unknown production.