### PR TITLE
Workaround to fix labeler removing labels.

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,3 +17,4 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: ""


### PR DESCRIPTION
Due to a bug in the labeler code the default value false get evaluated to true causing labeler to sync labels, this is causing it to remove manually added labels from PRs if the changed files don't match the labeler config.

This resets it to the intended behavior.