### PR TITLE
Drop IE 11 support! (browserslist targets update)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -110,10 +110,7 @@
   },
   "browserslist": [
     "defaults",
-    "not ie < 11",
-    "last 2 versions",
-    "> 1%",
-    "iOS 7",
-    "last 3 iOS versions"
+    "not ie 11",
+    "not op_mini all"
   ]
 }


### PR DESCRIPTION
This changes the browserslist targets to what I mentioned in #4034 and as mentioned in #4079 IE 11 usage is almost non existent now plus Microsoft themselves is dropping support for IE 11 very soon.

This change will allow babel to build bundles with a lot less polyfills and allows for #4070 to be merged without considering IE 11 support.

**NOTE:** This removes the pinned target of `ios 7`, if this is required for some reason let me know so I can add it back. Otherwise it is discouraged to use pinned versions for browser targets.

closes #4034