### PR TITLE
Updates info on how to release for Android and bumps version

### DIFF
--- a/mobileapp/.gitignore
+++ b/mobileapp/.gitignore
@@ -11,3 +11,4 @@ ul_web_hooks/
 GoogleService-Info.plist
 google-services.json
 locales-config.json
+electricitymap.keystore

--- a/mobileapp/README.md
+++ b/mobileapp/README.md
@@ -84,8 +84,9 @@ This is not required when using `cordova build` (it automatically runs `cordova 
 To do a release build (android):
 
 ```bash
-cordova build android --release -- --keystore=electricitymap.keystore --alias=electricitymapkey
+cordova build android --release -- --keystore=electricitymap.keystore --alias=electricitymapkey --storePassword XXX --password XXX
 ```
+(ask Mads for the password)
 
 To do a release build (ios):
 
@@ -118,7 +119,7 @@ To push a new store release:
   - Go into TestFlight and test on your own device
   - Submit the new build for review when everything is looking good
 - Android
-  - TBD
+  -  Open folder `mobileapp/platforms/android/app/build/outputs/apk/release` and upload the `app-release.apk` file on [Play Store Console](https://play.google.com/console)
 - Celebrate!
 
 ## App/Play Store Release Checklist

--- a/mobileapp/README.md
+++ b/mobileapp/README.md
@@ -86,7 +86,7 @@ To do a release build (android):
 ```bash
 cordova build android --release -- --keystore=electricitymap.keystore --alias=electricitymapkey --storePassword XXX --password XXX
 ```
-(ask Mads for the password)
+(ask internally for the password)
 
 To do a release build (ios):
 

--- a/mobileapp/config.xml
+++ b/mobileapp/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.tmrow.electricitymap" version="1.3.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.tmrow.electricitymap" version="1.3.3" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>electricityMap</name>
     <description>
         electricityMap is a live visualization of where your electricity comes from and how much CO2 was emitted to produce it.
@@ -28,7 +28,7 @@
         <preference name="SplashScreenDelay" value="0" />
         <preference name="StatusBarStyle" value="default" />
         <preference name="android-minSdkVersion" value="19" />
-        <preference name="android-targetSdkVersion" value="29" />
+        <preference name="android-targetSdkVersion" value="30" />
         <preference name="AndroidPersistentFileLocation" value="Compatibility" />
         <allow-intent href="market:*" />
     </platform>


### PR DESCRIPTION
This makes the documentation for how to release a bit more explicit and hopefully helps us out next time we have to do a new release.