### PR TITLE
Remove url-search-params-polyfill (included in babel now)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -51,8 +51,7 @@
     "styled-components": "^5.0.1",
     "sunrise-sunset-js": "^2.2.1",
     "swr": "^1.0.1",
-    "topojson": "^3.0.2",
-    "url-search-params-polyfill": "^8.1.0"
+    "topojson": "^3.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -4,7 +4,6 @@ import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 
 import 'mapbox-gl/dist/mapbox-gl.css'; // Required for map zooming buttons
-import 'url-search-params-polyfill'; // For IE 11 support
 
 import { history } from './helpers/router';
 import { store, sagaMiddleware } from './store';

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -11702,11 +11702,6 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-url-search-params-polyfill@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.0.tgz#5c15b69687165bfd4f6c7d8a161d70d85385885b"
-  integrity sha512-MRG3vzXyG20BJ2fox50/9ZRoe+2h3RM7DIudVD2u/GY9MtayO1Dkrna76IUOak+uoUPVWbyR0pHCzxctP/eDYQ==
-
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
With the merger of #4078 this feature is already polyfilled by babel and corejs3 and we no longer need the separate polyfill.