### PR TITLE
Fix app wrongfully saying app is updated.

### DIFF
--- a/web/BUILD.yaml
+++ b/web/BUILD.yaml
@@ -35,6 +35,7 @@ steps:
     image: google/cloud-sdk:243.0.0
     commands:
       - gsutil -m cp -a public-read -r public/* gs://static.electricitymap.org/public_web
+      - gsutil setmeta -h "Cache-Control:no-cache,max-age=0" gs://static.electricitymap.org/public_web/client-version.json
     secrets:
       gcloud:
         src: ~/.config/gcloud

--- a/web/src/layout/main.jsx
+++ b/web/src/layout/main.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 // TODO(olc): re-enable this rule
 
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
@@ -49,6 +49,19 @@ const MapContainer = styled.div`
   }
 `;
 
+const NewVersionInner = styled.div`
+    background-color: #3F51B5;
+`;
+
+const NewVersionButton = styled.button`
+    background: transparent;
+    color: white;
+    margin-left: 12px;
+    background-color: inherit;
+    border: none;
+    cursor: pointer;
+`;
+
 const fetcher = (...args) => fetch(...args).then(res => res.json())
 
 const Main = ({
@@ -62,6 +75,7 @@ const Main = ({
   const headerVisible = useHeaderVisible();
   const clientType = useSelector(state => state.application.clientType);
   const isLocalhost = useSelector(state => state.application.isLocalhost);
+  const [isClientVersionForceHidden, setIsClientVersionForceHidden] = useState(false);
 
   const showLoadingOverlay = useLoadingOverlayVisible();
 
@@ -134,10 +148,11 @@ const Main = ({
               .
             </div>
           </div>
-          <div id="new-version" className={`flash-message ${isClientVersionOutdated ? 'active' : ''}`}>
-            <div className="inner">
+          <div id="new-version" className={`flash-message ${isClientVersionOutdated && (!isClientVersionForceHidden) ? 'active' : ''}`}>
+            <NewVersionInner className='inner'>
               <span dangerouslySetInnerHTML={{ __html: __('misc.newversion') }} />
-            </div>
+              <NewVersionButton onClick={() => setIsClientVersionForceHidden(true)}>&#x2715;</NewVersionButton>
+            </NewVersionInner>
           </div>
 
           { /* end #inner */}

--- a/web/src/scss/components/_messaging.scss
+++ b/web/src/scss/components/_messaging.scss
@@ -85,10 +85,6 @@
     background-color: darkred;
 }
 
-#new-version .inner {
-    background-color: #3F51B5;
-}
-
 .referral-link {
     color: inherit;
 }
@@ -130,7 +126,7 @@
     position: relative;
     font-size: smaller;
     top: 0;
-    left: 0;  
+    left: 0;
     margin: 8px 0 2px 0;
 }
 


### PR DESCRIPTION
Fixes #3995

- Adds button to force hide outdated version
- Remove cache on client-version.json
