### PR TITLE
Moves dependency out of shared ZoneMap component

### DIFF
--- a/web/src/components/zonemap.jsx
+++ b/web/src/components/zonemap.jsx
@@ -4,7 +4,6 @@ import ReactMapGL, { NavigationControl, Source, Layer } from 'react-map-gl';
 import { noop } from '../helpers/noop';
 import { isEmpty } from '../helpers/isEmpty';
 import { debounce } from '../helpers/debounce'
-import { useFeatureToggle } from '../hooks/router';
 
 
 const interactiveLayerIds = ['zones-clickable-layer'];
@@ -14,6 +13,7 @@ const ZoneMap = ({
   children = null,
   co2ColorScale = null,
   hoveringEnabled = true,
+  isHistoryFeatureEnabled = false,
   onMapLoaded = noop,
   onMapError = noop,
   onMouseMove = noop,
@@ -43,7 +43,6 @@ const ZoneMap = ({
   const [hoveredZoneId, setHoveredZoneId] = useState(null);
   const [isSupported, setIsSupported] = useState(true);
   const [isLoaded, setIsLoaded] = useState(false);
-  const isHistoryFeatureEnabled = useFeatureToggle('history');
 
   const [isDragging, setIsDragging] = useState(false);
   const debouncedSetIsDragging = useMemo(

--- a/web/src/layout/map.jsx
+++ b/web/src/layout/map.jsx
@@ -12,6 +12,7 @@ import { debounce } from '../helpers/debounce';
 import { useInterpolatedSolarData, useInterpolatedWindData } from '../hooks/layers';
 import { useCo2ColorScale, useTheme } from '../hooks/theme';
 import { useZonesWithColors } from '../hooks/map';
+import { useFeatureToggle } from '../hooks/router';
 import { dispatchApplication } from '../store';
 
 import ZoneMap from '../components/zonemap';
@@ -41,6 +42,8 @@ export default () => {
   const location = useLocation();
   const history = useHistory();
   const co2ColorScale = useCo2ColorScale();
+  const isHistoryFeatureEnabled = useFeatureToggle('history');
+
   // TODO: Replace with useParams().zoneId once this component gets
   // put in the right render context and has this param available.
   const zoneId = getZoneId();
@@ -202,6 +205,7 @@ export default () => {
       <ZoneMap
         co2ColorScale={co2ColorScale}
         hoveringEnabled={hoveringEnabled}
+        isHistoryFeatureEnabled={isHistoryFeatureEnabled}
         onMapLoaded={handleMapLoaded}
         onMapError={handleMapError}
         onMouseMove={handleMouseMove}


### PR DESCRIPTION
The ZoneMap component is used outside of this project (for the map on our commercial website) and therefore we can't import the hooks locally. 

This makes it work for now, although this is a short-term solution and I think it would be nice to decouple this projects :)
That would also allow us to get rid of all these props being passed down!