### PR TITLE
Change Sweden (SE) to use ENTSOE.fetch_production_aggregate parser for production

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -5573,7 +5573,7 @@
       "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
       "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
-      "production": "SE.fetch_production",
+      "production": "ENTSOE.fetch_production_aggregate",
       "productionPerModeForecast": "ENTSOE.fetch_wind_solar_forecasts",
       "productionPerUnit": "ENTSOE.fetch_production_per_units"
     },

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -146,6 +146,7 @@ ENTSOE_DOMAIN_MAPPINGS = {
     'UA': '10YUA-WEPS-----0',
     'XK': '10Y1001C--00100H'
 }
+
 # Generation per unit can only be obtained at EIC (Control Area) level
 ENTSOE_EIC_MAPPING = {
     'DK-DK1': '10Y1001A1001A796',
@@ -154,6 +155,12 @@ ENTSOE_EIC_MAPPING = {
     'PL': '10YPL-AREA-----S',
     'SE': '10YSE-1--------K',
     # TODO: ADD DE
+}
+
+# Define zone_keys to an array of zone_keys for aggregated production data
+ZONE_KEY_AGGREGATES = {
+    'IT-SO': ['IT-CA', 'IT-SO'],
+    'SE': ['SE-SE1', 'SE-SE2', 'SE-SE3', 'SE-SE4'],
 }
 
 # Some exchanges require specific domains
@@ -909,12 +916,6 @@ def fetch_production(zone_key, session=None, target_datetime=None,
                     d['production'][k] = 0
 
     return list(filter(lambda x: validate_production(x, logger), data))
-
-
-ZONE_KEY_AGGREGATES = {
-    'IT-SO': ['IT-CA', 'IT-SO'],
-}
-
 
 # TODO: generalize and move to lib.utils so other parsers can reuse it. (it's
 # currently used by US_SEC.)


### PR DESCRIPTION
As #3936 is still blocked I thought we could use the ENTSOE.fetch_production_aggregate for Swedens (SE) production data as it has a more detailed breakdown of the production sources. (It adds gas and solar)


**Note:** ENTSOE only have useful data AFTER 2021-12-14 (before that it's only wind)
 Now I don't know how the backend works when switching parsers so I'm not sure from what date when to add the new co2eq override for unknown production (remove gas and solar from the mix) so this will be a draft for now until I have that info. 🙂 
 
 closes: #4000