### PR TITLE
Downgrade isort version for backend compatibility

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -240,7 +240,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [[package]]
 name = "isort"
-version = "5.10.1"
+version = "5.9.3"
 description = "A Python utility / library to sort Python imports."
 category = "main"
 optional = false
@@ -729,7 +729,7 @@ parsers = ["arrow", "beautifulsoup4", "demjson3", "eiapy", "html5lib", "imageio"
 [metadata]
 lock-version = "1.1"
 python-versions = '>= 3.7.1, < 4.0'
-content-hash = "6ded01c5545c6af635ae49566a0eabb0c158c2bfa5f9fe351f4015ee26f5f3f7"
+content-hash = "60f9be8c55688a260d0e8855b24787c9217364d284b6e0d4d6a53d05470a74b4"
 
 [metadata.files]
 arrow = [
@@ -830,8 +830,8 @@ importlib-metadata = [
     {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
 ]
 isort = [
-    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
-    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+    {file = "isort-5.9.3-py3-none-any.whl", hash = "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"},
+    {file = "isort-5.9.3.tar.gz", hash = "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ tablib = {version="~0.12.1", optional=true}
 tqdm = {version="^4.64.0", optional=true}
 xlrd = {version="^1.2.0", optional=true}
 black = "^22.3.0"
-isort = "^5.10.1"
+isort = "5.9.3"
 
 [tool.poetry.dev-dependencies]
 click = "^8.1.2"


### PR DESCRIPTION
Just downgrading the `isort` version to make sure it's compatible with the rest of emap's code