### PR TITLE
Fix frontend (web) icons

### DIFF
--- a/web/src/components/icon.jsx
+++ b/web/src/components/icon.jsx
@@ -6,6 +6,8 @@ const IconContainer = styled.svg`
   width: 24px;
 `;
 
+const path = window.isCordova ? resolvePath('images/material-icon-sprite.svg') : '/images/material-icon-sprite.svg';
+
 /**
  * To add a new icon to the SVG sprite, open the icons SVG file and copy the the <svg> element.
  * Then paste the the <svg> element and rename it to <symbol> in the file 'material-icon-sprite.svg' and give it a unique id.
@@ -20,7 +22,7 @@ const IconContainer = styled.svg`
 const Icon = ({ iconName }) => {
   return (
     <IconContainer>
-      <use href={resolvePath(`images/material-icon-sprite.svg#${iconName}`)} />
+      <use href={resolvePath(`${path}#${iconName}`)} />
     </IconContainer>
   );
 };


### PR DESCRIPTION
While #4187 fixes the icons on mobile it introduces a CORS(?) error when loading on web.
This pr changes the loading based on platform to use direct vs relative links (Mobile vs Web respectively) to keep the same functionality on both.

fixes: #4202