### PR TITLE
Cypress - enable recording

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,7 +3,7 @@ on:
   pull_request
 env:
   SNOWPACK_PUBLIC_ELECTRICITYMAP_PUBLIC_TOKEN: '${{ secrets.SNOWPACK_PUBLIC_ELECTRICITYMAP_TOKEN }}' # token has to be escaped
-
+  CYPRESS_RECORD_KEY: '${{ secrets.CYPRESS_RECORD_KEY }}'
 jobs:
   cypress-test:
     if: contains(github.event.pull_request.labels.*.name, 'frontend 🎨')
@@ -16,4 +16,5 @@ jobs:
         with:
           working-directory: ./web
           start: yarn develop
+          record: true
           wait-on: "http://localhost:8080"

--- a/web/cypress.json
+++ b/web/cypress.json
@@ -1,6 +1,4 @@
 {
   "projectId": "9z8tgk",
-  "video": false,
-  "screenshotOnRunFailure": false,
   "baseUrl": "http://localhost:8080"
 }


### PR DESCRIPTION

Enabling screenshot and videos may help us understand why the CI sometimes fail whereas local works fine.