### PR TITLE
[historical-view] Disable date range options and change text to 24 hours

### DIFF
--- a/web/src/components/timeControls.jsx
+++ b/web/src/components/timeControls.jsx
@@ -67,7 +67,11 @@ const DateOptionWrapper = styled.div`
 const getOptions = (language) => [
   {
     key: 'day',
-    label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('day'),
+    label: new Intl.NumberFormat(language, {
+      style: 'unit',
+      unit: 'hour',
+      unitDisplay: 'long',
+    }).format(24),
   },
   {
     key: 'month',

--- a/web/src/components/timeControls.jsx
+++ b/web/src/components/timeControls.jsx
@@ -23,7 +23,7 @@ const DateRangeOption = styled.span`
   border-radius: 16px;
   white-space: nowrap;
   text-transform: capitalize;
-  cursor: default;
+  cursor: not-allowed;
   font-weight: ${(props) => (props.active ? 700 : 500)};
   opacity: ${(props) => (props.active ? 1 : 0.5)};
   ${(props) =>
@@ -64,29 +64,28 @@ const DateOptionWrapper = styled.div`
   padding-top: 8px;
 `;
 
-const getOptions = (language) =>
-    [
-      {
-        key: 'day',
-        label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('day'),
-      },
-      {
-        key: 'month',
-        label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('month'),
-      },
-      {
-        key: 'year',
-        label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('year'),
-      },
-      {
-        key: '5year',
-        label: new Intl.NumberFormat(language, {
-          style: 'unit',
-          unit: 'year',
-          unitDisplay: 'long',
-        }).format(5),
-      },
-    ];
+const getOptions = (language) => [
+  {
+    key: 'day',
+    label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('day'),
+  },
+  {
+    key: 'month',
+    label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('month'),
+  },
+  {
+    key: 'year',
+    label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('year'),
+  },
+  {
+    key: '5year',
+    label: new Intl.NumberFormat(language, {
+      style: 'unit',
+      unit: 'year',
+      unitDisplay: 'long',
+    }).format(5),
+  },
+];
 
 const TimeControls = ({ date, selectedTimeAggregate, handleTimeAggregationChange }) => {
   const { __, i18n } = useTranslation();
@@ -104,7 +103,8 @@ const TimeControls = ({ date, selectedTimeAggregate, handleTimeAggregationChange
             key={o.key}
             active={o.key === selectedTimeAggregate}
             onClick={() => {
-              handleTimeAggregationChange(o.key);
+              // TODO: not enabled yet
+              // handleTimeAggregationChange(o.key);
             }}
           >
             {o.label}


### PR DESCRIPTION
Two things in one:

Since we only support hourly values still, I'm disabling the other options. A

Edit: woops put in the wrong video, here is the right one:

https://user-images.githubusercontent.com/45588799/168052377-7a0011e3-9bc6-410f-bdc0-2345563d0cd2.mov





Also based on our initial user feedback, it seems "24 hours" is a better text to display so we're trying that.

