### PR TITLE
Always load latest history data in countryPanel

### DIFF
--- a/web/src/hooks/redux.js
+++ b/web/src/hooks/redux.js
@@ -53,12 +53,7 @@ export function useCurrentZoneData() {
     if (!zoneId || !grid || !zoneHistory) {
       return null;
     }
-    if (zoneTimeIndex === null) {
-      // Return latest history data unless latest history does not correspond to the current grid datetime
-      return (zoneHistory[zoneHistory.length - 1].stateDatetime === grid.datetime
-        ? zoneHistory[zoneHistory.length - 1]
-        : null);
-    }
+
     return zoneHistory[zoneTimeIndex];
   }, [zoneId, zoneHistory, zoneTimeIndex, grid]);
 }

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -45,7 +45,7 @@ const initialApplicationState = {
   },
   onboardingSeen: cookieGetBool('onboardingSeen', false),
   searchQuery: null,
-  selectedZoneTimeIndex: null,
+  selectedZoneTimeIndex: 24,
   solarColorbarValue: null,
   webGLSupported: true,
   windColorbarValue: null,


### PR DESCRIPTION
Attempt at fixing #3949 

It seems that we have fixed the caching issues, but there are still some issues which seems to be related to the app not realizing that there is newer historical data available.

This PR ensures that we initialize with using the latest zoneTimeIndex always which may fix the issue.