### PR TITLE
Webpack config duplicate bundle fix

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -140,7 +140,7 @@ app.use('/', (req, res) => {
       }),
       bundleHash: getHash('bundle', 'js', manifest),
       vendorHash: getHash('vendor', 'js', manifest),
-      stylesHash: getHash('styles', 'css', manifest),
+      bundleStylesHash: getHash('bundle', 'css', manifest),
       vendorStylesHash: getHash('vendor', 'css', manifest),
       // Make the paths absolute as that's required for BrowserHistory routing
       // to work normally and it's also ok when used with the https:// protocol

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -46,7 +46,7 @@
         <link rel="preload" href="<%= resolvePath('fonts/EuclidTriangle-Regular.woff') %>" as="font" type="font/woff" crossorigin>
 
         <!-- CSS -->
-        <link rel="stylesheet" type="text/css" href="<%= resolvePath('dist/styles.' + stylesHash + '.css') %>">
+        <link rel="stylesheet" type="text/css" href="<%= resolvePath('dist/bundle.' + bundleStylesHash + '.css') %>">
         <link rel="stylesheet" type="text/css" href="<%= resolvePath('dist/vendor.' + vendorStylesHash + '.css') %>">
 
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -13,7 +13,6 @@ module.exports = {
   devtool: isProduction ? 'sourcemap' : 'eval',
   entry: {
     bundle: './src/index.jsx',
-    styles: './src/scss/styles.scss',
   },
   resolve: {
     extensions: ['.js', '.jsx', '.mjs', '.cjs'],


### PR DESCRIPTION
We accidentally created duplicate bundles of the CSS styles, this PR fixes that.