### PR TITLE
Trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Real-time data is defined as a data source with an hourly (or better) frequency,
 In short, citizens should not be responsible for the emissions associated with all the products they export, but only for what they consume.
 Consumption-based accounting (CBA) is a very important aspect of climate policy and allows assigning responsibility to consumers instead of producers.
 Furthermore, this method is robust to governments relocating dirty production to neighboring countries in order to green their image while still importing from it.
-You can read more in our blog post [here](https://electricitymap.org/blog/flow-tracing).
+You can read more in our blog post [here](https://electricitymap.org/blog/flow-tracing/).
 
 **Why don't you show emissions per capita?**
 A country that has few inhabitants but a lot of factories will appear high on CO<sub>2</sub>/capita.

--- a/web/src/layout/header.jsx
+++ b/web/src/layout/header.jsx
@@ -19,18 +19,18 @@ const headerLinks = [
         <OpenPositionsBadge />
       </React.Fragment>
     ),
-    href: 'https://electricitymap.org/jobs#joboffers?utm_source=app.electricitymap.org&utm_medium=referral',
+    href: 'https://electricitymap.org/jobs/#joboffers?utm_source=app.electricitymap.org&utm_medium=referral',
     id: 'jobs',
   },
 
   {
     label: 'Open Source',
-    href: 'https://electricitymap.org/open-source?utm_source=app.electricitymap.org&utm_medium=referral',
+    href: 'https://electricitymap.org/open-source/?utm_source=app.electricitymap.org&utm_medium=referral',
     id: 'open-source',
   },
   {
     label: 'Blog',
-    href: 'https://electricitymap.org/blog?utm_source=app.electricitymap.org&utm_medium=referral',
+    href: 'https://electricitymap.org/blog/?utm_source=app.electricitymap.org&utm_medium=referral',
     id: 'blog',
   },
   {


### PR DESCRIPTION
I made these quick fixes as our electricitymap.org gatsby website causes redirects unless the trailing slash is added.
(I was this while going over our plausible data)