### PR TITLE
Uses correct hash (to fix mobileapp build)

### DIFF
--- a/mobileapp/generate-index.js
+++ b/mobileapp/generate-index.js
@@ -43,7 +43,7 @@ locales.forEach(function(locale) {
         alternateUrls: [],
         bundleHash: getHash('bundle', 'js', manifest),
         vendorHash: getHash('vendor', 'js', manifest),
-        stylesHash: getHash('styles', 'css', manifest),
+        bundleStylesHash: getHash('bundle', 'css', manifest),
         vendorStylesHash: getHash('vendor', 'css', manifest),
         // Keep using relative resource paths on mobile platforms as that's
         // the way to keep them working with file:// protocol and HashHistory


### PR DESCRIPTION
Building of the mobileapp is currently failing because we forgot to update this variable in here after #4094

<img width="709" alt="Screenshot 2022-05-10 at 11 38 27" src="https://user-images.githubusercontent.com/3296643/167598922-e664ae7b-146b-421d-a85b-84450c09b859.png">
