### PR TITLE
Adds cypress workflow to run on pull request with 'frontend' label

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,7 +1,6 @@
-name: Cypress tests
+name: Cypress
 on:
-  pull_request:
-    types: [ labeled ]
+  pull_request
 env:
   SNOWPACK_PUBLIC_ELECTRICITYMAP_PUBLIC_TOKEN: '${{ secrets.SNOWPACK_PUBLIC_ELECTRICITYMAP_TOKEN }}' # token has to be escaped
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,7 +6,7 @@ env:
 
 jobs:
   cypress-test:
-    if: ${{ github.event.label.name == 'frontend 🎨' }}
+    if: contains(github.event.pull_request.labels.*.name, 'frontend 🎨')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,6 +1,6 @@
 name: Cypress tests
 on:
-  pull-requests:
+  pull_request:
     types: [ labeled ]
 env:
   SNOWPACK_PUBLIC_ELECTRICITYMAP_PUBLIC_TOKEN: '${{ secrets.SNOWPACK_PUBLIC_ELECTRICITYMAP_TOKEN }}' # token has to be escaped

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,6 +6,7 @@ env:
 
 jobs:
   cypress-test:
+    if: ${{ github.event.label.name == 'frontend 🎨' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,20 @@
+name: Cypress tests
+on:
+  pull-requests:
+    types: [ labeled ]
+env:
+  SNOWPACK_PUBLIC_ELECTRICITYMAP_PUBLIC_TOKEN: '${{ secrets.SNOWPACK_PUBLIC_ELECTRICITYMAP_TOKEN }}' # token has to be escaped
+
+jobs:
+  cypress-test:
+    if: ${{ github.event.label.name = 'frontend 🎨' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: ./web
+          start: yarn develop
+          wait-on: "http://localhost:8080"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,7 +7,6 @@ env:
 
 jobs:
   cypress-test:
-    if: ${{ github.event.label.name == 'frontend 🎨' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   cypress-test:
-    if: ${{ github.event.label.name = 'frontend 🎨' }}
+    if: ${{ github.event.label.name == 'frontend 🎨' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This should trigger a Github Action on pull requests with label = frontend that executes all our cypress tests (see #4136)