### PR TITLE
Pins Snowpack version to avoid bug on local development

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -92,7 +92,7 @@
     "sass": "^1.50.1",
     "sass-loader": "10.1.1",
     "shapefile": "^0.6.2",
-    "snowpack": "^3.8.8",
+    "snowpack": "3.8.6",
     "topojson-server": "^3.0.1",
     "webpack": "^5.72.1",
     "webpack-bundle-analyzer": "^4.5.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -9616,10 +9616,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snowpack@^3.8.8:
-  version "3.8.8"
-  resolved "https://registry.yarnpkg.com/snowpack/-/snowpack-3.8.8.tgz#237f1c0ad49c68313864f3aa4438db3affee0806"
-  integrity sha512-Y/4V8FdzzYpwmJU2TgXRRFytz+GFSliWULK9J5O6C72KyK60w20JKqCdRtVs1S6BuobCedF5vSBD1Gvtm+gsJg==
+snowpack@3.8.6:
+  version "3.8.6"
+  resolved "https://registry.yarnpkg.com/snowpack/-/snowpack-3.8.6.tgz#0bef5c071caef86a2f91aa5c3d5b70d0c2e2793c"
+  integrity sha512-EZ3Y7RtTiPvxnVFTKPfkvi2PKBrprXCvOHKWQQLBkHonf+xdtG51RiNjtrRLJeCjislAlD6OoeGHUxz76ToGHw==
   dependencies:
     "@npmcli/arborist" "^2.6.4"
     bufferutil "^4.0.2"
@@ -9648,7 +9648,6 @@ snowpack@^3.8.8:
     isbinaryfile "^4.0.6"
     jsonschema "~1.2.5"
     kleur "^4.1.1"
-    magic-string "^0.25.7"
     meriyah "^3.1.6"
     mime-types "^2.1.26"
     mkdirp "^1.0.3"


### PR DESCRIPTION
Found [an issue with a solution:](https://github.com/FredKSchott/snowpack/issues/3743#issuecomment-1050882255): pinning to `3.8.6` removes the "Cannot find prop-types" (and similar) bugs when running `yarn develop`.