### PR TITLE
[historical-view] Enables history graphs for other time aggregates

### DIFF
--- a/web/public/locales/ar.json
+++ b/web/public/locales/ar.json
@@ -14,13 +14,8 @@
         "emissions": "انبعاثات الكربون",
         "addeditsource": "<a href=\"%s\" target=\"_blank\">أضف أو عدّل على المصدر</a>"
     },
-    "country-history": {
-        "carbonintensity24h": "كثافة الكربون في آخر 24 ساعة مضت"
-    },
-    "footer": {
-        "foundbugs": "وجدت أخطاء برمجية أو لديك اقتراحات؟ أبلغنا عنها",
-        "here": "هنا"
-    },
+    "country-history": { "carbonintensity": { "hourly": "كثافة الكربون في آخر 24 ساعة مضت" } },
+    "footer": { "foundbugs": "وجدت أخطاء برمجية أو لديك اقتراحات؟ أبلغنا عنها", "here": "هنا" },
     "legends": {
         "windpotential": "قوة الرياح المحتملة",
         "solarpotential": "قوة أشعة الشمس المحتملة",
@@ -63,332 +58,106 @@
     "emissionsImportedFrom": "<b>%1$s %%</b> من الانبعاثات في <img id=\"country-flag\"></img> <b>%2$s</b> تستورد من <img id=\"country-exchange-flag\"></img> <b>%3$s</b>",
     "ofCO2eqPerMinute": "of CO₂eq per minute",
     "zoneShortName": {
-        "AD": {
-            "zoneName": "أندورا"
-        },
-        "AL": {
-            "zoneName": "ألبانيا"
-        },
-        "AM": {
-            "zoneName": "أرمينيا"
-        },
-        "AT": {
-            "zoneName": "النمسا"
-        },
-        "AR": {
-            "zoneName": "الأرجنتين"
-        },
-        "AUS-NSW": {
-            "countryName": "أستراليا",
-            "zoneName": "نيو ساوث ويلز"
-        },
-        "AUS-NT": {
-            "countryName": "أستراليا",
-            "zoneName": "الإقليم الشمالي"
-        },
-        "AUS-QLD": {
-            "countryName": "أستراليا",
-            "zoneName": "كوينزلاند"
-        },
-        "AUS-SA": {
-            "countryName": "أستراليا",
-            "zoneName": "جنوب أستراليا"
-        },
-        "AUS-TAS": {
-            "countryName": "أستراليا",
-            "zoneName": "تاسمانيا"
-        },
-        "AUS-VIC": {
-            "countryName": "أستراليا",
-            "zoneName": "فيكتوريا"
-        },
-        "AUS-WA": {
-            "countryName": "أستراليا",
-            "zoneName": "أستراليا الغربية"
-        },
-        "AX": {
-            "zoneName": "جزر_أولاند"
-        },
-        "AZ": {
-            "zoneName": "أذربيجان"
-        },
-        "BA": {
-            "zoneName": "البوسنة والهرسك"
-        },
-        "BE": {
-            "zoneName": "بلجيكا"
-        },
-        "BG": {
-            "zoneName": "بلغاريا"
-        },
-        "BY": {
-            "zoneName": "بيلاروسا"
-        },
-        "CA-AB": {
-            "countryName": "كندا",
-            "zoneName": "ألبرتا"
-        },
-        "CA-BC": {
-            "countryName": "كندا",
-            "zoneName": "كولومبيا البريطانية"
-        },
-        "CA-MB": {
-            "countryName": "كندا",
-            "zoneName": "مانيتوبا"
-        },
-        "CA-NL": {
-            "countryName": "كندا",
-            "zoneName": "نويفاوندلاند ولابرادو"
-        },
-        "CA-NB": {
-            "countryName": "كندا",
-            "zoneName": "نيو برونزويك"
-        },
-        "CA-NT": {
-            "countryName": "كندا",
-            "zoneName": "الأقاليم الشمالية الجنوبية"
-        },
-        "CA-NS": {
-            "countryName": "كندا",
-            "zoneName": "نوفا سكوتيا"
-        },
-        "CA-NU": {
-            "countryName": "كندا",
-            "zoneName": "نونافوت"
-        },
-        "CA-ON": {
-            "countryName": "كندا",
-            "zoneName": "أونتاريو"
-        },
-        "CA-PE": {
-            "countryName": "كندا",
-            "zoneName": "جزيرة الأمير إدوارد"
-        },
-        "CA-QC": {
-            "countryName": "Cكندا",
-            "zoneName": "كيبيك"
-        },
-        "CA-SK": {
-            "countryName": "كندا",
-            "zoneName": "ساسكاتشيوان"
-        },
-        "CA-YT": {
-            "countryName": "كندا",
-            "zoneName": "يوكون"
-        },
-        "CH": {
-            "zoneName": "سويسرا"
-        },
-        "CR": {
-            "zoneName": "كوستاريكا"
-        },
-        "CY": {
-            "zoneName": "قبرص"
-        },
-        "CZ": {
-            "zoneName": "تشيكيا"
-        },
-        "DE": {
-            "zoneName": "ألمانيا"
-        },
-        "DK": {
-            "zoneName": "الدنمارك"
-        },
-        "DZ": {
-            "zoneName": "الجزائر"
-        },
-        "EE": {
-            "zoneName": "إستونيا"
-        },
-        "EG": {
-            "zoneName": "مصر"
-        },
-        "ES": {
-            "zoneName": "إسبانيا"
-        },
-        "ES-IB": {
-            "countryName": "إسبانيا",
-            "zoneName": "جزر البليار"
-        },
-        "ES-CN": {
-            "countryName": "إسبانيا",
-            "zoneName": "جزر الكناري"
-        },
-        "FI": {
-            "zoneName": "فنلندا"
-        },
-        "FO": {
-            "zoneName": "جزر فارو"
-        },
-        "FR": {
-            "zoneName": "فرنسا"
-        },
-        "GB": {
-            "zoneName": "بريطانيا العظمى"
-        },
-        "GB-NIR": {
-            "zoneName": "إيرلندا الشمالية"
-        },
-        "GE": {
-            "zoneName": "جورجيا"
-        },
-        "GR": {
-            "zoneName": "اليونان"
-        },
-        "GT": {
-            "zoneName": "غواتيمالا"
-        },
-        "HN": {
-            "zoneName": "هندوراس"
-        },
-        "HR": {
-            "zoneName": "كرواتيا"
-        },
-        "HU": {
-            "zoneName": "هنغاريا"
-        },
-        "IE": {
-            "zoneName": "أيرلندا"
-        },
-        "IL": {
-            "zoneName": "إسرائيل"
-        },
-        "IQ": {
-            "zoneName": "العراق"
-        },
-        "IR": {
-            "zoneName": "إيران"
-        },
-        "IS": {
-            "zoneName": "آيسلندا"
-        },
-        "IT": {
-            "zoneName": "إيطاليا"
-        },
-        "JO": {
-            "zoneName": "الاردن"
-        },
-        "KZ": {
-            "zoneName": "كازاخستان"
-        },
-        "LB": {
-            "zoneName": "لبنان"
-        },
-        "LT": {
-            "zoneName": "ليتوانيا"
-        },
-        "LU": {
-            "zoneName": "لوكسمبورغ"
-        },
-        "LV": {
-            "zoneName": "لاتفيا"
-        },
-        "LY": {
-            "zoneName": "ليبيا"
-        },
-        "MA": {
-            "zoneName": "المغرب"
-        },
-        "MD": {
-            "zoneName": "مولدوفا"
-        },
-        "ME": {
-            "zoneName": "الجبل الاسود"
-        },
-        "MK": {
-            "zoneName": "شمال مقدونيا"
-        },
-        "MT": {
-            "zoneName": "مالطا"
-        },
-        "NI": {
-            "zoneName": "نيكاراغوا"
-        },
-        "NKR": {
-            "zoneName": "مرتفعات قرة باغ"
-        },
-        "NL": {
-            "zoneName": "هولندا"
-        },
-        "NO": {
-            "zoneName": "نورواي"
-        },
-        "NZ": {
-            "zoneName": "نيوزلندا"
-        },
-        "PA": {
-            "zoneName": "بنما"
-        },
-        "PE": {
-            "zoneName": "البيرو"
-        },
-        "PL": {
-            "zoneName": "بولندا"
-        },
-        "PS": {
-            "zoneName": "دولة فلسطين"
-        },
-        "PT": {
-            "zoneName": "البرتغال"
-        },
-        "PT-AC": {
-            "countryName": "البرتغال",
-            "zoneName": "أزورس"
-        },
-        "PT-MA": {
-            "countryName": "البرتغال",
-            "zoneName": "ماديرا"
-        },
-        "RO": {
-            "zoneName": "رومانيا"
-        },
-        "RS": {
-            "zoneName": "صربيا"
-        },
-        "RU": {
-            "zoneName": "روسيا"
-        },
-        "SA": {
-            "zoneName": "المملكة العربية السعودية"
-        },
-        "SE": {
-            "zoneName": "السويد"
-        },
-        "SI": {
-            "zoneName": "سلوفينيا"
-        },
-        "SK": {
-            "zoneName": "سلوفايكا"
-        },
-        "SV": {
-            "zoneName": "السلفادور"
-        },
-        "SY": {
-            "zoneName": "سوريا"
-        },
-        "TM": {
-            "zoneName": "تركمانستان"
-        },
-        "TN": {
-            "zoneName": "تونس"
-        },
-        "TR": {
-            "zoneName": "تركيا"
-        },
-        "TW": {
-            "zoneName": "تايوان"
-        },
-        "UA": {
-            "zoneName": "أوكرانيا"
-        },
-        "US": {
-            "zoneName": "الولايات المتحدة الأمريكية"
-        },
-        "UY": {
-            "zoneName": "أورغواي"
-        },
-        "UZ": {
-            "zoneName": "أوزبكستان"
-        }
+        "AD": { "zoneName": "أندورا" },
+        "AL": { "zoneName": "ألبانيا" },
+        "AM": { "zoneName": "أرمينيا" },
+        "AT": { "zoneName": "النمسا" },
+        "AR": { "zoneName": "الأرجنتين" },
+        "AUS-NSW": { "countryName": "أستراليا", "zoneName": "نيو ساوث ويلز" },
+        "AUS-NT": { "countryName": "أستراليا", "zoneName": "الإقليم الشمالي" },
+        "AUS-QLD": { "countryName": "أستراليا", "zoneName": "كوينزلاند" },
+        "AUS-SA": { "countryName": "أستراليا", "zoneName": "جنوب أستراليا" },
+        "AUS-TAS": { "countryName": "أستراليا", "zoneName": "تاسمانيا" },
+        "AUS-VIC": { "countryName": "أستراليا", "zoneName": "فيكتوريا" },
+        "AUS-WA": { "countryName": "أستراليا", "zoneName": "أستراليا الغربية" },
+        "AX": { "zoneName": "جزر_أولاند" },
+        "AZ": { "zoneName": "أذربيجان" },
+        "BA": { "zoneName": "البوسنة والهرسك" },
+        "BE": { "zoneName": "بلجيكا" },
+        "BG": { "zoneName": "بلغاريا" },
+        "BY": { "zoneName": "بيلاروسا" },
+        "CA-AB": { "countryName": "كندا", "zoneName": "ألبرتا" },
+        "CA-BC": { "countryName": "كندا", "zoneName": "كولومبيا البريطانية" },
+        "CA-MB": { "countryName": "كندا", "zoneName": "مانيتوبا" },
+        "CA-NL": { "countryName": "كندا", "zoneName": "نويفاوندلاند ولابرادو" },
+        "CA-NB": { "countryName": "كندا", "zoneName": "نيو برونزويك" },
+        "CA-NT": { "countryName": "كندا", "zoneName": "الأقاليم الشمالية الجنوبية" },
+        "CA-NS": { "countryName": "كندا", "zoneName": "نوفا سكوتيا" },
+        "CA-NU": { "countryName": "كندا", "zoneName": "نونافوت" },
+        "CA-ON": { "countryName": "كندا", "zoneName": "أونتاريو" },
+        "CA-PE": { "countryName": "كندا", "zoneName": "جزيرة الأمير إدوارد" },
+        "CA-QC": { "countryName": "Cكندا", "zoneName": "كيبيك" },
+        "CA-SK": { "countryName": "كندا", "zoneName": "ساسكاتشيوان" },
+        "CA-YT": { "countryName": "كندا", "zoneName": "يوكون" },
+        "CH": { "zoneName": "سويسرا" },
+        "CR": { "zoneName": "كوستاريكا" },
+        "CY": { "zoneName": "قبرص" },
+        "CZ": { "zoneName": "تشيكيا" },
+        "DE": { "zoneName": "ألمانيا" },
+        "DK": { "zoneName": "الدنمارك" },
+        "DZ": { "zoneName": "الجزائر" },
+        "EE": { "zoneName": "إستونيا" },
+        "EG": { "zoneName": "مصر" },
+        "ES": { "zoneName": "إسبانيا" },
+        "ES-IB": { "countryName": "إسبانيا", "zoneName": "جزر البليار" },
+        "ES-CN": { "countryName": "إسبانيا", "zoneName": "جزر الكناري" },
+        "FI": { "zoneName": "فنلندا" },
+        "FO": { "zoneName": "جزر فارو" },
+        "FR": { "zoneName": "فرنسا" },
+        "GB": { "zoneName": "بريطانيا العظمى" },
+        "GB-NIR": { "zoneName": "إيرلندا الشمالية" },
+        "GE": { "zoneName": "جورجيا" },
+        "GR": { "zoneName": "اليونان" },
+        "GT": { "zoneName": "غواتيمالا" },
+        "HN": { "zoneName": "هندوراس" },
+        "HR": { "zoneName": "كرواتيا" },
+        "HU": { "zoneName": "هنغاريا" },
+        "IE": { "zoneName": "أيرلندا" },
+        "IL": { "zoneName": "إسرائيل" },
+        "IQ": { "zoneName": "العراق" },
+        "IR": { "zoneName": "إيران" },
+        "IS": { "zoneName": "آيسلندا" },
+        "IT": { "zoneName": "إيطاليا" },
+        "JO": { "zoneName": "الاردن" },
+        "KZ": { "zoneName": "كازاخستان" },
+        "LB": { "zoneName": "لبنان" },
+        "LT": { "zoneName": "ليتوانيا" },
+        "LU": { "zoneName": "لوكسمبورغ" },
+        "LV": { "zoneName": "لاتفيا" },
+        "LY": { "zoneName": "ليبيا" },
+        "MA": { "zoneName": "المغرب" },
+        "MD": { "zoneName": "مولدوفا" },
+        "ME": { "zoneName": "الجبل الاسود" },
+        "MK": { "zoneName": "شمال مقدونيا" },
+        "MT": { "zoneName": "مالطا" },
+        "NI": { "zoneName": "نيكاراغوا" },
+        "NKR": { "zoneName": "مرتفعات قرة باغ" },
+        "NL": { "zoneName": "هولندا" },
+        "NO": { "zoneName": "نورواي" },
+        "NZ": { "zoneName": "نيوزلندا" },
+        "PA": { "zoneName": "بنما" },
+        "PE": { "zoneName": "البيرو" },
+        "PL": { "zoneName": "بولندا" },
+        "PS": { "zoneName": "دولة فلسطين" },
+        "PT": { "zoneName": "البرتغال" },
+        "PT-AC": { "countryName": "البرتغال", "zoneName": "أزورس" },
+        "PT-MA": { "countryName": "البرتغال", "zoneName": "ماديرا" },
+        "RO": { "zoneName": "رومانيا" },
+        "RS": { "zoneName": "صربيا" },
+        "RU": { "zoneName": "روسيا" },
+        "SA": { "zoneName": "المملكة العربية السعودية" },
+        "SE": { "zoneName": "السويد" },
+        "SI": { "zoneName": "سلوفينيا" },
+        "SK": { "zoneName": "سلوفايكا" },
+        "SV": { "zoneName": "السلفادور" },
+        "SY": { "zoneName": "سوريا" },
+        "TM": { "zoneName": "تركمانستان" },
+        "TN": { "zoneName": "تونس" },
+        "TR": { "zoneName": "تركيا" },
+        "TW": { "zoneName": "تايوان" },
+        "UA": { "zoneName": "أوكرانيا" },
+        "US": { "zoneName": "الولايات المتحدة الأمريكية" },
+        "UY": { "zoneName": "أورغواي" },
+        "UZ": { "zoneName": "أوزبكستان" }
     }
 }

--- a/web/public/locales/cs.json
+++ b/web/public/locales/cs.json
@@ -6,15 +6,9 @@
         "datasources": "zdroje dat",
         "contribute": "Zapojte se <a href=\"%s\" target=\"_blank\">přidáním své oblasti</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Oblasti",
-        "about": "Info"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Oblasti", "about": "Info" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Mapování dopadu spotřeby elektřiny na klima"
-        },
+        "view1": { "subtitle": "Mapování dopadu spotřeby elektřiny na klima" },
         "view2": {
             "header": "Sledujte, kolik CO₂ je vyprodukovaného vaší spotřebou elektřiny v reálném čase",
             "text": "Barevně zobrazujeme oblasti po celém světě na základě jejich uhlíkové intenzity"
@@ -50,13 +44,13 @@
         "search": "Hledej oblasti"
     },
     "country-history": {
-        "carbonintensity24h": "Uhlíková intenzita za posledních 24 hodin",
-        "emissionsorigin24h": "Původ emisí za posledních 24 hodin",
-        "emissionsproduction24h": "Emise vyprodukované za posledních 24 hodin",
-        "electricityorigin24h": "Původ elektřiny za posledních 24 hodin",
-        "electricityproduction24h": "Produkce elektřiny za posledních 24 hodin",
-        "electricityprices24h": "Cena elektřiny za posledních 24 hodin",
-        "Getdata": "Ziskejte historická a mezní data i předpověď přes API"
+        "Getdata": "Ziskejte historická a mezní data i předpověď přes API",
+        "carbonintensity": { "hourly": "Uhlíková intenzita za posledních 24 hodin" },
+        "emissionsorigin": { "hourly": "Původ emisí za posledních 24 hodin" },
+        "emissionsproduction": { "hourly": "Emise vyprodukované za posledních 24 hodin" },
+        "electricityorigin": { "hourly": "Původ elektřiny za posledních 24 hodin" },
+        "electricityproduction": { "hourly": "Produkce elektřiny za posledních 24 hodin" },
+        "electricityprices": { "hourly": "Cena elektřiny za posledních 24 hodin" }
     },
     "footer": {
         "foundbugs": "Našli jste nedostatky, nebo máte nápad? Řekněte nám o nich",
@@ -190,1217 +184,368 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publikuje data a obrázky na <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> pouze pro informační účely. Nezaručuje správnost ani žádnou formu záruky a vyhrazuje si právo kdykoliv změnit obsah nebo odstranit jeho části bez toho, aby o tom musel informovat. electricityMap nepřebírá žádnou zodpovědnost za jakékoliv škody nebo výdaje, které by mohly vzniknout v důsledku nepřesností, neúplnosti, neopatrnosti nebo zastaralosti electricityMap nebo informací získaných z ní. Není dovolené zahrnout tuto webovou stránku, nebo její jednotlivé prvky do jiné webové stránky bez předchozího písemného souhlasu.<br><br> Všechna práva duševního vlastnictví patří oprávněným majitelům a poskytovatelům licencí. Kopírování, distribuce a jakékoliv jiné použití těchto materiálů, především energetických údajů, není povolené bez písemného souhlasu electricityMap, s výjimkou případů, které jsou stanovené jinými předpisy (jako je právo citovat), pokud není pro konkrétní materiály uvedeno jinak. <br><br> Toto vyloučení odpovědnosti může být aktualizováno."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Spojené Arabské Emiráty"
-        },
-        "AF": {
-            "zoneName": "Afghánistán"
-        },
-        "AG": {
-            "zoneName": "Antigua a Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albánie"
-        },
-        "AM": {
-            "zoneName": "Arménie"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarktida"
-        },
-        "AS": {
-            "zoneName": "Americká Samoa"
-        },
-        "AT": {
-            "zoneName": "Rakousko"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AUS-NSW": {
-            "countryName": "Austrálie",
-            "zoneName": "Nový Jižní Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Austrálie",
-            "zoneName": "Severní teritorium"
-        },
-        "AUS-QLD": {
-            "countryName": "Austrálie",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Austrálie",
-            "zoneName": "Jižní Austrálie"
-        },
-        "AUS-TAS": {
-            "countryName": "Austrálie",
-            "zoneName": "Tasmánie"
-        },
-        "AUS-VIC": {
-            "countryName": "Austrálie",
-            "zoneName": "Viktorie"
-        },
-        "AUS-WA": {
-            "countryName": "Austrálie",
-            "zoneName": "Západní Austrálie"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Ålandy"
-        },
-        "AZ": {
-            "zoneName": "Ázerbájdžán"
-        },
-        "BA": {
-            "zoneName": "Bosna a Hercegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladéš"
-        },
-        "BE": {
-            "zoneName": "Belgie"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulharsko"
-        },
-        "BH": {
-            "zoneName": "Bahrajn"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermudy"
-        },
-        "BN": {
-            "zoneName": "Brunej"
-        },
-        "BO": {
-            "zoneName": "Bolívie"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Svatý Eustach a Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brazílie",
-            "zoneName": "Centrální Brazílie"
-        },
-        "BR-N": {
-            "countryName": "Brazílie",
-            "zoneName": "Severní Brazílie"
-        },
-        "BR-NE": {
-            "countryName": "Brazílie",
-            "zoneName": "Severovýchodní Brazílie"
-        },
-        "BR-S": {
-            "countryName": "Brazílie",
-            "zoneName": "Jižní Brazílie"
-        },
-        "BS": {
-            "zoneName": "Bahamy"
-        },
-        "BT": {
-            "zoneName": "Bhútán"
-        },
-        "BV": {
-            "zoneName": "Bouvetův ostrov"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Bělorusko"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "Britská Kolumbie"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland a Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "Nový Brunšvik"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Severozápadní teritoria"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nové Skotsko"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Ostrov prince Eduarda"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Quebec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Kokosové ostrovy"
-        },
-        "CD": {
-            "zoneName": "Demokratická republika Kongo"
-        },
-        "CF": {
-            "zoneName": "Středoafrická republika"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Švýcarsko"
-        },
-        "CI": {
-            "zoneName": "Pobřeží Slonoviny"
-        },
-        "CK": {
-            "zoneName": "Cookovy ostrovy"
-        },
-        "CL-SING": {
-            "countryName": "Chile",
-            "zoneName": "SING"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "SEA"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Čína"
-        },
-        "CO": {
-            "zoneName": "Kolumbie"
-        },
-        "CR": {
-            "zoneName": "Kostarika"
-        },
-        "CU": {
-            "zoneName": "Kuba"
-        },
-        "CV": {
-            "zoneName": "Kapverdy"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Vánoční ostrov"
-        },
-        "CY": {
-            "zoneName": "Kypr"
-        },
-        "CZ": {
-            "zoneName": "Česko"
-        },
-        "DE": {
-            "zoneName": "Německo"
-        },
-        "DJ": {
-            "zoneName": "Džibutsko"
-        },
-        "DK": {
-            "zoneName": "Dánsko"
-        },
-        "DK-DK1": {
-            "countryName": "Dánsko",
-            "zoneName": "Západní Dánsko"
-        },
-        "DK-DK2": {
-            "countryName": "Dánsko",
-            "zoneName": "Východní Dánsko"
-        },
-        "DK-BHM": {
-            "countryName": "Dánsko",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominika"
-        },
-        "DO": {
-            "zoneName": "Dominikánská republika"
-        },
-        "DZ": {
-            "zoneName": "Alžírsko"
-        },
-        "EC": {
-            "zoneName": "Ekvádor"
-        },
-        "EE": {
-            "zoneName": "Estonsko"
-        },
-        "EG": {
-            "zoneName": "Egypt"
-        },
-        "EH": {
-            "zoneName": "Západní Sahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Španělsko"
-        },
-        "ES-IB-FO": {
-            "countryName": "Španělsko",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Španělsko",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Španělsko",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Španělsko",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Španělsko",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Španělsko",
-            "zoneName": "Kanárské ostrovy"
-        },
-        "ES-CN-HI": {
-            "countryName": "Španělsko",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Španělsko",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Španělsko",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Španělsko",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Etiopie"
-        },
-        "FI": {
-            "zoneName": "Finsko"
-        },
-        "FJ": {
-            "zoneName": "Fidži"
-        },
-        "FK": {
-            "zoneName": "Falklandy"
-        },
-        "FM": {
-            "zoneName": "Mikronésie"
-        },
-        "FO": {
-            "zoneName": "Faerské ostrovy"
-        },
-        "FR": {
-            "zoneName": "Francie"
-        },
-        "FR-COR": {
-            "countryName": "Francie",
-            "zoneName": "Korsika"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Spojené království"
-        },
-        "GB-NIR": {
-            "zoneName": "Severní Irsko"
-        },
-        "GB-ORK": {
-            "countryName": "Velká Británie",
-            "zoneName": "Orkneje"
-        },
-        "GB-SHI": {
-            "countryName": "Velká Británie",
-            "zoneName": "Shetlandy"
-        },
-        "GB-ZET": {
-            "countryName": "Velká Británie",
-            "zoneName": "Shetlandy"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Gruzie"
-        },
-        "GF": {
-            "zoneName": "Francouzská Guyana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Grónsko"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Rovníková Guinea"
-        },
-        "GR": {
-            "zoneName": "Řecko"
-        },
-        "GR-IS": {
-            "countryName": "Řecko",
-            "zoneName": "Egejské ostrovy"
-        },
-        "GS": {
-            "zoneName": "Jižní Georgie a Jižní Sandwichovy ostrovy "
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hongkong"
-        },
-        "HM": {
-            "zoneName": "Heardův ostrov a McDonaldovy ostrovy "
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Chorvatsko"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Maďarsko"
-        },
-        "ID": {
-            "zoneName": "Indonésie"
-        },
-        "IE": {
-            "zoneName": "Irsko"
-        },
-        "IL": {
-            "zoneName": "Izrael"
-        },
-        "IM": {
-            "zoneName": "Ostrov Man"
-        },
-        "IN-AN": {
-            "countryName": "Indie",
-            "zoneName": "Andmany a Nikobary"
-        },
-        "IN-AP": {
-            "countryName": "Indie",
-            "zoneName": "Andhrapradáš"
-        },
-        "IN-AR": {
-            "countryName": "Indie",
-            "zoneName": "Arunáčalpraéš"
-        },
-        "IN-AS": {
-            "countryName": "Indie",
-            "zoneName": "Ásam"
-        },
-        "IN-BR": {
-            "countryName": "Indie",
-            "zoneName": "Bihár"
-        },
-        "IN-CT": {
-            "countryName": "Indie",
-            "zoneName": "Čhattásgarh"
-        },
-        "IN-DL": {
-            "countryName": "Indie",
-            "zoneName": "Dillí"
-        },
-        "IN-DN": {
-            "countryName": "Indie",
-            "zoneName": "Dádra a Nagar Havelí"
-        },
-        "IN-GA": {
-            "countryName": "Indie",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Indie",
-            "zoneName": "Gudžarát"
-        },
-        "IN-HP": {
-            "countryName": "Indie",
-            "zoneName": "Himáčalpradéš"
-        },
-        "IN-HR": {
-            "countryName": "Indie",
-            "zoneName": "Harijána"
-        },
-        "IN-JH": {
-            "countryName": "Indie",
-            "zoneName": "Džhárkhand"
-        },
-        "IN-JK": {
-            "countryName": "Indie",
-            "zoneName": "Džammú a Kašmír"
-        },
-        "IN-KA": {
-            "countryName": "Indie",
-            "zoneName": "Karnátaka"
-        },
-        "IN-KL": {
-            "countryName": "Indie",
-            "zoneName": "Kérala"
-        },
-        "IN-MH": {
-            "countryName": "Indie",
-            "zoneName": "Maháraštra"
-        },
-        "IN-ML": {
-            "countryName": "Indie",
-            "zoneName": "Meghálaj"
-        },
-        "IN-MN": {
-            "countryName": "Indie",
-            "zoneName": "Manípur"
-        },
-        "IN-MP": {
-            "countryName": "Indie",
-            "zoneName": "Madhjapradéš"
-        },
-        "IN-MZ": {
-            "countryName": "Indie",
-            "zoneName": "Mizorám"
-        },
-        "IN-NL": {
-            "countryName": "Indie",
-            "zoneName": "Nágsko"
-        },
-        "IN-OR": {
-            "countryName": "Indie",
-            "zoneName": "Urísa"
-        },
-        "IN-PB": {
-            "countryName": "Indie",
-            "zoneName": "Pandžáb"
-        },
-        "IN-PY": {
-            "countryName": "Indie",
-            "zoneName": "Puttučéri"
-        },
-        "IN-RJ": {
-            "countryName": "Indie",
-            "zoneName": "Radžastan"
-        },
-        "IN-SK": {
-            "countryName": "Indie",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "Indie",
-            "zoneName": "Tamilnádu"
-        },
-        "IN-TR": {
-            "countryName": "Indie",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Indie",
-            "zoneName": "Uttarpradáš"
-        },
-        "IN-UT": {
-            "countryName": "Indie",
-            "zoneName": "Uttarákhand"
-        },
-        "IN-WB": {
-            "countryName": "Indie",
-            "zoneName": "Západné Bengálsko"
-        },
-        "IO": {
-            "zoneName": "Britské indickooceánské území"
-        },
-        "IQ": {
-            "zoneName": "Irák"
-        },
-        "IQ-KUR": {
-            "countryName": "Irák",
-            "zoneName": "Kurdistán"
-        },
-        "IR": {
-            "zoneName": "Írán"
-        },
-        "IS": {
-            "zoneName": "Island"
-        },
-        "IT": {
-            "zoneName": "Itálie"
-        },
-        "IT-CNO": {
-            "countryName": "Itálie",
-            "zoneName": "Středo-severní"
-        },
-        "IT-CSO": {
-            "countryName": "Itálie",
-            "zoneName": "Středo-jižní"
-        },
-        "IT-NO": {
-            "countryName": "Itálie",
-            "zoneName": "Severní"
-        },
-        "IT-SAR": {
-            "countryName": "Itálie",
-            "zoneName": "Sardinie"
-        },
-        "IT-SIC": {
-            "countryName": "Itálie",
-            "zoneName": "Sicílie"
-        },
-        "IT-SO": {
-            "countryName": "Itálie",
-            "zoneName": "Jižní"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamajka"
-        },
-        "JO": {
-            "zoneName": "Jordánsko"
-        },
-        "JP-CB": {
-            "countryName": "Japonsko",
-            "zoneName": "Čobú"
-        },
-        "JP-CG": {
-            "countryName": "Japonsko",
-            "zoneName": "Čugokú"
-        },
-        "JP-HKD": {
-            "countryName": "Japonsko",
-            "zoneName": "Hokkaidó"
-        },
-        "JP-HR": {
-            "countryName": "Japonsko",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japonsko",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japonsko",
-            "zoneName": "Kjušú"
-        },
-        "JP-ON": {
-            "countryName": "Japonsko",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japonsko",
-            "zoneName": "Šikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japonsko",
-            "zoneName": "Tóhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japonsko",
-            "zoneName": "Tokio"
-        },
-        "KE": {
-            "zoneName": "Keňa"
-        },
-        "KG": {
-            "zoneName": "Kyrgyzstán"
-        },
-        "KH": {
-            "zoneName": "Kambodža"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Komory"
-        },
-        "KN": {
-            "zoneName": "Svatý Kryštof a Nevis"
-        },
-        "KP": {
-            "zoneName": "Severní Korea"
-        },
-        "KR": {
-            "zoneName": "Jižní Korea"
-        },
-        "KW": {
-            "zoneName": "Kuvajt"
-        },
-        "KY": {
-            "zoneName": "Kajmanské ostrovy "
-        },
-        "KZ": {
-            "zoneName": "Kazachstán"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Libanon"
-        },
-        "LC": {
-            "zoneName": "Svatá Lucie "
-        },
-        "LI": {
-            "zoneName": "Lichtenštejnsko"
-        },
-        "LK": {
-            "zoneName": "Srí Lanka"
-        },
-        "LR": {
-            "zoneName": "Libérie"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Litva"
-        },
-        "LU": {
-            "zoneName": "Lucembursko"
-        },
-        "LV": {
-            "zoneName": "Lotyšsko"
-        },
-        "LY": {
-            "zoneName": "Libye"
-        },
-        "MA": {
-            "zoneName": "Maroko"
-        },
-        "MC": {
-            "zoneName": "Monako"
-        },
-        "MD": {
-            "zoneName": "Moldavsko"
-        },
-        "ME": {
-            "zoneName": "Černá Hora "
-        },
-        "MF": {
-            "countryName": "Svatý Martin",
-            "zoneName": "francouzská část"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Marshallovy ostrovy"
-        },
-        "MK": {
-            "zoneName": "Severní Makedonie"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Mongolsko"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Severní Mariany"
-        },
-        "MQ": {
-            "zoneName": "Martinik"
-        },
-        "MR": {
-            "zoneName": "Mauritánie"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauricius"
-        },
-        "MV": {
-            "zoneName": "Maledivy"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mexiko"
-        },
-        "MX-BC": {
-            "countryName": "Mexiko",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mexiko",
-            "zoneName": "Střední Mexiko"
-        },
-        "MX-NE": {
-            "countryName": "Mexiko",
-            "zoneName": "Severovýchodní Mexiko"
-        },
-        "MX-NO": {
-            "countryName": "Mexiko",
-            "zoneName": "Severní Mexiko"
-        },
-        "MX-NW": {
-            "countryName": "Mexiko",
-            "zoneName": "Severozápadní Mexiko"
-        },
-        "MX-OC": {
-            "countryName": "Mexiko",
-            "zoneName": "Západní Mexiko"
-        },
-        "MX-OR": {
-            "countryName": "Mexiko",
-            "zoneName": "Východní Mexiko"
-        },
-        "MX-PN": {
-            "countryName": "Mexiko",
-            "zoneName": "Poloostrov"
-        },
-        "MY-EM": {
-            "countryName": "Malajsie",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malajsie",
-            "zoneName": "Poloostrov"
-        },
-        "MZ": {
-            "zoneName": "Mosambik"
-        },
-        "NA": {
-            "zoneName": "Namibie"
-        },
-        "NC": {
-            "zoneName": "Nová Kaledonie"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigérie"
-        },
-        "NI": {
-            "zoneName": "Nikaragua"
-        },
-        "NKR": {
-            "zoneName": "Náhorní Karabach"
-        },
-        "NL": {
-            "zoneName": "Nizozemsko"
-        },
-        "NO-NO1": {
-            "countryName": "Norsko",
-            "zoneName": "Jihovýchodní Norsko"
-        },
-        "NO-NO2": {
-            "countryName": "Norsko",
-            "zoneName": "Jihozápadní Norsko"
-        },
-        "NO-NO3": {
-            "countryName": "Norsko",
-            "zoneName": "Střední Norsko"
-        },
-        "NO-NO4": {
-            "countryName": "Norsko",
-            "zoneName": "Severní Norsko"
-        },
-        "NO-NO5": {
-            "countryName": "Norsko",
-            "zoneName": "Západní Norsko"
-        },
-        "NP": {
-            "zoneName": "Nepál"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Novy Zéland"
-        },
-        "NZ-NZA": {
-            "countryName": "Novy Zéland",
-            "zoneName": "Aucklandské ostrovy"
-        },
-        "NZ-NZC": {
-            "countryName": "Novy Zéland",
-            "zoneName": "Chathamské ostrovy"
-        },
-        "OM": {
-            "zoneName": "Omán"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Francouzská Polynésie"
-        },
-        "PG": {
-            "zoneName": "Papua-Nová Guinea"
-        },
-        "PH": {
-            "zoneName": "Filipíny"
-        },
-        "PK": {
-            "zoneName": "Pákistán"
-        },
-        "PL": {
-            "zoneName": "Polsko"
-        },
-        "PM": {
-            "zoneName": "Saint Pierre a Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairnovy ostrovy"
-        },
-        "PR": {
-            "zoneName": "Portoriko"
-        },
-        "PS": {
-            "zoneName": "Palestinská autonomie"
-        },
-        "PT": {
-            "zoneName": "Portugalsko"
-        },
-        "PT-AC": {
-            "countryName": "Portugalsko",
-            "zoneName": "Azory"
-        },
-        "PT-MA": {
-            "countryName": "Portugalsko",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Katar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Rumunsko"
-        },
-        "RS": {
-            "zoneName": "Srbsko"
-        },
-        "RU": {
-            "zoneName": "Rusko"
-        },
-        "RU-1": {
-            "countryName": "Rusko",
-            "zoneName": "Evropské Rusko a Ural"
-        },
-        "RU-2": {
-            "countryName": "Rusko",
-            "zoneName": "Sibiř"
-        },
-        "RU-EU": {
-            "zoneName": "Rusko"
-        },
-        "RU-AS": {
-            "zoneName": "Rusko"
-        },
-        "RU-KGD": {
-            "countryName": "Rusko",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Saudská Arábie"
-        },
-        "SB": {
-            "zoneName": "Šalamounovy ostrovy"
-        },
-        "SC": {
-            "zoneName": "Seychely"
-        },
-        "SD": {
-            "zoneName": "Súdán"
-        },
-        "SE": {
-            "zoneName": "Švédsko"
-        },
-        "SG": {
-            "zoneName": "Singapur"
-        },
-        "SH": {
-            "zoneName": "Svatá Helena, Ascension a Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovinsko"
-        },
-        "SJ": {
-            "zoneName": "Špicberky a Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovensko"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somálsko"
-        },
-        "SR": {
-            "zoneName": "Surinam"
-        },
-        "SS": {
-            "zoneName": "Jižní Súdán"
-        },
-        "ST": {
-            "zoneName": "Svatý Tomáš a Princův ostrov "
-        },
-        "SV": {
-            "zoneName": "Salvador"
-        },
-        "SX": {
-            "countryName": "Svatý Martin",
-            "zoneName": "nizozemská část"
-        },
-        "SY": {
-            "zoneName": "Sýrie"
-        },
-        "SZ": {
-            "zoneName": "Svazijsko"
-        },
-        "TC": {
-            "zoneName": "Turks a Caicos"
-        },
-        "TD": {
-            "zoneName": "Čad"
-        },
-        "TF": {
-            "zoneName": "Francouzská jižní a antarktická území"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thajsko"
-        },
-        "TJ": {
-            "zoneName": "Tadžikistán"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Východní Timor"
-        },
-        "TM": {
-            "zoneName": "Turkmenistán"
-        },
-        "TN": {
-            "zoneName": "Tunisko"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turecko"
-        },
-        "TT": {
-            "zoneName": "Trinidad a Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Tchaj-wan"
-        },
-        "TZ": {
-            "zoneName": "Tanzanie"
-        },
-        "UA": {
-            "zoneName": "Ukrajina"
-        },
-        "UA-CR": {
-            "countryName": "Ukrajina",
-            "zoneName": "Krym"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Menší odlehlé ostrovy USA "
-        },
-        "US-HI": {
-            "countryName": "Spojené státy americké",
-            "zoneName": "Havaj"
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistán"
-        },
-        "VA": {
-            "zoneName": "Vatikán"
-        },
-        "VC": {
-            "zoneName": "Svatý Vincenc a Grenadiny"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Britské Panenské ostrovy",
-            "zoneName": "Britské Panenské ostrovy"
-        },
-        "VI": {
-            "countryName": "Spojené státy americké",
-            "zoneName": "Americké Panenské ostrovy"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis a Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Severokyperská turecká republika"
-        },
-        "YE": {
-            "zoneName": "Jemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Jihoafrická republika"
-        },
-        "ZM": {
-            "zoneName": "Zambie"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmánie",
-            "zoneName": "King Island"
-        }
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Spojené Arabské Emiráty" },
+        "AF": { "zoneName": "Afghánistán" },
+        "AG": { "zoneName": "Antigua a Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albánie" },
+        "AM": { "zoneName": "Arménie" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarktida" },
+        "AS": { "zoneName": "Americká Samoa" },
+        "AT": { "zoneName": "Rakousko" },
+        "AR": { "zoneName": "Argentina" },
+        "AUS-NSW": { "countryName": "Austrálie", "zoneName": "Nový Jižní Wales" },
+        "AUS-NT": { "countryName": "Austrálie", "zoneName": "Severní teritorium" },
+        "AUS-QLD": { "countryName": "Austrálie", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Austrálie", "zoneName": "Jižní Austrálie" },
+        "AUS-TAS": { "countryName": "Austrálie", "zoneName": "Tasmánie" },
+        "AUS-VIC": { "countryName": "Austrálie", "zoneName": "Viktorie" },
+        "AUS-WA": { "countryName": "Austrálie", "zoneName": "Západní Austrálie" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Ålandy" },
+        "AZ": { "zoneName": "Ázerbájdžán" },
+        "BA": { "zoneName": "Bosna a Hercegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladéš" },
+        "BE": { "zoneName": "Belgie" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulharsko" },
+        "BH": { "zoneName": "Bahrajn" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermudy" },
+        "BN": { "zoneName": "Brunej" },
+        "BO": { "zoneName": "Bolívie" },
+        "BQ": { "zoneName": "Bonaire, Svatý Eustach a Saba" },
+        "BR-CS": { "countryName": "Brazílie", "zoneName": "Centrální Brazílie" },
+        "BR-N": { "countryName": "Brazílie", "zoneName": "Severní Brazílie" },
+        "BR-NE": { "countryName": "Brazílie", "zoneName": "Severovýchodní Brazílie" },
+        "BR-S": { "countryName": "Brazílie", "zoneName": "Jižní Brazílie" },
+        "BS": { "zoneName": "Bahamy" },
+        "BT": { "zoneName": "Bhútán" },
+        "BV": { "zoneName": "Bouvetův ostrov" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Bělorusko" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "Britská Kolumbie" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland a Labrador" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "Nový Brunšvik" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Severozápadní teritoria" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nové Skotsko" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Ostrov prince Eduarda" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Quebec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Kokosové ostrovy" },
+        "CD": { "zoneName": "Demokratická republika Kongo" },
+        "CF": { "zoneName": "Středoafrická republika" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Švýcarsko" },
+        "CI": { "zoneName": "Pobřeží Slonoviny" },
+        "CK": { "zoneName": "Cookovy ostrovy" },
+        "CL-SING": { "countryName": "Chile", "zoneName": "SING" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "SEA" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Čína" },
+        "CO": { "zoneName": "Kolumbie" },
+        "CR": { "zoneName": "Kostarika" },
+        "CU": { "zoneName": "Kuba" },
+        "CV": { "zoneName": "Kapverdy" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Vánoční ostrov" },
+        "CY": { "zoneName": "Kypr" },
+        "CZ": { "zoneName": "Česko" },
+        "DE": { "zoneName": "Německo" },
+        "DJ": { "zoneName": "Džibutsko" },
+        "DK": { "zoneName": "Dánsko" },
+        "DK-DK1": { "countryName": "Dánsko", "zoneName": "Západní Dánsko" },
+        "DK-DK2": { "countryName": "Dánsko", "zoneName": "Východní Dánsko" },
+        "DK-BHM": { "countryName": "Dánsko", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominika" },
+        "DO": { "zoneName": "Dominikánská republika" },
+        "DZ": { "zoneName": "Alžírsko" },
+        "EC": { "zoneName": "Ekvádor" },
+        "EE": { "zoneName": "Estonsko" },
+        "EG": { "zoneName": "Egypt" },
+        "EH": { "zoneName": "Západní Sahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Španělsko" },
+        "ES-IB-FO": { "countryName": "Španělsko", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Španělsko", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Španělsko", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Španělsko", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Španělsko", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Španělsko", "zoneName": "Kanárské ostrovy" },
+        "ES-CN-HI": { "countryName": "Španělsko", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Španělsko", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "Španělsko", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Španělsko", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Etiopie" },
+        "FI": { "zoneName": "Finsko" },
+        "FJ": { "zoneName": "Fidži" },
+        "FK": { "zoneName": "Falklandy" },
+        "FM": { "zoneName": "Mikronésie" },
+        "FO": { "zoneName": "Faerské ostrovy" },
+        "FR": { "zoneName": "Francie" },
+        "FR-COR": { "countryName": "Francie", "zoneName": "Korsika" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Spojené království" },
+        "GB-NIR": { "zoneName": "Severní Irsko" },
+        "GB-ORK": { "countryName": "Velká Británie", "zoneName": "Orkneje" },
+        "GB-SHI": { "countryName": "Velká Británie", "zoneName": "Shetlandy" },
+        "GB-ZET": { "countryName": "Velká Británie", "zoneName": "Shetlandy" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Gruzie" },
+        "GF": { "zoneName": "Francouzská Guyana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Grónsko" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Rovníková Guinea" },
+        "GR": { "zoneName": "Řecko" },
+        "GR-IS": { "countryName": "Řecko", "zoneName": "Egejské ostrovy" },
+        "GS": { "zoneName": "Jižní Georgie a Jižní Sandwichovy ostrovy " },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hongkong" },
+        "HM": { "zoneName": "Heardův ostrov a McDonaldovy ostrovy " },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Chorvatsko" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Maďarsko" },
+        "ID": { "zoneName": "Indonésie" },
+        "IE": { "zoneName": "Irsko" },
+        "IL": { "zoneName": "Izrael" },
+        "IM": { "zoneName": "Ostrov Man" },
+        "IN-AN": { "countryName": "Indie", "zoneName": "Andmany a Nikobary" },
+        "IN-AP": { "countryName": "Indie", "zoneName": "Andhrapradáš" },
+        "IN-AR": { "countryName": "Indie", "zoneName": "Arunáčalpraéš" },
+        "IN-AS": { "countryName": "Indie", "zoneName": "Ásam" },
+        "IN-BR": { "countryName": "Indie", "zoneName": "Bihár" },
+        "IN-CT": { "countryName": "Indie", "zoneName": "Čhattásgarh" },
+        "IN-DL": { "countryName": "Indie", "zoneName": "Dillí" },
+        "IN-DN": { "countryName": "Indie", "zoneName": "Dádra a Nagar Havelí" },
+        "IN-GA": { "countryName": "Indie", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Indie", "zoneName": "Gudžarát" },
+        "IN-HP": { "countryName": "Indie", "zoneName": "Himáčalpradéš" },
+        "IN-HR": { "countryName": "Indie", "zoneName": "Harijána" },
+        "IN-JH": { "countryName": "Indie", "zoneName": "Džhárkhand" },
+        "IN-JK": { "countryName": "Indie", "zoneName": "Džammú a Kašmír" },
+        "IN-KA": { "countryName": "Indie", "zoneName": "Karnátaka" },
+        "IN-KL": { "countryName": "Indie", "zoneName": "Kérala" },
+        "IN-MH": { "countryName": "Indie", "zoneName": "Maháraštra" },
+        "IN-ML": { "countryName": "Indie", "zoneName": "Meghálaj" },
+        "IN-MN": { "countryName": "Indie", "zoneName": "Manípur" },
+        "IN-MP": { "countryName": "Indie", "zoneName": "Madhjapradéš" },
+        "IN-MZ": { "countryName": "Indie", "zoneName": "Mizorám" },
+        "IN-NL": { "countryName": "Indie", "zoneName": "Nágsko" },
+        "IN-OR": { "countryName": "Indie", "zoneName": "Urísa" },
+        "IN-PB": { "countryName": "Indie", "zoneName": "Pandžáb" },
+        "IN-PY": { "countryName": "Indie", "zoneName": "Puttučéri" },
+        "IN-RJ": { "countryName": "Indie", "zoneName": "Radžastan" },
+        "IN-SK": { "countryName": "Indie", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "Indie", "zoneName": "Tamilnádu" },
+        "IN-TR": { "countryName": "Indie", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Indie", "zoneName": "Uttarpradáš" },
+        "IN-UT": { "countryName": "Indie", "zoneName": "Uttarákhand" },
+        "IN-WB": { "countryName": "Indie", "zoneName": "Západné Bengálsko" },
+        "IO": { "zoneName": "Britské indickooceánské území" },
+        "IQ": { "zoneName": "Irák" },
+        "IQ-KUR": { "countryName": "Irák", "zoneName": "Kurdistán" },
+        "IR": { "zoneName": "Írán" },
+        "IS": { "zoneName": "Island" },
+        "IT": { "zoneName": "Itálie" },
+        "IT-CNO": { "countryName": "Itálie", "zoneName": "Středo-severní" },
+        "IT-CSO": { "countryName": "Itálie", "zoneName": "Středo-jižní" },
+        "IT-NO": { "countryName": "Itálie", "zoneName": "Severní" },
+        "IT-SAR": { "countryName": "Itálie", "zoneName": "Sardinie" },
+        "IT-SIC": { "countryName": "Itálie", "zoneName": "Sicílie" },
+        "IT-SO": { "countryName": "Itálie", "zoneName": "Jižní" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamajka" },
+        "JO": { "zoneName": "Jordánsko" },
+        "JP-CB": { "countryName": "Japonsko", "zoneName": "Čobú" },
+        "JP-CG": { "countryName": "Japonsko", "zoneName": "Čugokú" },
+        "JP-HKD": { "countryName": "Japonsko", "zoneName": "Hokkaidó" },
+        "JP-HR": { "countryName": "Japonsko", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japonsko", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japonsko", "zoneName": "Kjušú" },
+        "JP-ON": { "countryName": "Japonsko", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japonsko", "zoneName": "Šikoku" },
+        "JP-TH": { "countryName": "Japonsko", "zoneName": "Tóhoku" },
+        "JP-TK": { "countryName": "Japonsko", "zoneName": "Tokio" },
+        "KE": { "zoneName": "Keňa" },
+        "KG": { "zoneName": "Kyrgyzstán" },
+        "KH": { "zoneName": "Kambodža" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Komory" },
+        "KN": { "zoneName": "Svatý Kryštof a Nevis" },
+        "KP": { "zoneName": "Severní Korea" },
+        "KR": { "zoneName": "Jižní Korea" },
+        "KW": { "zoneName": "Kuvajt" },
+        "KY": { "zoneName": "Kajmanské ostrovy " },
+        "KZ": { "zoneName": "Kazachstán" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Libanon" },
+        "LC": { "zoneName": "Svatá Lucie " },
+        "LI": { "zoneName": "Lichtenštejnsko" },
+        "LK": { "zoneName": "Srí Lanka" },
+        "LR": { "zoneName": "Libérie" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Litva" },
+        "LU": { "zoneName": "Lucembursko" },
+        "LV": { "zoneName": "Lotyšsko" },
+        "LY": { "zoneName": "Libye" },
+        "MA": { "zoneName": "Maroko" },
+        "MC": { "zoneName": "Monako" },
+        "MD": { "zoneName": "Moldavsko" },
+        "ME": { "zoneName": "Černá Hora " },
+        "MF": { "countryName": "Svatý Martin", "zoneName": "francouzská část" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Marshallovy ostrovy" },
+        "MK": { "zoneName": "Severní Makedonie" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Mongolsko" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Severní Mariany" },
+        "MQ": { "zoneName": "Martinik" },
+        "MR": { "zoneName": "Mauritánie" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauricius" },
+        "MV": { "zoneName": "Maledivy" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mexiko" },
+        "MX-BC": { "countryName": "Mexiko", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mexiko", "zoneName": "Střední Mexiko" },
+        "MX-NE": { "countryName": "Mexiko", "zoneName": "Severovýchodní Mexiko" },
+        "MX-NO": { "countryName": "Mexiko", "zoneName": "Severní Mexiko" },
+        "MX-NW": { "countryName": "Mexiko", "zoneName": "Severozápadní Mexiko" },
+        "MX-OC": { "countryName": "Mexiko", "zoneName": "Západní Mexiko" },
+        "MX-OR": { "countryName": "Mexiko", "zoneName": "Východní Mexiko" },
+        "MX-PN": { "countryName": "Mexiko", "zoneName": "Poloostrov" },
+        "MY-EM": { "countryName": "Malajsie", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malajsie", "zoneName": "Poloostrov" },
+        "MZ": { "zoneName": "Mosambik" },
+        "NA": { "zoneName": "Namibie" },
+        "NC": { "zoneName": "Nová Kaledonie" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolk" },
+        "NG": { "zoneName": "Nigérie" },
+        "NI": { "zoneName": "Nikaragua" },
+        "NKR": { "zoneName": "Náhorní Karabach" },
+        "NL": { "zoneName": "Nizozemsko" },
+        "NO-NO1": { "countryName": "Norsko", "zoneName": "Jihovýchodní Norsko" },
+        "NO-NO2": { "countryName": "Norsko", "zoneName": "Jihozápadní Norsko" },
+        "NO-NO3": { "countryName": "Norsko", "zoneName": "Střední Norsko" },
+        "NO-NO4": { "countryName": "Norsko", "zoneName": "Severní Norsko" },
+        "NO-NO5": { "countryName": "Norsko", "zoneName": "Západní Norsko" },
+        "NP": { "zoneName": "Nepál" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Novy Zéland" },
+        "NZ-NZA": { "countryName": "Novy Zéland", "zoneName": "Aucklandské ostrovy" },
+        "NZ-NZC": { "countryName": "Novy Zéland", "zoneName": "Chathamské ostrovy" },
+        "OM": { "zoneName": "Omán" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Francouzská Polynésie" },
+        "PG": { "zoneName": "Papua-Nová Guinea" },
+        "PH": { "zoneName": "Filipíny" },
+        "PK": { "zoneName": "Pákistán" },
+        "PL": { "zoneName": "Polsko" },
+        "PM": { "zoneName": "Saint Pierre a Miquelon" },
+        "PN": { "zoneName": "Pitcairnovy ostrovy" },
+        "PR": { "zoneName": "Portoriko" },
+        "PS": { "zoneName": "Palestinská autonomie" },
+        "PT": { "zoneName": "Portugalsko" },
+        "PT-AC": { "countryName": "Portugalsko", "zoneName": "Azory" },
+        "PT-MA": { "countryName": "Portugalsko", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Katar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Rumunsko" },
+        "RS": { "zoneName": "Srbsko" },
+        "RU": { "zoneName": "Rusko" },
+        "RU-1": { "countryName": "Rusko", "zoneName": "Evropské Rusko a Ural" },
+        "RU-2": { "countryName": "Rusko", "zoneName": "Sibiř" },
+        "RU-EU": { "zoneName": "Rusko" },
+        "RU-AS": { "zoneName": "Rusko" },
+        "RU-KGD": { "countryName": "Rusko", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Saudská Arábie" },
+        "SB": { "zoneName": "Šalamounovy ostrovy" },
+        "SC": { "zoneName": "Seychely" },
+        "SD": { "zoneName": "Súdán" },
+        "SE": { "zoneName": "Švédsko" },
+        "SG": { "zoneName": "Singapur" },
+        "SH": { "zoneName": "Svatá Helena, Ascension a Tristan da Cunha" },
+        "SI": { "zoneName": "Slovinsko" },
+        "SJ": { "zoneName": "Špicberky a Jan Mayen" },
+        "SK": { "zoneName": "Slovensko" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somálsko" },
+        "SR": { "zoneName": "Surinam" },
+        "SS": { "zoneName": "Jižní Súdán" },
+        "ST": { "zoneName": "Svatý Tomáš a Princův ostrov " },
+        "SV": { "zoneName": "Salvador" },
+        "SX": { "countryName": "Svatý Martin", "zoneName": "nizozemská část" },
+        "SY": { "zoneName": "Sýrie" },
+        "SZ": { "zoneName": "Svazijsko" },
+        "TC": { "zoneName": "Turks a Caicos" },
+        "TD": { "zoneName": "Čad" },
+        "TF": { "zoneName": "Francouzská jižní a antarktická území" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thajsko" },
+        "TJ": { "zoneName": "Tadžikistán" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Východní Timor" },
+        "TM": { "zoneName": "Turkmenistán" },
+        "TN": { "zoneName": "Tunisko" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turecko" },
+        "TT": { "zoneName": "Trinidad a Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Tchaj-wan" },
+        "TZ": { "zoneName": "Tanzanie" },
+        "UA": { "zoneName": "Ukrajina" },
+        "UA-CR": { "countryName": "Ukrajina", "zoneName": "Krym" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Menší odlehlé ostrovy USA " },
+        "US-HI": { "countryName": "Spojené státy americké", "zoneName": "Havaj" },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistán" },
+        "VA": { "zoneName": "Vatikán" },
+        "VC": { "zoneName": "Svatý Vincenc a Grenadiny" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Britské Panenské ostrovy", "zoneName": "Britské Panenské ostrovy" },
+        "VI": { "countryName": "Spojené státy americké", "zoneName": "Americké Panenské ostrovy" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis a Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Severokyperská turecká republika" },
+        "YE": { "zoneName": "Jemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Jihoafrická republika" },
+        "ZM": { "zoneName": "Zambie" },
+        "ZW": { "zoneName": "Zimbabwe" },
+        "AUS-TAS-KI": { "countryName": "Tasmánie", "zoneName": "King Island" }
     }
 }

--- a/web/public/locales/da.json
+++ b/web/public/locales/da.json
@@ -29,12 +29,12 @@
         "now": "Nu"
     },
     "country-history": {
-        "carbonintensity24h": "CO₂-intensitet i de sidste 24 timer",
-        "emissionsorigin24h": "CO₂-udledningens oprindelse i de sidste 24 timer",
-        "emissionsproduction24h": "CO₂ udledt i de sidste 24 timer",
-        "electricityorigin24h": "Elektricitetens oprindelse i de sidste 24 timer",
-        "electricityproduction24h": "Elproduktionen i de sidste 24 timer",
-        "electricityprices24h": "Elprisen i de sidste 24 timer"
+        "carbonintensity": { "hourly": "CO₂-intensitet i de sidste 24 timer" },
+        "emissionsorigin": { "hourly": "CO₂-udledningens oprindelse i de sidste 24 timer" },
+        "emissionsproduction": { "hourly": "CO₂ udledt i de sidste 24 timer" },
+        "electricityorigin": { "hourly": "Elektricitetens oprindelse i de sidste 24 timer" },
+        "electricityproduction": { "hourly": "Elproduktionen i de sidste 24 timer" },
+        "electricityprices": { "hourly": "Elprisen i de sidste 24 timer" }
     },
     "footer": {
         "foundbugs": "Har du fundet fejl eller har du ideer? Skriv",
@@ -78,11 +78,7 @@
         "newversion": "En ny version er tilgængelig! Tryk <a onClick=\"location.reload(true);\">her</a> for at opdatere.",
         "retrynow": "Prøv igen nu"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Regioner",
-        "about": "Om kortet"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Regioner", "about": "Om kortet" },
     "wind": "Vind",
     "solar": "Sol",
     "hydro": "Hydro",
@@ -105,171 +101,58 @@
     "emissionsImportedFrom": "<b>%1$s %%</b> af CO₂-udledninger i <img id=\"country-flag\"></img> <b>%2$s</b> importeres fra <img id=\"country-exchange-flag\"></img> <b>%3$s</b>",
     "ofCO2eqPerMinute": "af CO₂-ækvivalenter per minut",
     "zoneShortName": {
-        "AL": {
-            "zoneName": "Albanien"
-        },
-        "AT": {
-            "zoneName": "Østrig"
-        },
-        "AX": {
-            "zoneName": "Åland"
-        },
-        "BA": {
-            "zoneName": "Bosnien-Hercegovina"
-        },
-        "BE": {
-            "zoneName": "Belgien"
-        },
-        "BG": {
-            "zoneName": "Bulgarien"
-        },
-        "BY": {
-            "zoneName": "Belarus"
-        },
-        "CH": {
-            "zoneName": "Schweiz"
-        },
-        "CZ": {
-            "zoneName": "Tjekkiet"
-        },
-        "DE": {
-            "zoneName": "Tyskland"
-        },
-        "DK": {
-            "zoneName": "Danmark"
-        },
-        "DK-DK1": {
-            "countryName": "Danmark",
-            "zoneName": "Vestdanmark"
-        },
-        "DK-DK2": {
-            "countryName": "Danmark",
-            "zoneName": "Østdanmark"
-        },
-        "EE": {
-            "zoneName": "Estland"
-        },
-        "ES": {
-            "zoneName": "Spanien"
-        },
-        "FI": {
-            "zoneName": "Finland"
-        },
-        "FR": {
-            "zoneName": "Frankrig"
-        },
-        "GB": {
-            "zoneName": "Storbritannien"
-        },
-        "GB-NIR": {
-            "zoneName": "Nordirland"
-        },
-        "GR": {
-            "zoneName": "Grækenland"
-        },
-        "HR": {
-            "zoneName": "Kroatien"
-        },
-        "HU": {
-            "zoneName": "Ungarn"
-        },
-        "IE": {
-            "zoneName": "Irland"
-        },
-        "IS": {
-            "zoneName": "Island"
-        },
-        "IT": {
-            "zoneName": "Italien"
-        },
-        "LT": {
-            "zoneName": "Litauen"
-        },
-        "LU": {
-            "zoneName": "Luxemburg"
-        },
-        "LV": {
-            "zoneName": "Letland"
-        },
-        "MD": {
-            "zoneName": "Moldavien"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MK": {
-            "zoneName": "Nordmakedonien"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "NL": {
-            "zoneName": "Holland"
-        },
-        "NO": {
-            "zoneName": "Norge"
-        },
-        "NO-NO1": {
-            "countryName": "Norge",
-            "zoneName": "Sydøstnorge"
-        },
-        "NO-NO2": {
-            "countryName": "Norge",
-            "zoneName": "Sydvestnorge"
-        },
-        "NO-NO3": {
-            "countryName": "Norge",
-            "zoneName": "Midtnorge"
-        },
-        "NO-NO4": {
-            "countryName": "Norge",
-            "zoneName": "Nordnorge"
-        },
-        "NO-NO5": {
-            "countryName": "Norge",
-            "zoneName": "Vestnorge"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PL": {
-            "zoneName": "Polen"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "RO": {
-            "zoneName": "Rumænien"
-        },
-        "RS": {
-            "zoneName": "Serbien"
-        },
-        "RU": {
-            "zoneName": "Rusland"
-        },
-        "SE": {
-            "zoneName": "Sverige"
-        },
-        "SG": {
-            "zoneName": "Singapore"
-        },
-        "SI": {
-            "zoneName": "Slovenien"
-        },
-        "SK": {
-            "zoneName": "Slovakiet"
-        },
-        "TR": {
-            "zoneName": "Tyrkiet"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "UA": {
-            "zoneName": "Ukraine"
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        }
+        "AL": { "zoneName": "Albanien" },
+        "AT": { "zoneName": "Østrig" },
+        "AX": { "zoneName": "Åland" },
+        "BA": { "zoneName": "Bosnien-Hercegovina" },
+        "BE": { "zoneName": "Belgien" },
+        "BG": { "zoneName": "Bulgarien" },
+        "BY": { "zoneName": "Belarus" },
+        "CH": { "zoneName": "Schweiz" },
+        "CZ": { "zoneName": "Tjekkiet" },
+        "DE": { "zoneName": "Tyskland" },
+        "DK": { "zoneName": "Danmark" },
+        "DK-DK1": { "countryName": "Danmark", "zoneName": "Vestdanmark" },
+        "DK-DK2": { "countryName": "Danmark", "zoneName": "Østdanmark" },
+        "EE": { "zoneName": "Estland" },
+        "ES": { "zoneName": "Spanien" },
+        "FI": { "zoneName": "Finland" },
+        "FR": { "zoneName": "Frankrig" },
+        "GB": { "zoneName": "Storbritannien" },
+        "GB-NIR": { "zoneName": "Nordirland" },
+        "GR": { "zoneName": "Grækenland" },
+        "HR": { "zoneName": "Kroatien" },
+        "HU": { "zoneName": "Ungarn" },
+        "IE": { "zoneName": "Irland" },
+        "IS": { "zoneName": "Island" },
+        "IT": { "zoneName": "Italien" },
+        "LT": { "zoneName": "Litauen" },
+        "LU": { "zoneName": "Luxemburg" },
+        "LV": { "zoneName": "Letland" },
+        "MD": { "zoneName": "Moldavien" },
+        "ME": { "zoneName": "Montenegro" },
+        "MK": { "zoneName": "Nordmakedonien" },
+        "MT": { "zoneName": "Malta" },
+        "NL": { "zoneName": "Holland" },
+        "NO": { "zoneName": "Norge" },
+        "NO-NO1": { "countryName": "Norge", "zoneName": "Sydøstnorge" },
+        "NO-NO2": { "countryName": "Norge", "zoneName": "Sydvestnorge" },
+        "NO-NO3": { "countryName": "Norge", "zoneName": "Midtnorge" },
+        "NO-NO4": { "countryName": "Norge", "zoneName": "Nordnorge" },
+        "NO-NO5": { "countryName": "Norge", "zoneName": "Vestnorge" },
+        "PE": { "zoneName": "Peru" },
+        "PL": { "zoneName": "Polen" },
+        "PT": { "zoneName": "Portugal" },
+        "RO": { "zoneName": "Rumænien" },
+        "RS": { "zoneName": "Serbien" },
+        "RU": { "zoneName": "Rusland" },
+        "SE": { "zoneName": "Sverige" },
+        "SG": { "zoneName": "Singapore" },
+        "SI": { "zoneName": "Slovenien" },
+        "SK": { "zoneName": "Slovakiet" },
+        "TR": { "zoneName": "Tyrkiet" },
+        "TW": { "zoneName": "Taiwan" },
+        "UA": { "zoneName": "Ukraine" },
+        "UY": { "zoneName": "Uruguay" }
     }
 }

--- a/web/public/locales/de.json
+++ b/web/public/locales/de.json
@@ -6,15 +6,9 @@
         "datasources": "Datenquellen",
         "contribute": "Wirke mit, indem du <a href=\"%s\" target=\"_blank\">dein Land hinzufügst</a>"
     },
-    "mobile-main-menu": {
-        "map": "Karte",
-        "areas": "Regionen",
-        "about": "Über"
-    },
+    "mobile-main-menu": { "map": "Karte", "areas": "Regionen", "about": "Über" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Visualisierung der klimarelevanten Emissionen der Stromerzeugung"
-        },
+        "view1": { "subtitle": "Visualisierung der klimarelevanten Emissionen der Stromerzeugung" },
         "view2": {
             "header": "Betrachte in Echtzeit, wie viel CO₂-Äquivalente bei der Stromerzeugung freigesetzt werden.",
             "text": "Die Färbung der Zonen erfolgt anhand der spezifischen Emissionen klimawirksamer Gase (CO₂-Intensität), die zur Deckung des Strombedarfs einer Region freigesetzt werden. Eine grüne Färbung steht dabei für eine klimafreundlichere Erzeugung."
@@ -56,14 +50,14 @@
         "search": "Land oder Region suchen"
     },
     "country-history": {
-        "carbonintensity24h": "spezifische CO₂-Emissionen in den letzten 24 h",
-        "emissionsorigin24h": "Ursprung der Emissionen in den letzten 24 h",
-        "emissionsproduction24h": "Erzeugte Emissionen in den letzten 24 h",
-        "electricityorigin24h": "Ursprung der Elektrizität in den letzten 24 h",
-        "electricityproduction24h": "Erzeugte Elektrizität in den letzten 24 h",
-        "electricityprices24h": "Strompreis in den letzten 24 h",
         "Getdata": "Zugang zu historischen Daten und zur Vorhersage-API",
-        "emissions24h": "Emissionen in den letzten 24 Stunden"
+        "carbonintensity": { "hourly": "spezifische CO₂-Emissionen in den letzten 24 h" },
+        "emissionsorigin": { "hourly": "Ursprung der Emissionen in den letzten 24 h" },
+        "emissionsproduction": { "hourly": "Erzeugte Emissionen in den letzten 24 h" },
+        "electricityorigin": { "hourly": "Ursprung der Elektrizität in den letzten 24 h" },
+        "electricityproduction": { "hourly": "Erzeugte Elektrizität in den letzten 24 h" },
+        "electricityprices": { "hourly": "Strompreis in den letzten 24 h" },
+        "emissions": { "hourly": "Emissionen in den letzten 24 Stunden" }
     },
     "footer": {
         "foundbugs": "Hast du Bugs gefunden? Hast du Ideen zur Verbesserung der Karte?",
@@ -204,1384 +198,422 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> veröffentlicht Daten und Bilder auf der <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> zu Informationszwecken. Sie erhebt keinen Anspruch auf Richtigkeit und übernimmt keinerlei Gewährleistung und behält sich das Recht vor, den Inhalt jederzeit zu ändern oder Teile davon zu entfernen, ohne Sie darüber informieren zu müssen. electricityMap übernimmt keine Verantwortung und ist nicht haftbar für Schäden oder Ausgaben, die Ihnen durch Ungenauigkeit, Unvollständigkeit, Unpünktlichkeit oder Veralterung der electricityMap oder der daraus abgeleiteten Informationen entstehen. Es ist nicht erlaubt, diese Webseite oder einzelne ihrer Elemente ohne vorherige schriftliche Genehmigung in eine andere Webseite einzubinden. Die Vervielfältigung, Verbreitung und sonstige Nutzung dieser Materialien, insbesondere der Energiedaten, ist ohne die schriftliche Zustimmung von electricityMap nicht gestattet, soweit nicht zwingende gesetzliche Vorschriften (wie z.B. das Zitatrecht) etwas anderes vorsehen. Dieser Haftungsausschluss kann von Zeit zu Zeit aktualisiert werden."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Vereinigte Arabische Emirate"
-        },
-        "AF": {
-            "zoneName": "Afghanistan"
-        },
-        "AG": {
-            "zoneName": "Antigua und Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albanien"
-        },
-        "AM": {
-            "zoneName": "Armenien"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarktis"
-        },
-        "AS": {
-            "zoneName": "Amerikanisch-Samoa"
-        },
-        "AT": {
-            "zoneName": "Österreich"
-        },
-        "AR": {
-            "zoneName": "Argentinien"
-        },
-        "AUS-NSW": {
-            "countryName": "Australien",
-            "zoneName": "New South Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Australien",
-            "zoneName": "Northern Territory"
-        },
-        "AUS-QLD": {
-            "countryName": "Australien",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australien",
-            "zoneName": "South Australia"
-        },
-        "AUS-TAS": {
-            "countryName": "Australien",
-            "zoneName": "Tasmania"
-        },
-        "AUS-VIC": {
-            "countryName": "Australien",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australien",
-            "zoneName": "Western Australia"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Ålandinseln"
-        },
-        "AZ": {
-            "zoneName": "Aserbaidschan"
-        },
-        "BA": {
-            "zoneName": "Bosnien und Herzegowina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesch"
-        },
-        "BE": {
-            "zoneName": "Belgien"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgarien"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivien"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius und Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brasilien",
-            "zoneName": "Zentral-Brasilien"
-        },
-        "BR-N": {
-            "countryName": "Brasilien",
-            "zoneName": "Nord-Brasilien"
-        },
-        "BR-NE": {
-            "countryName": "Brasilien",
-            "zoneName": "Nordost-Brasilien"
-        },
-        "BR-S": {
-            "countryName": "Brasilien",
-            "zoneName": "Süd-Brasilien"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Bouvetinsel"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Belarus"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "British Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland and Labrador"
-        },
-        "CA-NL-LB": {
-            "countryName": "Kanada",
-            "zoneName": "Labrador"
-        },
-        "CA-NL-NF": {
-            "countryName": "Kanada",
-            "zoneName": "Neufundland"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Northwest Territories"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Prince Edward Island"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Kokosinseln"
-        },
-        "CD": {
-            "zoneName": "Demokratische Republik Kongo"
-        },
-        "CF": {
-            "zoneName": "Zentralafrikanische Republik"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Schweiz"
-        },
-        "CI": {
-            "zoneName": "Elfenbeinküste"
-        },
-        "CK": {
-            "zoneName": "Cook Inseln"
-        },
-        "CL-SING": {
-            "countryName": "Chile",
-            "zoneName": "SING"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "SEA"
-        },
-        "CL-CHP": {
-            "countryName": "Chile",
-            "zoneName": "Osterinsel"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Volksrepublik China"
-        },
-        "CO": {
-            "zoneName": "Kolumbien"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Kuba"
-        },
-        "CV": {
-            "zoneName": "Kap Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Weihnachtsinsel"
-        },
-        "CY": {
-            "zoneName": "Zypern"
-        },
-        "CZ": {
-            "zoneName": "Tschechien"
-        },
-        "DE": {
-            "zoneName": "Deutschland"
-        },
-        "DJ": {
-            "zoneName": "Dschibuti"
-        },
-        "DK": {
-            "zoneName": "Dänemark"
-        },
-        "DK-DK1": {
-            "countryName": "Dänemark",
-            "zoneName": "West-Dänemark"
-        },
-        "DK-DK2": {
-            "countryName": "Dänemark",
-            "zoneName": "Ost-Dänemark"
-        },
-        "DK-BHM": {
-            "countryName": "Dänemark",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "Dominikanische Republik"
-        },
-        "DZ": {
-            "zoneName": "Algerien"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Estland"
-        },
-        "EG": {
-            "zoneName": "Ägypten"
-        },
-        "EH": {
-            "zoneName": "Westsahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Spanien"
-        },
-        "ES-IB": {
-            "countryName": "Spanien",
-            "zoneName": "Balearen"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Spanien",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Spanien",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Spanien",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Spanien",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Spanien",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Spanien",
-            "zoneName": "Teneriffa"
-        },
-        "ET": {
-            "zoneName": "Äthiopien"
-        },
-        "FI": {
-            "zoneName": "Finnland"
-        },
-        "FJ": {
-            "zoneName": "Fidschi"
-        },
-        "FK": {
-            "zoneName": "Falklandinseln"
-        },
-        "FM": {
-            "zoneName": "Mikronesien"
-        },
-        "FO": {
-            "zoneName": "Faröer Inseln"
-        },
-        "FR": {
-            "zoneName": "Frankreich"
-        },
-        "FR-COR": {
-            "countryName": "Frankreich",
-            "zoneName": "Korsika"
-        },
-        "GA": {
-            "zoneName": "Gabun"
-        },
-        "GB": {
-            "countryName": "Vereinigtes Königreich",
-            "zoneName": "Großbritannien"
-        },
-        "GB-NIR": {
-            "countryName": "Vereinigtes Königreich",
-            "zoneName": "Nordirland"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgien"
-        },
-        "GF": {
-            "zoneName": "Französich Guayana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Grönland"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Äquatorialguinea"
-        },
-        "GR": {
-            "zoneName": "Griechenland"
-        },
-        "GR-IS": {
-            "countryName": "Griechenland",
-            "zoneName": "Ägäische Inseln"
-        },
-        "GS": {
-            "zoneName": "Südgeorgien und die südlichen Sandwichinseln"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Heard und McDonaldinseln"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Kroatien"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Ungarn"
-        },
-        "ID": {
-            "zoneName": "Indonesien"
-        },
-        "IE": {
-            "zoneName": "Irland"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Isle of Man"
-        },
-        "IN-AN": {
-            "countryName": "Indien",
-            "zoneName": "Andamanen und Nicobaren"
-        },
-        "IN-AP": {
-            "countryName": "Indien",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Indien",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Indien",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "Indien",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Indien",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Indien",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "Indien",
-            "zoneName": "Dadra und Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "Indien",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Indien",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "Indien",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Indien",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "Indien",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Indien",
-            "zoneName": "Jammu und Kaschmir"
-        },
-        "IN-KA": {
-            "countryName": "Indien",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Indien",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Indien",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "Indien",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Indien",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Indien",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Indien",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Indien",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Indien",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "Indien",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "Indien",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "Indien",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "Indien",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "Indien",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "Indien",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Indien",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Indien",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Indien",
-            "zoneName": "West Bengal"
-        },
-        "IO": {
-            "zoneName": "Britisches Territorium im Indischen Ozean"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Island"
-        },
-        "IT": {
-            "zoneName": "Italien"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaika"
-        },
-        "JO": {
-            "zoneName": "Jordanien"
-        },
-        "JP": {
-            "zoneName": "Japan"
-        },
-        "KE": {
-            "zoneName": "Kenia"
-        },
-        "KG": {
-            "zoneName": "Kirgistan"
-        },
-        "KH": {
-            "zoneName": "Kambodscha"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Komoren"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts und Nevis"
-        },
-        "KP": {
-            "zoneName": "Nordkorea"
-        },
-        "KR": {
-            "zoneName": "Südkorea"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Kaiman Inseln"
-        },
-        "KZ": {
-            "zoneName": "Kasachstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Libanon"
-        },
-        "LC": {
-            "zoneName": "St. Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Litauen"
-        },
-        "LU": {
-            "zoneName": "Luxemburg"
-        },
-        "LV": {
-            "zoneName": "Lettland"
-        },
-        "LY": {
-            "zoneName": "Libyen"
-        },
-        "MA": {
-            "zoneName": "Marokko"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldawien"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Saint-Martin",
-            "zoneName": "Französ. Teil"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Marshallinseln"
-        },
-        "MK": {
-            "zoneName": "Nordmazedonien"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Mongolei"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Nördliche Marianen"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritanien"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Malediven"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mexiko"
-        },
-        "MY-EM": {
-            "countryName": "Malaysia",
-            "zoneName": "Sabah und Sarawak"
-        },
-        "MY-WM": {
-            "countryName": "Malaysia",
-            "zoneName": "Halbinsel"
-        },
-        "MZ": {
-            "zoneName": "Mosambik"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "Neukaledonien"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolkinsel"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Bergkarabach"
-        },
-        "NL": {
-            "zoneName": "Niederlande"
-        },
-        "NO": {
-            "zoneName": "Norwegen"
-        },
-        "NO-NO1": {
-            "countryName": "Norwegen",
-            "zoneName": "Südost-Norwegen"
-        },
-        "NO-NO2": {
-            "countryName": "Norwegen",
-            "zoneName": "Südwest-Norwegen"
-        },
-        "NO-NO3": {
-            "countryName": "Norwegen",
-            "zoneName": "Zentral-Norwegen"
-        },
-        "NO-NO4": {
-            "countryName": "Norwegen",
-            "zoneName": "Nord-Norwegen"
-        },
-        "NO-NO5": {
-            "countryName": "Norwegen",
-            "zoneName": "West-Norwegen"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Neuseeland"
-        },
-        "NZ-NZA": {
-            "countryName": "Neuseeland",
-            "zoneName": "Aucklandinseln"
-        },
-        "NZ-NZC": {
-            "countryName": "Neuseeland",
-            "zoneName": "Chathaminseln"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Französisch Polynesien"
-        },
-        "PG": {
-            "zoneName": "Papua-Neuguinea"
-        },
-        "PH": {
-            "zoneName": "Philippinen"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Polen"
-        },
-        "PM": {
-            "zoneName": "Saint-Pierre und Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairninseln"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Palästina"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Azoren"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Katar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Rumänien"
-        },
-        "RS": {
-            "zoneName": "Serbien"
-        },
-        "RU": {
-            "zoneName": "Russland"
-        },
-        "RU-EU": {
-            "zoneName": "Russland",
-            "countryName": "Arktis"
-        },
-        "RU-AS": {
-            "zoneName": "Russland",
-            "countryName": "Osten"
-        },
-        "RU-1": {
-            "countryName": "Russland",
-            "zoneName": "Europäischer Teil und Ural-Region"
-        },
-        "RU-2": {
-            "countryName": "Russland",
-            "zoneName": "Sibirien"
-        },
-        "RU-KGD": {
-            "countryName": "Russland",
-            "zoneName": "Kaliningrad"
-        },
-        "RU-FE": {
-            "countryName": "Russland",
-            "zoneName": "Fernost"
-        },
-        "RW": {
-            "zoneName": "Ruanda"
-        },
-        "SA": {
-            "zoneName": "Saudi Arabien"
-        },
-        "SB": {
-            "zoneName": "Salomonen"
-        },
-        "SC": {
-            "zoneName": "Seychellen"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Schweden"
-        },
-        "SG": {
-            "zoneName": "Singapur"
-        },
-        "SH": {
-            "zoneName": "St. Helena, Ascension und Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slowenien"
-        },
-        "SJ": {
-            "zoneName": "Svalbard und Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slowakei"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Südsudan"
-        },
-        "ST": {
-            "zoneName": "Sao Tome und Principe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "niederländ. Teil"
-        },
-        "SY": {
-            "zoneName": "Syrien"
-        },
-        "SZ": {
-            "zoneName": "Swasiland"
-        },
-        "TC": {
-            "zoneName": "Turks- und Caicosinseln"
-        },
-        "TD": {
-            "zoneName": "Tschad"
-        },
-        "TF": {
-            "zoneName": "Französische Süd- und Antarktisgebiete"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thailand"
-        },
-        "TJ": {
-            "zoneName": "Tadschikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunesien"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Türkei"
-        },
-        "TT": {
-            "zoneName": "Trinidad und Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tansania"
-        },
-        "UA": {
-            "zoneName": "Ukraine"
-        },
-        "UA-CR": {
-            "countryName": "Ukraine",
-            "zoneName": "Krim"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "United States Minor Outlying Islands"
-        },
-        "US-HI": {
-            "zoneName": "Hawaii",
-            "countryName": "Vereinigte Staaten"
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Usbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatikanstadt"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent und die Grenadinen"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Jungferninseln",
-            "zoneName": "Britische Jungferninseln"
-        },
-        "VI": {
-            "countryName": "USA",
-            "zoneName": "Jungferninseln"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis und Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Nordzypern"
-        },
-        "YE": {
-            "zoneName": "Jemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Südafrika"
-        },
-        "ZM": {
-            "zoneName": "Sambia"
-        },
-        "ZW": {
-            "zoneName": "Simbabwe"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistan"
-        },
-        "JP-CB": {
-            "countryName": "Japan",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japan",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japan",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Japan",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japan",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japan",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Japan",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japan",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japan",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japan",
-            "zoneName": "Tōkyō"
-        },
-        "MX-BC": {
-            "countryName": "Mexiko",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mexiko",
-            "zoneName": "Zentral-Mexiko"
-        },
-        "MX-NE": {
-            "countryName": "Mexiko",
-            "zoneName": "Nordost-Mexiko"
-        },
-        "MX-NO": {
-            "countryName": "Mexiko",
-            "zoneName": "Nord-Mexiko"
-        },
-        "MX-NW": {
-            "countryName": "Mexiko",
-            "zoneName": "Nordwest-Mexiko"
-        },
-        "MX-OC": {
-            "countryName": "Mexiko",
-            "zoneName": "West-Mexiko"
-        },
-        "MX-OR": {
-            "countryName": "Mexiko",
-            "zoneName": "Ost-Mexiko"
-        },
-        "MX-PN": {
-            "countryName": "Mexiko",
-            "zoneName": "Halbinsel"
-        },
-        "GB-ORK": {
-            "countryName": "Großbritannien",
-            "zoneName": "Orkney Islands"
-        },
-        "GB-SHI": {
-            "countryName": "Großbritannien",
-            "zoneName": "Shetland Islands"
-        },
-        "GB-ZET": {
-            "countryName": "Großbritannien",
-            "zoneName": "Shetland Islands"
-        },
-        "IT-CNO": {
-            "countryName": "Italien",
-            "zoneName": "Zentral-Nord-Italien"
-        },
-        "IT-CSO": {
-            "countryName": "Italien",
-            "zoneName": "Zentral-Süd-Italien"
-        },
-        "IT-NO": {
-            "countryName": "Italien",
-            "zoneName": "Nord-Italien"
-        },
-        "IT-SAR": {
-            "countryName": "Italien",
-            "zoneName": "Sardinien"
-        },
-        "IT-SIC": {
-            "countryName": "Italien",
-            "zoneName": "Sizilien"
-        },
-        "IT-SO": {
-            "countryName": "Italien",
-            "zoneName": "Süd-Italien"
-        },
-        "ES-IB-FO": {
-            "countryName": "Spanien",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Spanien",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Spanien",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Spanien",
-            "zoneName": "Menorca"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmanien",
-            "zoneName": "King Island"
-        },
-        "CL-SING-SIC": {
-            "countryName": "Chile",
-            "zoneName": "SING/SIC"
-        },
-        "US-HI-HA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Oahu"
-        },
-        "US-CAL-BANC": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Ausgleichsbehörde von Nordkalifornien"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Vereinigte Arabische Emirate" },
+        "AF": { "zoneName": "Afghanistan" },
+        "AG": { "zoneName": "Antigua und Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albanien" },
+        "AM": { "zoneName": "Armenien" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarktis" },
+        "AS": { "zoneName": "Amerikanisch-Samoa" },
+        "AT": { "zoneName": "Österreich" },
+        "AR": { "zoneName": "Argentinien" },
+        "AUS-NSW": { "countryName": "Australien", "zoneName": "New South Wales" },
+        "AUS-NT": { "countryName": "Australien", "zoneName": "Northern Territory" },
+        "AUS-QLD": { "countryName": "Australien", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australien", "zoneName": "South Australia" },
+        "AUS-TAS": { "countryName": "Australien", "zoneName": "Tasmania" },
+        "AUS-VIC": { "countryName": "Australien", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australien", "zoneName": "Western Australia" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Ålandinseln" },
+        "AZ": { "zoneName": "Aserbaidschan" },
+        "BA": { "zoneName": "Bosnien und Herzegowina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesch" },
+        "BE": { "zoneName": "Belgien" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgarien" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivien" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius und Saba" },
+        "BR-CS": { "countryName": "Brasilien", "zoneName": "Zentral-Brasilien" },
+        "BR-N": { "countryName": "Brasilien", "zoneName": "Nord-Brasilien" },
+        "BR-NE": { "countryName": "Brasilien", "zoneName": "Nordost-Brasilien" },
+        "BR-S": { "countryName": "Brasilien", "zoneName": "Süd-Brasilien" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Bouvetinsel" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Belarus" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "British Columbia" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland and Labrador" },
+        "CA-NL-LB": { "countryName": "Kanada", "zoneName": "Labrador" },
+        "CA-NL-NF": { "countryName": "Kanada", "zoneName": "Neufundland" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "New Brunswick" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Northwest Territories" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nova Scotia" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Prince Edward Island" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Kokosinseln" },
+        "CD": { "zoneName": "Demokratische Republik Kongo" },
+        "CF": { "zoneName": "Zentralafrikanische Republik" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Schweiz" },
+        "CI": { "zoneName": "Elfenbeinküste" },
+        "CK": { "zoneName": "Cook Inseln" },
+        "CL-SING": { "countryName": "Chile", "zoneName": "SING" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "SEA" },
+        "CL-CHP": { "countryName": "Chile", "zoneName": "Osterinsel" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Volksrepublik China" },
+        "CO": { "zoneName": "Kolumbien" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Kuba" },
+        "CV": { "zoneName": "Kap Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Weihnachtsinsel" },
+        "CY": { "zoneName": "Zypern" },
+        "CZ": { "zoneName": "Tschechien" },
+        "DE": { "zoneName": "Deutschland" },
+        "DJ": { "zoneName": "Dschibuti" },
+        "DK": { "zoneName": "Dänemark" },
+        "DK-DK1": { "countryName": "Dänemark", "zoneName": "West-Dänemark" },
+        "DK-DK2": { "countryName": "Dänemark", "zoneName": "Ost-Dänemark" },
+        "DK-BHM": { "countryName": "Dänemark", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "Dominikanische Republik" },
+        "DZ": { "zoneName": "Algerien" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Estland" },
+        "EG": { "zoneName": "Ägypten" },
+        "EH": { "zoneName": "Westsahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Spanien" },
+        "ES-IB": { "countryName": "Spanien", "zoneName": "Balearen" },
+        "ES-CN-FVLZ": { "countryName": "Spanien", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Spanien", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Spanien", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Spanien", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "Spanien", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Spanien", "zoneName": "Teneriffa" },
+        "ET": { "zoneName": "Äthiopien" },
+        "FI": { "zoneName": "Finnland" },
+        "FJ": { "zoneName": "Fidschi" },
+        "FK": { "zoneName": "Falklandinseln" },
+        "FM": { "zoneName": "Mikronesien" },
+        "FO": { "zoneName": "Faröer Inseln" },
+        "FR": { "zoneName": "Frankreich" },
+        "FR-COR": { "countryName": "Frankreich", "zoneName": "Korsika" },
+        "GA": { "zoneName": "Gabun" },
+        "GB": { "countryName": "Vereinigtes Königreich", "zoneName": "Großbritannien" },
+        "GB-NIR": { "countryName": "Vereinigtes Königreich", "zoneName": "Nordirland" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgien" },
+        "GF": { "zoneName": "Französich Guayana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Grönland" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Äquatorialguinea" },
+        "GR": { "zoneName": "Griechenland" },
+        "GR-IS": { "countryName": "Griechenland", "zoneName": "Ägäische Inseln" },
+        "GS": { "zoneName": "Südgeorgien und die südlichen Sandwichinseln" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Heard und McDonaldinseln" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Kroatien" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Ungarn" },
+        "ID": { "zoneName": "Indonesien" },
+        "IE": { "zoneName": "Irland" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Isle of Man" },
+        "IN-AN": { "countryName": "Indien", "zoneName": "Andamanen und Nicobaren" },
+        "IN-AP": { "countryName": "Indien", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Indien", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Indien", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "Indien", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Indien", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Indien", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "Indien", "zoneName": "Dadra und Nagar Haveli" },
+        "IN-GA": { "countryName": "Indien", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Indien", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "Indien", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Indien", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "Indien", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Indien", "zoneName": "Jammu und Kaschmir" },
+        "IN-KA": { "countryName": "Indien", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Indien", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Indien", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "Indien", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Indien", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Indien", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Indien", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Indien", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Indien", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "Indien", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "Indien", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "Indien", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "Indien", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "Indien", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "Indien", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Indien", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Indien", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Indien", "zoneName": "West Bengal" },
+        "IO": { "zoneName": "Britisches Territorium im Indischen Ozean" },
+        "IQ": { "zoneName": "Irak" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Island" },
+        "IT": { "zoneName": "Italien" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaika" },
+        "JO": { "zoneName": "Jordanien" },
+        "JP": { "zoneName": "Japan" },
+        "KE": { "zoneName": "Kenia" },
+        "KG": { "zoneName": "Kirgistan" },
+        "KH": { "zoneName": "Kambodscha" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Komoren" },
+        "KN": { "zoneName": "Saint Kitts und Nevis" },
+        "KP": { "zoneName": "Nordkorea" },
+        "KR": { "zoneName": "Südkorea" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Kaiman Inseln" },
+        "KZ": { "zoneName": "Kasachstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Libanon" },
+        "LC": { "zoneName": "St. Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Litauen" },
+        "LU": { "zoneName": "Luxemburg" },
+        "LV": { "zoneName": "Lettland" },
+        "LY": { "zoneName": "Libyen" },
+        "MA": { "zoneName": "Marokko" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldawien" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Saint-Martin", "zoneName": "Französ. Teil" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Marshallinseln" },
+        "MK": { "zoneName": "Nordmazedonien" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Mongolei" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Nördliche Marianen" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritanien" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Malediven" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mexiko" },
+        "MY-EM": { "countryName": "Malaysia", "zoneName": "Sabah und Sarawak" },
+        "MY-WM": { "countryName": "Malaysia", "zoneName": "Halbinsel" },
+        "MZ": { "zoneName": "Mosambik" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "Neukaledonien" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolkinsel" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Bergkarabach" },
+        "NL": { "zoneName": "Niederlande" },
+        "NO": { "zoneName": "Norwegen" },
+        "NO-NO1": { "countryName": "Norwegen", "zoneName": "Südost-Norwegen" },
+        "NO-NO2": { "countryName": "Norwegen", "zoneName": "Südwest-Norwegen" },
+        "NO-NO3": { "countryName": "Norwegen", "zoneName": "Zentral-Norwegen" },
+        "NO-NO4": { "countryName": "Norwegen", "zoneName": "Nord-Norwegen" },
+        "NO-NO5": { "countryName": "Norwegen", "zoneName": "West-Norwegen" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Neuseeland" },
+        "NZ-NZA": { "countryName": "Neuseeland", "zoneName": "Aucklandinseln" },
+        "NZ-NZC": { "countryName": "Neuseeland", "zoneName": "Chathaminseln" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Französisch Polynesien" },
+        "PG": { "zoneName": "Papua-Neuguinea" },
+        "PH": { "zoneName": "Philippinen" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Polen" },
+        "PM": { "zoneName": "Saint-Pierre und Miquelon" },
+        "PN": { "zoneName": "Pitcairninseln" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Palästina" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Azoren" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Katar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Rumänien" },
+        "RS": { "zoneName": "Serbien" },
+        "RU": { "zoneName": "Russland" },
+        "RU-EU": { "zoneName": "Russland", "countryName": "Arktis" },
+        "RU-AS": { "zoneName": "Russland", "countryName": "Osten" },
+        "RU-1": { "countryName": "Russland", "zoneName": "Europäischer Teil und Ural-Region" },
+        "RU-2": { "countryName": "Russland", "zoneName": "Sibirien" },
+        "RU-KGD": { "countryName": "Russland", "zoneName": "Kaliningrad" },
+        "RU-FE": { "countryName": "Russland", "zoneName": "Fernost" },
+        "RW": { "zoneName": "Ruanda" },
+        "SA": { "zoneName": "Saudi Arabien" },
+        "SB": { "zoneName": "Salomonen" },
+        "SC": { "zoneName": "Seychellen" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Schweden" },
+        "SG": { "zoneName": "Singapur" },
+        "SH": { "zoneName": "St. Helena, Ascension und Tristan da Cunha" },
+        "SI": { "zoneName": "Slowenien" },
+        "SJ": { "zoneName": "Svalbard und Jan Mayen" },
+        "SK": { "zoneName": "Slowakei" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Südsudan" },
+        "ST": { "zoneName": "Sao Tome und Principe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "niederländ. Teil" },
+        "SY": { "zoneName": "Syrien" },
+        "SZ": { "zoneName": "Swasiland" },
+        "TC": { "zoneName": "Turks- und Caicosinseln" },
+        "TD": { "zoneName": "Tschad" },
+        "TF": { "zoneName": "Französische Süd- und Antarktisgebiete" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thailand" },
+        "TJ": { "zoneName": "Tadschikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunesien" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Türkei" },
+        "TT": { "zoneName": "Trinidad und Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tansania" },
+        "UA": { "zoneName": "Ukraine" },
+        "UA-CR": { "countryName": "Ukraine", "zoneName": "Krim" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "United States Minor Outlying Islands" },
+        "US-HI": { "zoneName": "Hawaii", "countryName": "Vereinigte Staaten" },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Usbekistan" },
+        "VA": { "zoneName": "Vatikanstadt" },
+        "VC": { "zoneName": "Saint Vincent und die Grenadinen" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Jungferninseln", "zoneName": "Britische Jungferninseln" },
+        "VI": { "countryName": "USA", "zoneName": "Jungferninseln" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis und Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Nordzypern" },
+        "YE": { "zoneName": "Jemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Südafrika" },
+        "ZM": { "zoneName": "Sambia" },
+        "ZW": { "zoneName": "Simbabwe" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
+        "JP-CB": { "countryName": "Japan", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Japan", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Japan", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Japan", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japan", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japan", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Japan", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japan", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japan", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Japan", "zoneName": "Tōkyō" },
+        "MX-BC": { "countryName": "Mexiko", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mexiko", "zoneName": "Zentral-Mexiko" },
+        "MX-NE": { "countryName": "Mexiko", "zoneName": "Nordost-Mexiko" },
+        "MX-NO": { "countryName": "Mexiko", "zoneName": "Nord-Mexiko" },
+        "MX-NW": { "countryName": "Mexiko", "zoneName": "Nordwest-Mexiko" },
+        "MX-OC": { "countryName": "Mexiko", "zoneName": "West-Mexiko" },
+        "MX-OR": { "countryName": "Mexiko", "zoneName": "Ost-Mexiko" },
+        "MX-PN": { "countryName": "Mexiko", "zoneName": "Halbinsel" },
+        "GB-ORK": { "countryName": "Großbritannien", "zoneName": "Orkney Islands" },
+        "GB-SHI": { "countryName": "Großbritannien", "zoneName": "Shetland Islands" },
+        "GB-ZET": { "countryName": "Großbritannien", "zoneName": "Shetland Islands" },
+        "IT-CNO": { "countryName": "Italien", "zoneName": "Zentral-Nord-Italien" },
+        "IT-CSO": { "countryName": "Italien", "zoneName": "Zentral-Süd-Italien" },
+        "IT-NO": { "countryName": "Italien", "zoneName": "Nord-Italien" },
+        "IT-SAR": { "countryName": "Italien", "zoneName": "Sardinien" },
+        "IT-SIC": { "countryName": "Italien", "zoneName": "Sizilien" },
+        "IT-SO": { "countryName": "Italien", "zoneName": "Süd-Italien" },
+        "ES-IB-FO": { "countryName": "Spanien", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Spanien", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Spanien", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Spanien", "zoneName": "Menorca" },
+        "AUS-TAS-KI": { "countryName": "Tasmanien", "zoneName": "King Island" },
+        "CL-SING-SIC": { "countryName": "Chile", "zoneName": "SING/SIC" },
+        "US-HI-HA": { "countryName": "Vereinigte Staaten", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "Vereinigte Staaten", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Vereinigte Staaten", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Vereinigte Staaten", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Vereinigte Staaten", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Vereinigte Staaten", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Vereinigte Staaten", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Vereinigte Staaten", "zoneName": "Oahu" },
+        "US-CAL-BANC": { "countryName": "Vereinigte Staaten", "zoneName": "Ausgleichsbehörde von Nordkalifornien" },
         "US-CAL-CISO": {
             "countryName": "Vereinigte Staaten",
             "zoneName": "Unabhängiger Systembetreiber in Kalifornien"
         },
-        "US-CAL-IID": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Kaiserlicher Bewässerungsbezirk"
-        },
+        "US-CAL-IID": { "countryName": "Vereinigte Staaten", "zoneName": "Kaiserlicher Bewässerungsbezirk" },
         "US-CAL-LDWP": {
             "countryName": "Vereinigte Staaten",
             "zoneName": "Los Angeles Abteilung für Wasser und Energie"
         },
-        "US-CAL-TIDC": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Turlock Bewässerungsbezirk"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Duke Energy Progress Westen"
-        },
-        "US-CAR-DUK": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Duke Energy Carolinas"
-        },
+        "US-CAL-TIDC": { "countryName": "Vereinigte Staaten", "zoneName": "Turlock Bewässerungsbezirk" },
+        "US-CAR-CPLE": { "countryName": "Vereinigte Staaten", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "Vereinigte Staaten", "zoneName": "Duke Energy Progress Westen" },
+        "US-CAR-DUK": { "countryName": "Vereinigte Staaten", "zoneName": "Duke Energy Carolinas" },
         "US-CAR-SC": {
             "countryName": "Vereinigte Staaten",
             "zoneName": "South Carolina Behörde für den öffentlichen Dienst"
         },
-        "US-CAR-SCEG": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "South Carolina Electrik & Gas Firmen"
-        },
+        "US-CAR-SCEG": { "countryName": "Vereinigte Staaten", "zoneName": "South Carolina Electrik & Gas Firmen" },
         "US-CAR-YAD": {
             "countryName": "Vereinigte Staaten",
             "zoneName": "Yadkin Division von Alcoa Power Generating, Inc."
         },
-        "US-CENT-SPA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Südwestliche Machtverteilung"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Südwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Florida kommunaler Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Florida Energie & Licht Firma"
-        },
-        "US-FLA-GVL": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Stadt von Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "JEA"
-        },
-        "US-FLA-NSB": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Versorgungskommission von New Smyrna Beach"
-        },
-        "US-FLA-SEC": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Elektrische Genossenschaft Seminole"
-        },
-        "US-FLA-TAL": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Stadt von Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "PJM Interconnection, Llc"
-        },
-        "US-MIDW-AECI": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Associated Electric Cooperative, Inc."
-        },
+        "US-CENT-SPA": { "countryName": "Vereinigte Staaten", "zoneName": "Südwestliche Machtverteilung" },
+        "US-CENT-SWPP": { "countryName": "Vereinigte Staaten", "zoneName": "Südwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "Vereinigte Staaten", "zoneName": "Florida kommunaler Power Pool" },
+        "US-FLA-FPC": { "countryName": "Vereinigte Staaten", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "Vereinigte Staaten", "zoneName": "Florida Energie & Licht Firma" },
+        "US-FLA-GVL": { "countryName": "Vereinigte Staaten", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "Vereinigte Staaten", "zoneName": "Stadt von Homestead" },
+        "US-FLA-JEA": { "countryName": "Vereinigte Staaten", "zoneName": "JEA" },
+        "US-FLA-NSB": { "countryName": "Vereinigte Staaten", "zoneName": "Versorgungskommission von New Smyrna Beach" },
+        "US-FLA-SEC": { "countryName": "Vereinigte Staaten", "zoneName": "Elektrische Genossenschaft Seminole" },
+        "US-FLA-TAL": { "countryName": "Vereinigte Staaten", "zoneName": "Stadt von Tallahassee" },
+        "US-FLA-TEC": { "countryName": "Vereinigte Staaten", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "Vereinigte Staaten", "zoneName": "PJM Interconnection, Llc" },
+        "US-MIDW-AECI": { "countryName": "Vereinigte Staaten", "zoneName": "Associated Electric Cooperative, Inc." },
         "US-MIDW-LGEE": {
             "countryName": "Vereinigte Staaten",
             "zoneName": "Louisville Gas & Electric Company und Kentucky Utilities"
@@ -1590,78 +622,24 @@
             "countryName": "Vereinigte Staaten",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc."
         },
-        "US-NE-ISNE": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Iso New England, Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "PUD Nr.1 von Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "PUD Nr.1 von Douglas County"
-        },
-        "US-NW-GCPD": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "PUD Nr.2 von Grant County, Washington"
-        },
-        "US-NW-GRID": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Gridforce Energie Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Idaho Energie Firma"
-        },
-        "US-NW-NEVP": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Nevada Energie Firma"
-        },
-        "US-NW-NWMT": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Nordwest Energie"
-        },
-        "US-NW-PACE": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "PacifiCorp Osten"
-        },
-        "US-NW-PACW": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "PacifiCorp Westen"
-        },
-        "US-NW-PGE": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Portland Allgemeine Elektrik Firma"
-        },
-        "US-NW-PSCO": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Öffentliche Servicefirma von Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Puget Sound Energie"
-        },
-        "US-NW-SCL": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Seattle Stadtlicht"
-        },
+        "US-NE-ISNE": { "countryName": "Vereinigte Staaten", "zoneName": "Iso New England, Inc." },
+        "US-NW-AVA": { "countryName": "Vereinigte Staaten", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "Vereinigte Staaten", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "Vereinigte Staaten", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "Vereinigte Staaten", "zoneName": "PUD Nr.1 von Chelan County" },
+        "US-NW-DOPD": { "countryName": "Vereinigte Staaten", "zoneName": "PUD Nr.1 von Douglas County" },
+        "US-NW-GCPD": { "countryName": "Vereinigte Staaten", "zoneName": "PUD Nr.2 von Grant County, Washington" },
+        "US-NW-GRID": { "countryName": "Vereinigte Staaten", "zoneName": "Gridforce Energie Management, Llc" },
+        "US-NW-GWA": { "countryName": "Vereinigte Staaten", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "Vereinigte Staaten", "zoneName": "Idaho Energie Firma" },
+        "US-NW-NEVP": { "countryName": "Vereinigte Staaten", "zoneName": "Nevada Energie Firma" },
+        "US-NW-NWMT": { "countryName": "Vereinigte Staaten", "zoneName": "Nordwest Energie" },
+        "US-NW-PACE": { "countryName": "Vereinigte Staaten", "zoneName": "PacifiCorp Osten" },
+        "US-NW-PACW": { "countryName": "Vereinigte Staaten", "zoneName": "PacifiCorp Westen" },
+        "US-NW-PGE": { "countryName": "Vereinigte Staaten", "zoneName": "Portland Allgemeine Elektrik Firma" },
+        "US-NW-PSCO": { "countryName": "Vereinigte Staaten", "zoneName": "Öffentliche Servicefirma von Colorado" },
+        "US-NW-PSEI": { "countryName": "Vereinigte Staaten", "zoneName": "Puget Sound Energie" },
+        "US-NW-SCL": { "countryName": "Vereinigte Staaten", "zoneName": "Seattle Stadtlicht" },
         "US-NW-TPWR": {
             "countryName": "Vereinigte Staaten",
             "zoneName": "Stadt Tacoma, Abteilung für öffentliche Versorgungsunternehmen, Abteilung Licht"
@@ -1670,109 +648,38 @@
             "countryName": "Vereinigte Staaten",
             "zoneName": "Westliche Energieverwaltung - Rocky Mountain Region"
         },
-        "US-NW-WAUW": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Westliche Energieverwaltung UGP Westen"
-        },
-        "US-NW-WWA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "New York unabhängiger Systembetreiber"
-        },
-        "US-SE-AEC": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Südöstliche Energieverwaltung"
-        },
-        "US-SE-SOCO": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Südliche Firmen Services, Inc. - Trans"
-        },
-        "US-SW-AZPS": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Arizona Firma für öffentlichen Dienst"
-        },
-        "US-SW-DEAA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "El Paso Elektrik Firma"
-        },
-        "US-SW-GRIF": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Griffith Energie, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Gila Flussenergie, LLC"
-        },
-        "US-SW-HGMA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "New Harquahala Erzeugungsunternehmen, LLC"
-        },
-        "US-SW-PNM": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "New Mexiko Firma für öffentlichen Dinest"
-        },
-        "US-SW-SRP": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Salzfluss Projekt"
-        },
-        "US-SW-TEPC": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Tucson Elektrische Energie Firma"
-        },
+        "US-NW-WAUW": { "countryName": "Vereinigte Staaten", "zoneName": "Westliche Energieverwaltung UGP Westen" },
+        "US-NW-WWA": { "countryName": "Vereinigte Staaten", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "Vereinigte Staaten", "zoneName": "New York unabhängiger Systembetreiber" },
+        "US-SE-AEC": { "countryName": "Vereinigte Staaten", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "Vereinigte Staaten", "zoneName": "Südöstliche Energieverwaltung" },
+        "US-SE-SOCO": { "countryName": "Vereinigte Staaten", "zoneName": "Südliche Firmen Services, Inc. - Trans" },
+        "US-SW-AZPS": { "countryName": "Vereinigte Staaten", "zoneName": "Arizona Firma für öffentlichen Dienst" },
+        "US-SW-DEAA": { "countryName": "Vereinigte Staaten", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "Vereinigte Staaten", "zoneName": "El Paso Elektrik Firma" },
+        "US-SW-GRIF": { "countryName": "Vereinigte Staaten", "zoneName": "Griffith Energie, LLC" },
+        "US-SW-GRMA": { "countryName": "Vereinigte Staaten", "zoneName": "Gila Flussenergie, LLC" },
+        "US-SW-HGMA": { "countryName": "Vereinigte Staaten", "zoneName": "New Harquahala Erzeugungsunternehmen, LLC" },
+        "US-SW-PNM": { "countryName": "Vereinigte Staaten", "zoneName": "New Mexiko Firma für öffentlichen Dinest" },
+        "US-SW-SRP": { "countryName": "Vereinigte Staaten", "zoneName": "Salzfluss Projekt" },
+        "US-SW-TEPC": { "countryName": "Vereinigte Staaten", "zoneName": "Tucson Elektrische Energie Firma" },
         "US-SW-WALC": {
             "countryName": "Vereinigte Staaten",
             "zoneName": "Westliche Energieverwaltung - Wüsten Südwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Tennessee Valley Behörde"
-        },
+        "US-TEN-TVA": { "countryName": "Vereinigte Staaten", "zoneName": "Tennessee Valley Behörde" },
         "US-TEX-ERCO": {
             "countryName": "Vereinigte Staaten",
             "zoneName": "Rat für elektrische Zuverlässigkeit von Texas, Inc."
         },
-        "CL-SEN": {
-            "countryName": "Chile",
-            "zoneName": "Nationales elektrisches System"
-        },
-        "US-AK": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "Alaska"
-        },
-        "US-MIDW-GLHB": {
-            "countryName": "Vereinigte Staaten",
-            "zoneName": "GridLiance"
-        },
-        "XK": {
-            "zoneName": "Kosovo"
-        },
-        "AUS-TAS-FI": {
-            "countryName": "Australien",
-            "zoneName": "Flinders Island"
-        },
-        "AUS-TAS-CBI": {
-            "countryName": "Australien",
-            "zoneName": "Cape Barren Island"
-        },
-        "AUS-WA-RI": {
-            "countryName": "Australien",
-            "zoneName": "Rottnest Island"
-        },
-        "NZ-NZST": {
-            "countryName": "Neuseeland",
-            "zoneName": "Stewart Island"
-        }
+        "CL-SEN": { "countryName": "Chile", "zoneName": "Nationales elektrisches System" },
+        "US-AK": { "countryName": "Vereinigte Staaten", "zoneName": "Alaska" },
+        "US-MIDW-GLHB": { "countryName": "Vereinigte Staaten", "zoneName": "GridLiance" },
+        "XK": { "zoneName": "Kosovo" },
+        "AUS-TAS-FI": { "countryName": "Australien", "zoneName": "Flinders Island" },
+        "AUS-TAS-CBI": { "countryName": "Australien", "zoneName": "Cape Barren Island" },
+        "AUS-WA-RI": { "countryName": "Australien", "zoneName": "Rottnest Island" },
+        "NZ-NZST": { "countryName": "Neuseeland", "zoneName": "Stewart Island" }
     },
     "mobile-info-tab": {
         "map-info-text": "Diese Karte veranschaulicht in Echtzeit, wie viel CO₂-Äquivalente bei der Stromerzeugung freigesetzt werden. Die Färbung der Zonen erfolgt anhand des spezifischen Ausstoßes von Treibhausgasen (CO₂-Intensität), die durch die Deckung des Strombedarfs einer Region emittiert werden. Eine grüne Färbung steht dabei für eine klimafreundlichere Erzeugung.",

--- a/web/public/locales/el.json
+++ b/web/public/locales/el.json
@@ -6,15 +6,9 @@
         "datasources": "πηγές δεδομένων",
         "contribute": "Συνεισφέρετε <a href=\"%s\" target=\"_blank\">προσθέτοντας την περιοχή σας</a>"
     },
-    "mobile-main-menu": {
-        "map": "Χάρτης",
-        "areas": "Περιοχές",
-        "about": "Σχετικά με εμάς"
-    },
+    "mobile-main-menu": { "map": "Χάρτης", "areas": "Περιοχές", "about": "Σχετικά με εμάς" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Χαρτογράφηση των κλιματικών επιπτώσεων της ηλεκτρικής ενέργειας"
-        },
+        "view1": { "subtitle": "Χαρτογράφηση των κλιματικών επιπτώσεων της ηλεκτρικής ενέργειας" },
         "view2": {
             "header": "Δείτε πόσο CO₂ εκπέμπεται για να παραχθεί η ηλεκτρική σας ενέργεια, σε πραγματικό χρόνο.",
             "text": "Χρωματίζουμε τις περιοχές του κόσμου κατά την Ένταση Άνθρακα (συμπεριλαμβανομένων όλων των αερίων θερμοκηπίου) της ηλεκτρικής ενέργειας που καταναλώνεται εκεί. Όσο πιο πράσινο το χρώμα, τόσο πιο φιλική προς το κλίμα είναι η ηλεκτρική ενέργεια."
@@ -50,14 +44,14 @@
         "search": "Αναζήτηση περιοχών"
     },
     "country-history": {
-        "carbonintensity24h": "Ένταση άνθρακα τις τελευταίες 24 ώρες",
-        "emissions24h": "Εκπομπές τις τελευταίες 24 ώρες",
-        "emissionsorigin24h": "Προέλευση εκπομπών τις τελευταίες 24 ώρες",
-        "emissionsproduction24h": "Εκπομπές που παράχθηκαν τις τελευταίες 24 ώρες",
-        "electricityorigin24h": "Προέλευση ηλεκτρικής ενέργειας τις τελευταίες 24 ώρες",
-        "electricityproduction24h": "Παραγωγή ηλεκτρικής ενέργειας τις τελευταίες 24 ώρες",
-        "electricityprices24h": "Τιμές ηλεκτρικής ενέργειας τις τελευταίες 24 ώρες",
-        "Getdata": "Λάβετε ωριαία ιστορικά και ζωντανά δεδομένα, καθώς και προβλέψεις, με το electricityMap API"
+        "Getdata": "Λάβετε ωριαία ιστορικά και ζωντανά δεδομένα, καθώς και προβλέψεις, με το electricityMap API",
+        "carbonintensity": { "hourly": "Ένταση άνθρακα τις τελευταίες 24 ώρες" },
+        "emissionsorigin": { "hourly": "Προέλευση εκπομπών τις τελευταίες 24 ώρες" },
+        "emissionsproduction": { "hourly": "Εκπομπές που παράχθηκαν τις τελευταίες 24 ώρες" },
+        "electricityorigin": { "hourly": "Προέλευση ηλεκτρικής ενέργειας τις τελευταίες 24 ώρες" },
+        "electricityproduction": { "hourly": "Παραγωγή ηλεκτρικής ενέργειας τις τελευταίες 24 ώρες" },
+        "electricityprices": { "hourly": "Τιμές ηλεκτρικής ενέργειας τις τελευταίες 24 ώρες" },
+        "emissions": { "hourly": "Εκπομπές τις τελευταίες 24 ώρες" }
     },
     "footer": {
         "foundbugs": "Βρήκατε σφάλματα ή έχετε ιδέες; Αναφέρετέ τα",
@@ -195,1193 +189,359 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publishes data and images on the <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> for information purposes. It makes no claims of correctness nor provides any form of warranties, and reserves the right to change the content at any time or to remove parts without having to inform you of this. electricityMap assumes no responsibility for, and shall not be liable for, any damages or expenses you may incur as a result of any inaccuracy, incompleteness, untimeliness or obsolescence of the electricityMap, or the information derived from them.  It is not allowed to include this webpage, or any of its individual elements, in another webpage, without formal prior written consent.<br><br> All intellectual property rights belong to the rightful owners and its licensors. Copying, distribution and any other use of these materials, in particular the energy data, is not permitted without the written permission of electricityMap, except and only to the extent otherwise provided in regulations of mandatory law (such as the right to quote), unless specified otherwise for specific materials. <br><br>This disclaimer may be updated from time to time."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Ηνωμένα Αραβικά Εμιράτα"
-        },
-        "AF": {
-            "zoneName": "Αφγανιστάν"
-        },
-        "AG": {
-            "zoneName": "Antigua and Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Αλβανία"
-        },
-        "AM": {
-            "zoneName": "Αρμενία"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Ανταρκτική"
-        },
-        "AS": {
-            "zoneName": "American Samoa"
-        },
-        "AT": {
-            "zoneName": "Αυστρία"
-        },
-        "AR": {
-            "zoneName": "Αργεντινή"
-        },
-        "AUS-NSW": {
-            "countryName": "Αυστραλία",
-            "zoneName": "New South Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Αυστραλία",
-            "zoneName": "Northern Territory"
-        },
-        "AUS-QLD": {
-            "countryName": "Αυστραλία",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Αυστραλία",
-            "zoneName": "South Australia"
-        },
-        "AUS-TAS": {
-            "countryName": "Αυστραλία",
-            "zoneName": "Tasmania"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmania",
-            "zoneName": "King Island"
-        },
-        "AUS-VIC": {
-            "countryName": "Αυστραλία",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Αυστραλία",
-            "zoneName": "Western Australia"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Åland Islands"
-        },
-        "AZ": {
-            "zoneName": "Αζερμπαϊτζάν"
-        },
-        "BA": {
-            "zoneName": "Βοσνία και Ερζεγοβίνη"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Μπαγκλαντές"
-        },
-        "BE": {
-            "zoneName": "Βέλγιο"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Βουλγαρία"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius and Saba"
-        },
-        "BR-CS": {
-            "countryName": "Βραζιλία",
-            "zoneName": "Central Brazil"
-        },
-        "BR-N": {
-            "countryName": "Βραζιλία",
-            "zoneName": "North Brazil"
-        },
-        "BR-NE": {
-            "countryName": "Βραζιλία",
-            "zoneName": "North-East Brazil"
-        },
-        "BR-S": {
-            "countryName": "Βραζιλία",
-            "zoneName": "South Brazil"
-        },
-        "BS": {
-            "zoneName": "Μπαχάμες"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Bouvet Island"
-        },
-        "BW": {
-            "zoneName": "Μποτσουάνα"
-        },
-        "BY": {
-            "zoneName": "Λευκορωσία"
-        },
-        "BZ": {
-            "zoneName": "Μπελίζ"
-        },
-        "CA-AB": {
-            "countryName": "Καναδάς",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Καναδάς",
-            "zoneName": "British Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Καναδάς",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Καναδάς",
-            "zoneName": "Newfoundland and Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Καναδάς",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Καναδάς",
-            "zoneName": "Northwest Territories"
-        },
-        "CA-NS": {
-            "countryName": "Καναδάς",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NU": {
-            "countryName": "Καναδάς",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Καναδάς",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Καναδάς",
-            "zoneName": "Prince Edward Island"
-        },
-        "CA-QC": {
-            "countryName": "Καναδάς",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Καναδάς",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Καναδάς",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Cocos Islands"
-        },
-        "CD": {
-            "zoneName": "Democratic Republic of the Congo"
-        },
-        "CF": {
-            "zoneName": "Central African Republic"
-        },
-        "CG": {
-            "zoneName": "Κονγκό"
-        },
-        "CH": {
-            "zoneName": "Ελβετία"
-        },
-        "CI": {
-            "zoneName": "Ακτή Ελεφαντοστού"
-        },
-        "CK": {
-            "zoneName": "Cook Islands"
-        },
-        "CL-SEA": {
-            "countryName": "Χιλή",
-            "zoneName": "Sistema Eléctrico de Aysén"
-        },
-        "CL-SEM": {
-            "countryName": "Χιλή",
-            "zoneName": "Sistema Eléctrico de Magallanes"
-        },
-        "CL-SEN": {
-            "countryName": "Χιλή",
-            "zoneName": "Sistema Eléctrico Nacional"
-        },
-        "CM": {
-            "zoneName": "Καμερούν"
-        },
-        "CN": {
-            "zoneName": "Κίνα"
-        },
-        "CO": {
-            "zoneName": "Κολομβία"
-        },
-        "CR": {
-            "zoneName": "Κόστα Ρίκα"
-        },
-        "CU": {
-            "zoneName": "Cuba"
-        },
-        "CV": {
-            "zoneName": "Cabo Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Christmas Island"
-        },
-        "CY": {
-            "zoneName": "Κύπρος"
-        },
-        "CZ": {
-            "zoneName": "Τσεχία"
-        },
-        "DE": {
-            "zoneName": "Γερμανία"
-        },
-        "DJ": {
-            "zoneName": "Τζιμπουτί"
-        },
-        "DK": {
-            "zoneName": "Δανία"
-        },
-        "DK-DK1": {
-            "countryName": "Δανία",
-            "zoneName": "Δυτική Δανία"
-        },
-        "DK-DK2": {
-            "countryName": "Δανία",
-            "zoneName": "Ανατολική Δανία"
-        },
-        "DK-BHM": {
-            "countryName": "Δανία",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Ντομίνικα"
-        },
-        "DO": {
-            "zoneName": "Δομινικανή Δημοκρατία"
-        },
-        "DZ": {
-            "zoneName": "Αλγερία"
-        },
-        "EC": {
-            "zoneName": "Εκουαδόρ"
-        },
-        "EE": {
-            "zoneName": "Εσθονία"
-        },
-        "EG": {
-            "zoneName": "Αίγυπτος"
-        },
-        "EH": {
-            "zoneName": "Western Sahara"
-        },
-        "ER": {
-            "zoneName": "Ερυθραία"
-        },
-        "ES": {
-            "zoneName": "Ισπανία"
-        },
-        "ES-IB-FO": {
-            "countryName": "Ισπανία",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Ισπανία",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Ισπανία",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Ισπανία",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Ισπανία",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Ισπανία",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Ισπανία",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Ισπανία",
-            "zoneName": "Isla de la Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Ισπανία",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Ισπανία",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Αιθιοπία"
-        },
-        "FI": {
-            "zoneName": "Φινλανδία"
-        },
-        "FJ": {
-            "zoneName": "Φίτζι"
-        },
-        "FK": {
-            "zoneName": "Falkland Islands"
-        },
-        "FM": {
-            "zoneName": "Μικρονησία"
-        },
-        "FO": {
-            "zoneName": "Faroe Islands"
-        },
-        "FR": {
-            "zoneName": "Γαλλία"
-        },
-        "FR-COR": {
-            "countryName": "Γαλλία",
-            "zoneName": "Κορσική"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Μεγάλη Βρετανία"
-        },
-        "GB-NIR": {
-            "zoneName": "Βόρεια Ιρλανδία"
-        },
-        "GB-ORK": {
-            "countryName": "Μεγάλη Βρετανία",
-            "zoneName": "Orkney Islands"
-        },
-        "GB-SHI": {
-            "countryName": "Μεγάλη Βρετανία",
-            "zoneName": "Shetland Islands"
-        },
-        "GB-ZET": {
-            "countryName": "Μεγάλη Βρετανία",
-            "zoneName": "Shetland Islands"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Γεωργία"
-        },
-        "GF": {
-            "zoneName": "French Guiana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Γκάνα"
-        },
-        "GI": {
-            "zoneName": "Γιβραλτάρ"
-        },
-        "GL": {
-            "zoneName": "Γροιλανδία"
-        },
-        "GM": {
-            "zoneName": "Γκάμπια"
-        },
-        "GN": {
-            "zoneName": "Γουινέα"
-        },
-        "GP": {
-            "zoneName": "Γουαδελούπη"
-        },
-        "GQ": {
-            "zoneName": "Ισημερινή Γουινέα"
-        },
-        "GR": {
-            "zoneName": "Ελλάδα"
-        },
-        "GR-IS": {
-            "countryName": "Ελλάδα",
-            "zoneName": "Νησιά Αιγαίου Πελάγους"
-        },
-        "GS": {
-            "zoneName": "South Georgia and the South Sandwich Islands"
-        },
-        "GT": {
-            "zoneName": "Γουατεμάλα"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Γουιάνα"
-        },
-        "HK": {
-            "zoneName": "Χονγκ Κονγκ"
-        },
-        "HM": {
-            "zoneName": "Heard Island and McDonald Islands"
-        },
-        "HN": {
-            "zoneName": "Ονδούρα"
-        },
-        "HR": {
-            "zoneName": "Κροατία"
-        },
-        "HT": {
-            "zoneName": "Αΐτη"
-        },
-        "HU": {
-            "zoneName": "Ουγγαρία"
-        },
-        "ID": {
-            "zoneName": "Ινδονησία"
-        },
-        "IE": {
-            "zoneName": "Ιρλανδία"
-        },
-        "IL": {
-            "zoneName": "Ισραήλ"
-        },
-        "IM": {
-            "zoneName": "Isle of Man"
-        },
-        "IN-AN": {
-            "countryName": "Ινδία",
-            "zoneName": "Andaman and Nicobar Islands"
-        },
-        "IN-AP": {
-            "countryName": "Ινδία",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Ινδία",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Ινδία",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "Ινδία",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Ινδία",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Ινδία",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "Ινδία",
-            "zoneName": "Dadra and Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "Ινδία",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Ινδία",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "Ινδία",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Ινδία",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "Ινδία",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Ινδία",
-            "zoneName": "Jammu and Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "Ινδία",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Ινδία",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Ινδία",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "Ινδία",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Ινδία",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Ινδία",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Ινδία",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Ινδία",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Ινδία",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "Ινδία",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "Ινδία",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "Ινδία",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "Ινδία",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "Ινδία",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "Ινδία",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Ινδία",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Ινδία",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Ινδία",
-            "zoneName": "West Bengal"
-        },
-        "IO": {
-            "zoneName": "British Indian Ocean Territory"
-        },
-        "IQ": {
-            "zoneName": "Ιράκ"
-        },
-        "IQ-KUR": {
-            "countryName": "Ιράκ",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Ιράν"
-        },
-        "IS": {
-            "zoneName": "Ισλανδία"
-        },
-        "IT": {
-            "zoneName": "Ιταλία"
-        },
-        "IT-CNO": {
-            "countryName": "Ιταλία",
-            "zoneName": "Βόρεια Κεντρική Ιταλία"
-        },
-        "IT-CSO": {
-            "countryName": "Ιταλία",
-            "zoneName": "Νότια Κεντρική Ιταλία"
-        },
-        "IT-NO": {
-            "countryName": "Ιταλία",
-            "zoneName": "Βόρεια Ιταλία"
-        },
-        "IT-SAR": {
-            "countryName": "Ιταλία",
-            "zoneName": "Σαρδηνία"
-        },
-        "IT-SIC": {
-            "countryName": "Ιταλία",
-            "zoneName": "Σικελία"
-        },
-        "IT-SO": {
-            "countryName": "Ιταλία",
-            "zoneName": "Νότια Ιταλία"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Τζαμάικα"
-        },
-        "JO": {
-            "zoneName": "Ιορδανία"
-        },
-        "JP-CB": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Ιαπωνία",
-            "zoneName": "Tōkyō"
-        },
-        "KE": {
-            "zoneName": "Κένυα"
-        },
-        "KG": {
-            "zoneName": "Kyrgyzstan"
-        },
-        "KH": {
-            "zoneName": "Cambodia"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comoros"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts and Nevis"
-        },
-        "KP": {
-            "zoneName": "Βόρεια Κορέα"
-        },
-        "KR": {
-            "zoneName": "Νότια Κορέα"
-        },
-        "KW": {
-            "zoneName": "Κουβέιτ"
-        },
-        "KY": {
-            "zoneName": "Cayman Islands"
-        },
-        "KZ": {
-            "zoneName": "Καζακστάν"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Λίβανος"
-        },
-        "LC": {
-            "zoneName": "Saint Lucia"
-        },
-        "LI": {
-            "zoneName": "Λιχτενστάιν"
-        },
-        "LK": {
-            "zoneName": "Σρι Λάνκα"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Λιθουανία"
-        },
-        "LU": {
-            "zoneName": "Λουξεμβούργο"
-        },
-        "LV": {
-            "zoneName": "Λετονία"
-        },
-        "LY": {
-            "zoneName": "Λιβύη"
-        },
-        "MA": {
-            "zoneName": "Μαρόκο"
-        },
-        "MC": {
-            "zoneName": "Μονακό"
-        },
-        "MD": {
-            "zoneName": "Μολδαβία"
-        },
-        "ME": {
-            "zoneName": "Μαυροβούνιο"
-        },
-        "MF": {
-            "countryName": "Saint Martin",
-            "zoneName": "French"
-        },
-        "MG": {
-            "zoneName": "Μαδαγασκάρη"
-        },
-        "MH": {
-            "zoneName": "Marshall Islands"
-        },
-        "MK": {
-            "zoneName": "Βόρεια Μακεδονία"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Μογγολία"
-        },
-        "MO": {
-            "zoneName": "Μακάο"
-        },
-        "MP": {
-            "zoneName": "Northern Mariana Islands"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Μάλτα"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Maldives"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Μεξικό"
-        },
-        "MX-BC": {
-            "countryName": "Μεξικό",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Μεξικό",
-            "zoneName": "Κεντρικό Μεξικό"
-        },
-        "MX-NE": {
-            "countryName": "Μεξικό",
-            "zoneName": "Βορειοανατολικό Μεξικό"
-        },
-        "MX-NO": {
-            "countryName": "Μεξικό",
-            "zoneName": "Βόρειο Μεξικό"
-        },
-        "MX-NW": {
-            "countryName": "Μεξικό",
-            "zoneName": "Βορειοδυτικό Μεξικό"
-        },
-        "MX-OC": {
-            "countryName": "Μεξικό",
-            "zoneName": "Occidental"
-        },
-        "MX-OR": {
-            "countryName": "Μεξικό",
-            "zoneName": "Oriental"
-        },
-        "MX-PN": {
-            "countryName": "Μεξικό",
-            "zoneName": "Peninsula"
-        },
-        "MY-EM": {
-            "countryName": "Μαλαισία",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Μαλαισία",
-            "zoneName": "Peninsula"
-        },
-        "MZ": {
-            "zoneName": "Mozambique"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "New Caledonia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolk Island"
-        },
-        "NG": {
-            "zoneName": "Νιγηρία"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabakh"
-        },
-        "NL": {
-            "zoneName": "Ολλανδία"
-        },
-        "NO-NO1": {
-            "countryName": "Νορβηγία",
-            "zoneName": "Νοτιοανατολική Νορβηγία"
-        },
-        "NO-NO2": {
-            "countryName": "Νορβηγία",
-            "zoneName": "Νοτιοδυτική Νορβηγία"
-        },
-        "NO-NO3": {
-            "countryName": "Νορβηγία",
-            "zoneName": "Κεντρική Νορβηγία"
-        },
-        "NO-NO4": {
-            "countryName": "Νορβηγία",
-            "zoneName": "Βόρεια Νορβηγία"
-        },
-        "NO-NO5": {
-            "countryName": "Νορβηγία",
-            "zoneName": "Δυτική Νορβηγία"
-        },
-        "NP": {
-            "zoneName": "Νεπάλ"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ-NZA": {
-            "countryName": "Νέα Ζηλανδία",
-            "zoneName": "Auckland Islands"
-        },
-        "NZ-NZC": {
-            "countryName": "Νέα Ζηλανδία",
-            "zoneName": "Chatham Islands"
-        },
-        "NZ": {
-            "zoneName": "Νέα Ζηλανδία"
-        },
-        "OM": {
-            "zoneName": "Ομάν"
-        },
-        "PA": {
-            "zoneName": "Παναμάς"
-        },
-        "PE": {
-            "zoneName": "Περού"
-        },
-        "PF": {
-            "zoneName": "Γαλλική Πολυνησία"
-        },
-        "PG": {
-            "zoneName": "Παπούα Νέα Γουινέα"
-        },
-        "PH": {
-            "zoneName": "Φιλιππίνες"
-        },
-        "PK": {
-            "zoneName": "Πακιστάν"
-        },
-        "PL": {
-            "zoneName": "Πολωνία"
-        },
-        "PM": {
-            "zoneName": "Saint Pierre and Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Πουέρτο Ρίκο"
-        },
-        "PS": {
-            "zoneName": "Παλαιστίνη"
-        },
-        "PT": {
-            "zoneName": "Πορτογαλία"
-        },
-        "PT-AC": {
-            "countryName": "Πορτογαλία",
-            "zoneName": "Azores"
-        },
-        "PT-MA": {
-            "countryName": "Πορτογαλία",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Παραγουάη"
-        },
-        "QA": {
-            "zoneName": "Κατάρ"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Ρουμανία"
-        },
-        "RS": {
-            "zoneName": "Σερβία"
-        },
-        "RU": {
-            "zoneName": "Ρωσία"
-        },
-        "RU-1": {
-            "countryName": "Ρωσία",
-            "zoneName": "Ευρωπαϊκή Ρωσία και Ουράλια"
-        },
-        "RU-2": {
-            "countryName": "Ρωσία",
-            "zoneName": "Σιβηρία"
-        },
-        "RU-EU": {
-            "zoneName": "Ρωσία"
-        },
-        "RU-AS": {
-            "zoneName": "Ρωσία"
-        },
-        "RU-KGD": {
-            "countryName": "Ρωσία",
-            "zoneName": "Καλίνινγκραντ"
-        },
-        "RW": {
-            "zoneName": "Ρουάντα"
-        },
-        "SA": {
-            "zoneName": "Σαουδική Αραβία"
-        },
-        "SB": {
-            "zoneName": "Solomon Islands"
-        },
-        "SC": {
-            "zoneName": "Seychelles"
-        },
-        "SD": {
-            "zoneName": "Σουδάν"
-        },
-        "SE": {
-            "zoneName": "Σουηδία"
-        },
-        "SG": {
-            "zoneName": "Σιγκαπούρη"
-        },
-        "SH": {
-            "zoneName": "Saint Helena, Ascension and Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Σλοβενία"
-        },
-        "SJ": {
-            "zoneName": "Svalbard and Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Σλοβακία"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Σομαλία"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Νότιο Σουδάν"
-        },
-        "ST": {
-            "zoneName": "Sao Tome and Principe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Dutch"
-        },
-        "SY": {
-            "zoneName": "Συρία"
-        },
-        "SZ": {
-            "zoneName": "Swaziland"
-        },
-        "TC": {
-            "zoneName": "Turks and Caicos Islands"
-        },
-        "TD": {
-            "zoneName": "Chad"
-        },
-        "TF": {
-            "zoneName": "French Southern Territories"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Ταϊλάνδη"
-        },
-        "TJ": {
-            "zoneName": "Tajikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Τυνησία"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Τουρκία"
-        },
-        "TT": {
-            "zoneName": "Trinidad and Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Ταϊβάν"
-        },
-        "TZ": {
-            "zoneName": "Τανζανία"
-        },
-        "UA": {
-            "zoneName": "Ουκρανία"
-        },
-        "UA-CR": {
-            "countryName": "Κριμαία",
-            "zoneName": "Ουκρανία"
-        },
-        "UG": {
-            "zoneName": "Ουγκάντα"
-        },
-        "UM": {
-            "zoneName": "United States Minor Outlying Islands"
-        },
-        "US-HI-HA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Oahu"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Ηνωμένα Αραβικά Εμιράτα" },
+        "AF": { "zoneName": "Αφγανιστάν" },
+        "AG": { "zoneName": "Antigua and Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Αλβανία" },
+        "AM": { "zoneName": "Αρμενία" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Ανταρκτική" },
+        "AS": { "zoneName": "American Samoa" },
+        "AT": { "zoneName": "Αυστρία" },
+        "AR": { "zoneName": "Αργεντινή" },
+        "AUS-NSW": { "countryName": "Αυστραλία", "zoneName": "New South Wales" },
+        "AUS-NT": { "countryName": "Αυστραλία", "zoneName": "Northern Territory" },
+        "AUS-QLD": { "countryName": "Αυστραλία", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Αυστραλία", "zoneName": "South Australia" },
+        "AUS-TAS": { "countryName": "Αυστραλία", "zoneName": "Tasmania" },
+        "AUS-TAS-KI": { "countryName": "Tasmania", "zoneName": "King Island" },
+        "AUS-VIC": { "countryName": "Αυστραλία", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Αυστραλία", "zoneName": "Western Australia" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Åland Islands" },
+        "AZ": { "zoneName": "Αζερμπαϊτζάν" },
+        "BA": { "zoneName": "Βοσνία και Ερζεγοβίνη" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Μπαγκλαντές" },
+        "BE": { "zoneName": "Βέλγιο" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Βουλγαρία" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius and Saba" },
+        "BR-CS": { "countryName": "Βραζιλία", "zoneName": "Central Brazil" },
+        "BR-N": { "countryName": "Βραζιλία", "zoneName": "North Brazil" },
+        "BR-NE": { "countryName": "Βραζιλία", "zoneName": "North-East Brazil" },
+        "BR-S": { "countryName": "Βραζιλία", "zoneName": "South Brazil" },
+        "BS": { "zoneName": "Μπαχάμες" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Bouvet Island" },
+        "BW": { "zoneName": "Μποτσουάνα" },
+        "BY": { "zoneName": "Λευκορωσία" },
+        "BZ": { "zoneName": "Μπελίζ" },
+        "CA-AB": { "countryName": "Καναδάς", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Καναδάς", "zoneName": "British Columbia" },
+        "CA-MB": { "countryName": "Καναδάς", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Καναδάς", "zoneName": "Newfoundland and Labrador" },
+        "CA-NB": { "countryName": "Καναδάς", "zoneName": "New Brunswick" },
+        "CA-NT": { "countryName": "Καναδάς", "zoneName": "Northwest Territories" },
+        "CA-NS": { "countryName": "Καναδάς", "zoneName": "Nova Scotia" },
+        "CA-NU": { "countryName": "Καναδάς", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Καναδάς", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Καναδάς", "zoneName": "Prince Edward Island" },
+        "CA-QC": { "countryName": "Καναδάς", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Καναδάς", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Καναδάς", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Cocos Islands" },
+        "CD": { "zoneName": "Democratic Republic of the Congo" },
+        "CF": { "zoneName": "Central African Republic" },
+        "CG": { "zoneName": "Κονγκό" },
+        "CH": { "zoneName": "Ελβετία" },
+        "CI": { "zoneName": "Ακτή Ελεφαντοστού" },
+        "CK": { "zoneName": "Cook Islands" },
+        "CL-SEA": { "countryName": "Χιλή", "zoneName": "Sistema Eléctrico de Aysén" },
+        "CL-SEM": { "countryName": "Χιλή", "zoneName": "Sistema Eléctrico de Magallanes" },
+        "CL-SEN": { "countryName": "Χιλή", "zoneName": "Sistema Eléctrico Nacional" },
+        "CM": { "zoneName": "Καμερούν" },
+        "CN": { "zoneName": "Κίνα" },
+        "CO": { "zoneName": "Κολομβία" },
+        "CR": { "zoneName": "Κόστα Ρίκα" },
+        "CU": { "zoneName": "Cuba" },
+        "CV": { "zoneName": "Cabo Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Christmas Island" },
+        "CY": { "zoneName": "Κύπρος" },
+        "CZ": { "zoneName": "Τσεχία" },
+        "DE": { "zoneName": "Γερμανία" },
+        "DJ": { "zoneName": "Τζιμπουτί" },
+        "DK": { "zoneName": "Δανία" },
+        "DK-DK1": { "countryName": "Δανία", "zoneName": "Δυτική Δανία" },
+        "DK-DK2": { "countryName": "Δανία", "zoneName": "Ανατολική Δανία" },
+        "DK-BHM": { "countryName": "Δανία", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Ντομίνικα" },
+        "DO": { "zoneName": "Δομινικανή Δημοκρατία" },
+        "DZ": { "zoneName": "Αλγερία" },
+        "EC": { "zoneName": "Εκουαδόρ" },
+        "EE": { "zoneName": "Εσθονία" },
+        "EG": { "zoneName": "Αίγυπτος" },
+        "EH": { "zoneName": "Western Sahara" },
+        "ER": { "zoneName": "Ερυθραία" },
+        "ES": { "zoneName": "Ισπανία" },
+        "ES-IB-FO": { "countryName": "Ισπανία", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Ισπανία", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Ισπανία", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Ισπανία", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Ισπανία", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Ισπανία", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Ισπανία", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Ισπανία", "zoneName": "Isla de la Gomera" },
+        "ES-CN-LP": { "countryName": "Ισπανία", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Ισπανία", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Αιθιοπία" },
+        "FI": { "zoneName": "Φινλανδία" },
+        "FJ": { "zoneName": "Φίτζι" },
+        "FK": { "zoneName": "Falkland Islands" },
+        "FM": { "zoneName": "Μικρονησία" },
+        "FO": { "zoneName": "Faroe Islands" },
+        "FR": { "zoneName": "Γαλλία" },
+        "FR-COR": { "countryName": "Γαλλία", "zoneName": "Κορσική" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Μεγάλη Βρετανία" },
+        "GB-NIR": { "zoneName": "Βόρεια Ιρλανδία" },
+        "GB-ORK": { "countryName": "Μεγάλη Βρετανία", "zoneName": "Orkney Islands" },
+        "GB-SHI": { "countryName": "Μεγάλη Βρετανία", "zoneName": "Shetland Islands" },
+        "GB-ZET": { "countryName": "Μεγάλη Βρετανία", "zoneName": "Shetland Islands" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Γεωργία" },
+        "GF": { "zoneName": "French Guiana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Γκάνα" },
+        "GI": { "zoneName": "Γιβραλτάρ" },
+        "GL": { "zoneName": "Γροιλανδία" },
+        "GM": { "zoneName": "Γκάμπια" },
+        "GN": { "zoneName": "Γουινέα" },
+        "GP": { "zoneName": "Γουαδελούπη" },
+        "GQ": { "zoneName": "Ισημερινή Γουινέα" },
+        "GR": { "zoneName": "Ελλάδα" },
+        "GR-IS": { "countryName": "Ελλάδα", "zoneName": "Νησιά Αιγαίου Πελάγους" },
+        "GS": { "zoneName": "South Georgia and the South Sandwich Islands" },
+        "GT": { "zoneName": "Γουατεμάλα" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Γουιάνα" },
+        "HK": { "zoneName": "Χονγκ Κονγκ" },
+        "HM": { "zoneName": "Heard Island and McDonald Islands" },
+        "HN": { "zoneName": "Ονδούρα" },
+        "HR": { "zoneName": "Κροατία" },
+        "HT": { "zoneName": "Αΐτη" },
+        "HU": { "zoneName": "Ουγγαρία" },
+        "ID": { "zoneName": "Ινδονησία" },
+        "IE": { "zoneName": "Ιρλανδία" },
+        "IL": { "zoneName": "Ισραήλ" },
+        "IM": { "zoneName": "Isle of Man" },
+        "IN-AN": { "countryName": "Ινδία", "zoneName": "Andaman and Nicobar Islands" },
+        "IN-AP": { "countryName": "Ινδία", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Ινδία", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Ινδία", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "Ινδία", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Ινδία", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Ινδία", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "Ινδία", "zoneName": "Dadra and Nagar Haveli" },
+        "IN-GA": { "countryName": "Ινδία", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Ινδία", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "Ινδία", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Ινδία", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "Ινδία", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Ινδία", "zoneName": "Jammu and Kashmir" },
+        "IN-KA": { "countryName": "Ινδία", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Ινδία", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Ινδία", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "Ινδία", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Ινδία", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Ινδία", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Ινδία", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Ινδία", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Ινδία", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "Ινδία", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "Ινδία", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "Ινδία", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "Ινδία", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "Ινδία", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "Ινδία", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Ινδία", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Ινδία", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Ινδία", "zoneName": "West Bengal" },
+        "IO": { "zoneName": "British Indian Ocean Territory" },
+        "IQ": { "zoneName": "Ιράκ" },
+        "IQ-KUR": { "countryName": "Ιράκ", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Ιράν" },
+        "IS": { "zoneName": "Ισλανδία" },
+        "IT": { "zoneName": "Ιταλία" },
+        "IT-CNO": { "countryName": "Ιταλία", "zoneName": "Βόρεια Κεντρική Ιταλία" },
+        "IT-CSO": { "countryName": "Ιταλία", "zoneName": "Νότια Κεντρική Ιταλία" },
+        "IT-NO": { "countryName": "Ιταλία", "zoneName": "Βόρεια Ιταλία" },
+        "IT-SAR": { "countryName": "Ιταλία", "zoneName": "Σαρδηνία" },
+        "IT-SIC": { "countryName": "Ιταλία", "zoneName": "Σικελία" },
+        "IT-SO": { "countryName": "Ιταλία", "zoneName": "Νότια Ιταλία" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Τζαμάικα" },
+        "JO": { "zoneName": "Ιορδανία" },
+        "JP-CB": { "countryName": "Ιαπωνία", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Ιαπωνία", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Ιαπωνία", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Ιαπωνία", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Ιαπωνία", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Ιαπωνία", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Ιαπωνία", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Ιαπωνία", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Ιαπωνία", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Ιαπωνία", "zoneName": "Tōkyō" },
+        "KE": { "zoneName": "Κένυα" },
+        "KG": { "zoneName": "Kyrgyzstan" },
+        "KH": { "zoneName": "Cambodia" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comoros" },
+        "KN": { "zoneName": "Saint Kitts and Nevis" },
+        "KP": { "zoneName": "Βόρεια Κορέα" },
+        "KR": { "zoneName": "Νότια Κορέα" },
+        "KW": { "zoneName": "Κουβέιτ" },
+        "KY": { "zoneName": "Cayman Islands" },
+        "KZ": { "zoneName": "Καζακστάν" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Λίβανος" },
+        "LC": { "zoneName": "Saint Lucia" },
+        "LI": { "zoneName": "Λιχτενστάιν" },
+        "LK": { "zoneName": "Σρι Λάνκα" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Λιθουανία" },
+        "LU": { "zoneName": "Λουξεμβούργο" },
+        "LV": { "zoneName": "Λετονία" },
+        "LY": { "zoneName": "Λιβύη" },
+        "MA": { "zoneName": "Μαρόκο" },
+        "MC": { "zoneName": "Μονακό" },
+        "MD": { "zoneName": "Μολδαβία" },
+        "ME": { "zoneName": "Μαυροβούνιο" },
+        "MF": { "countryName": "Saint Martin", "zoneName": "French" },
+        "MG": { "zoneName": "Μαδαγασκάρη" },
+        "MH": { "zoneName": "Marshall Islands" },
+        "MK": { "zoneName": "Βόρεια Μακεδονία" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Μογγολία" },
+        "MO": { "zoneName": "Μακάο" },
+        "MP": { "zoneName": "Northern Mariana Islands" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Μάλτα" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Maldives" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Μεξικό" },
+        "MX-BC": { "countryName": "Μεξικό", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Μεξικό", "zoneName": "Κεντρικό Μεξικό" },
+        "MX-NE": { "countryName": "Μεξικό", "zoneName": "Βορειοανατολικό Μεξικό" },
+        "MX-NO": { "countryName": "Μεξικό", "zoneName": "Βόρειο Μεξικό" },
+        "MX-NW": { "countryName": "Μεξικό", "zoneName": "Βορειοδυτικό Μεξικό" },
+        "MX-OC": { "countryName": "Μεξικό", "zoneName": "Occidental" },
+        "MX-OR": { "countryName": "Μεξικό", "zoneName": "Oriental" },
+        "MX-PN": { "countryName": "Μεξικό", "zoneName": "Peninsula" },
+        "MY-EM": { "countryName": "Μαλαισία", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Μαλαισία", "zoneName": "Peninsula" },
+        "MZ": { "zoneName": "Mozambique" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "New Caledonia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolk Island" },
+        "NG": { "zoneName": "Νιγηρία" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Nagorno-Karabakh" },
+        "NL": { "zoneName": "Ολλανδία" },
+        "NO-NO1": { "countryName": "Νορβηγία", "zoneName": "Νοτιοανατολική Νορβηγία" },
+        "NO-NO2": { "countryName": "Νορβηγία", "zoneName": "Νοτιοδυτική Νορβηγία" },
+        "NO-NO3": { "countryName": "Νορβηγία", "zoneName": "Κεντρική Νορβηγία" },
+        "NO-NO4": { "countryName": "Νορβηγία", "zoneName": "Βόρεια Νορβηγία" },
+        "NO-NO5": { "countryName": "Νορβηγία", "zoneName": "Δυτική Νορβηγία" },
+        "NP": { "zoneName": "Νεπάλ" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ-NZA": { "countryName": "Νέα Ζηλανδία", "zoneName": "Auckland Islands" },
+        "NZ-NZC": { "countryName": "Νέα Ζηλανδία", "zoneName": "Chatham Islands" },
+        "NZ": { "zoneName": "Νέα Ζηλανδία" },
+        "OM": { "zoneName": "Ομάν" },
+        "PA": { "zoneName": "Παναμάς" },
+        "PE": { "zoneName": "Περού" },
+        "PF": { "zoneName": "Γαλλική Πολυνησία" },
+        "PG": { "zoneName": "Παπούα Νέα Γουινέα" },
+        "PH": { "zoneName": "Φιλιππίνες" },
+        "PK": { "zoneName": "Πακιστάν" },
+        "PL": { "zoneName": "Πολωνία" },
+        "PM": { "zoneName": "Saint Pierre and Miquelon" },
+        "PN": { "zoneName": "Pitcairn" },
+        "PR": { "zoneName": "Πουέρτο Ρίκο" },
+        "PS": { "zoneName": "Παλαιστίνη" },
+        "PT": { "zoneName": "Πορτογαλία" },
+        "PT-AC": { "countryName": "Πορτογαλία", "zoneName": "Azores" },
+        "PT-MA": { "countryName": "Πορτογαλία", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Παραγουάη" },
+        "QA": { "zoneName": "Κατάρ" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Ρουμανία" },
+        "RS": { "zoneName": "Σερβία" },
+        "RU": { "zoneName": "Ρωσία" },
+        "RU-1": { "countryName": "Ρωσία", "zoneName": "Ευρωπαϊκή Ρωσία και Ουράλια" },
+        "RU-2": { "countryName": "Ρωσία", "zoneName": "Σιβηρία" },
+        "RU-EU": { "zoneName": "Ρωσία" },
+        "RU-AS": { "zoneName": "Ρωσία" },
+        "RU-KGD": { "countryName": "Ρωσία", "zoneName": "Καλίνινγκραντ" },
+        "RW": { "zoneName": "Ρουάντα" },
+        "SA": { "zoneName": "Σαουδική Αραβία" },
+        "SB": { "zoneName": "Solomon Islands" },
+        "SC": { "zoneName": "Seychelles" },
+        "SD": { "zoneName": "Σουδάν" },
+        "SE": { "zoneName": "Σουηδία" },
+        "SG": { "zoneName": "Σιγκαπούρη" },
+        "SH": { "zoneName": "Saint Helena, Ascension and Tristan da Cunha" },
+        "SI": { "zoneName": "Σλοβενία" },
+        "SJ": { "zoneName": "Svalbard and Jan Mayen" },
+        "SK": { "zoneName": "Σλοβακία" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Σομαλία" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Νότιο Σουδάν" },
+        "ST": { "zoneName": "Sao Tome and Principe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Dutch" },
+        "SY": { "zoneName": "Συρία" },
+        "SZ": { "zoneName": "Swaziland" },
+        "TC": { "zoneName": "Turks and Caicos Islands" },
+        "TD": { "zoneName": "Chad" },
+        "TF": { "zoneName": "French Southern Territories" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Ταϊλάνδη" },
+        "TJ": { "zoneName": "Tajikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Τυνησία" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Τουρκία" },
+        "TT": { "zoneName": "Trinidad and Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Ταϊβάν" },
+        "TZ": { "zoneName": "Τανζανία" },
+        "UA": { "zoneName": "Ουκρανία" },
+        "UA-CR": { "countryName": "Κριμαία", "zoneName": "Ουκρανία" },
+        "UG": { "zoneName": "Ουγκάντα" },
+        "UM": { "zoneName": "United States Minor Outlying Islands" },
+        "US-HI-HA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Oahu" },
         "US-CAL-BANC": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Balancing Authority Of Northern California"
@@ -1390,30 +550,15 @@
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "California Independent System Operator"
         },
-        "US-CAL-IID": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Imperial Irrigation District"
-        },
+        "US-CAL-IID": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Imperial Irrigation District" },
         "US-CAL-LDWP": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Los Angeles Department Of Water And Power"
         },
-        "US-CAL-TIDC": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Duke Energy Carolinas"
-        },
+        "US-CAL-TIDC": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Duke Energy Carolinas" },
         "US-CAR-SC": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "South Carolina Public Service Authority"
@@ -1430,62 +575,26 @@
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Southwestern Power Administration"
         },
-        "US-CENT-SWPP": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "City Of Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "JEA"
-        },
+        "US-CENT-SWPP": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "City Of Homestead" },
+        "US-FLA-JEA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "JEA" },
         "US-FLA-NSB": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Utilities Commission Of New Smyrna Beach"
         },
-        "US-FLA-SEC": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "City Of Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "PJM Interconnection, Llc"
-        },
+        "US-FLA-SEC": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "City Of Tallahassee" },
+        "US-FLA-TEC": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "PJM Interconnection, Llc" },
         "US-MIDW-AECI": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Associated Electric Cooperative, Inc."
         },
-        "US-MIDW-GLHB": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "GridLiance"
-        },
+        "US-MIDW-GLHB": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1494,78 +603,30 @@
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc.."
         },
-        "US-NE-ISNE": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
+        "US-NE-ISNE": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "PUD No. 1 Of Douglas County" },
         "US-NW-GCPD": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "PUD No. 2 Of Grant County, Washington"
         },
-        "US-NW-GRID": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Portland General Electric Company"
-        },
+        "US-NW-GRID": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Portland General Electric Company" },
         "US-NW-PSCO": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Public Service Company Of Colorado"
         },
-        "US-NW-PSEI": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NW-PSEI": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
@@ -1578,46 +639,22 @@
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Western Area Power Administration UGP West"
         },
-        "US-NW-WWA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
+        "US-NW-WWA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Naturener Wind Watch, Llc" },
         "US-NY-NYIS": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "New York Independent System Operator"
         },
-        "US-SE-AEC": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Southeastern Power Administration"
-        },
+        "US-SE-AEC": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Southeastern Power Administration" },
         "US-SE-SOCO": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Southern Company Services, Inc. - Trans"
         },
-        "US-SW-AZPS": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Gila River Power, LLC"
-        },
+        "US-SW-AZPS": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Gila River Power, LLC" },
         "US-SW-HGMA": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "New Harquahala Generating Company, LLC"
@@ -1626,78 +663,33 @@
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Public Service Company Of New Mexico"
         },
-        "US-SW-SRP": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-SW-SRP": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Tennessee Valley Authority"
-        },
+        "US-TEN-TVA": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Tennessee Valley Authority" },
         "US-TEX-ERCO": {
             "countryName": "Ηνωμένες Πολιτείες Αμερικής",
             "zoneName": "Electric Reliability Council Of Texas, Inc."
         },
-        "UY": {
-            "zoneName": "Ουρουγουάη"
-        },
-        "UZ": {
-            "zoneName": "Ουζμπεκιστάν"
-        },
-        "VA": {
-            "zoneName": "Βατικανό"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent and the Grenadines"
-        },
-        "VE": {
-            "zoneName": "Βενεζουέλα"
-        },
-        "VG": {
-            "countryName": "Virgin Islands",
-            "zoneName": "Virgin Islands"
-        },
-        "VI": {
-            "countryName": "Ηνωμένες Πολιτείες Αμερικής",
-            "zoneName": "Virgin Islands"
-        },
-        "VN": {
-            "zoneName": "Βιετνάμ"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis and Futuna"
-        },
-        "WS": {
-            "zoneName": "Σαμόα"
-        },
-        "XX": {
-            "zoneName": "Κατεχόμενη Κύπρος"
-        },
-        "YE": {
-            "zoneName": "Yemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Νότια Αφρική"
-        },
-        "ZM": {
-            "zoneName": "Ζάμπια"
-        },
-        "ZW": {
-            "zoneName": "Ζιμπάμπουε"
-        }
+        "UY": { "zoneName": "Ουρουγουάη" },
+        "UZ": { "zoneName": "Ουζμπεκιστάν" },
+        "VA": { "zoneName": "Βατικανό" },
+        "VC": { "zoneName": "Saint Vincent and the Grenadines" },
+        "VE": { "zoneName": "Βενεζουέλα" },
+        "VG": { "countryName": "Virgin Islands", "zoneName": "Virgin Islands" },
+        "VI": { "countryName": "Ηνωμένες Πολιτείες Αμερικής", "zoneName": "Virgin Islands" },
+        "VN": { "zoneName": "Βιετνάμ" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis and Futuna" },
+        "WS": { "zoneName": "Σαμόα" },
+        "XX": { "zoneName": "Κατεχόμενη Κύπρος" },
+        "YE": { "zoneName": "Yemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Νότια Αφρική" },
+        "ZM": { "zoneName": "Ζάμπια" },
+        "ZW": { "zoneName": "Ζιμπάμπουε" }
     }
 }

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -58,13 +58,13 @@
         "search": "Search areas"
     },
     "country-history": {
-        "carbonintensity24h": "Carbon intensity in the last 24 hours",
-        "emissions24h": "Emissions in the last 24 hours",
-        "emissionsorigin24h": "Origin of emissions in the last 24 hours",
-        "emissionsproduction24h": "Emissions produced in the last 24 hours",
-        "electricityorigin24h": "Origin of electricity in the last 24 hours",
-        "electricityproduction24h": "Electricity production in the last 24 hours",
-        "electricityprices24h": "Electricity prices in the last 24 hours",
+        "carbonintensity": { "default": "Carbon intensity in the last %1$s" },
+        "emissions": { "default": "Emissions in the last %1$s" },
+        "emissionsorigin": { "default": "Emissions in the last %1$s" },
+        "emissionsproduction": { "default": "Origin of emissions in the last %1$s" },
+        "electricityorigin": { "default": "Origin of electricity in the last %1$s" },
+        "electricityproduction": { "default": "Electricity production in the last %1$s" },
+        "electricityprices": { "default": "Electricity prices in the last %1$s" },
         "Getdata": "Get hourly historical, live, and forecast data with electricityMap API"
     },
     "footer": {

--- a/web/public/locales/es.json
+++ b/web/public/locales/es.json
@@ -6,15 +6,9 @@
         "datasources": "las fuentes de los datos",
         "contribute": "Contribuye <a href=\"%s\" target=\"_blank\">añadiendo tu región o país</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Zonas",
-        "about": "Info"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Zonas", "about": "Info" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Visualización del impacto climático de la electricidad"
-        },
+        "view1": { "subtitle": "Visualización del impacto climático de la electricidad" },
         "view2": {
             "header": "Visualiza cuánto CO₂ se emite para producir tu electricidad, en tiempo real.",
             "text": "El color de cada país refleja la intensidad de carbono (que incluye todos los gases de efecto invernadero) de la electricidad que se consume. Cuanto más verde sea, más respectuosa con el clima será la electricidad."
@@ -50,14 +44,14 @@
         "search": "Buscar zonas"
     },
     "country-history": {
-        "carbonintensity24h": "Intensidad de carbono en las últimas 24 horas",
-        "emissions24h": "Emisiones en las últimas 24 horas",
-        "emissionsorigin24h": "Origen de las emisiones en las últimas 24 horas",
-        "emissionsproduction24h": "Emisiones producidas en las últimas 24 horas",
-        "electricityorigin24h": "Origen de la electricidad en las últimas 24 horas",
-        "electricityproduction24h": "Producción de electricidad en las últimas 24 horas",
-        "electricityprices24h": "Precios de la electricidad en las últimas 24 horas",
-        "Getdata": "Obtener datos históricos por horas y en tiempo real + pronóstico con la API de electricityMap"
+        "Getdata": "Obtener datos históricos por horas y en tiempo real + pronóstico con la API de electricityMap",
+        "carbonintensity": { "hourly": "Intensidad de carbono en las últimas 24 horas" },
+        "emissionsorigin": { "hourly": "Origen de las emisiones en las últimas 24 horas" },
+        "emissionsproduction": { "hourly": "Emisiones producidas en las últimas 24 horas" },
+        "electricityorigin": { "hourly": "Origen de la electricidad en las últimas 24 horas" },
+        "electricityproduction": { "hourly": "Producción de electricidad en las últimas 24 horas" },
+        "electricityprices": { "hourly": "Precios de la electricidad en las últimas 24 horas" },
+        "emissions": { "hourly": "Emisiones en las últimas 24 horas" }
     },
     "footer": {
         "foundbugs": "¿Has encontrado algún error o tienes alguna sugerencia? Cuéntanoslo",
@@ -193,1302 +187,386 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publica datos e imágenes en el <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> solo con fines informativos. electricityMap no se hace responsable de la exactitud de estos datos ni ofrece ningún tipo de garantía, y se reserva el derecho a modificar el contenido del sitio o eliminar parte de él en cualquier momento. electricityMap declina toda responsabilidad y no se hace responsable de daños o gastos que resulten de la inexactitud de electricityMap, ya sea por un error, falta de datos o presencia de información obsoleta o adelantada.  Esto se aplica a electricityMap y a todo producto derivado. Queda prohibido incluir esta página web o cualquiera de sus elementos en otra página sin previo consentimiento escrito de electricityMap.<br><br> Todos los derechos de propiedad intelectual pertenecen a los propietarios legales y legítimos de este sitio y a sus licenciatarios. La copia, distribución u otro uso de estos materiales, en particular de los datos sobre energía, están prohibidas sin el consentimiento escrito de electricityMap, salvo contraindicación legal (como el derecho de cita), a menos que esto no se especifique en los documentos. <br><br>Esta nota legal puede ser actualizada de vez en cuando."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Emiratos Árabes Unidos"
-        },
-        "AF": {
-            "zoneName": "Afganistán"
-        },
-        "AG": {
-            "zoneName": "Antigua y Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguila"
-        },
-        "AL": {
-            "zoneName": "Albania"
-        },
-        "AM": {
-            "zoneName": "Armenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antártida"
-        },
-        "AS": {
-            "zoneName": "Samoa Americana"
-        },
-        "AT": {
-            "zoneName": "Austria"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AUS-NSW": {
-            "countryName": "Australia",
-            "zoneName": "Nueva Gales del Sur"
-        },
-        "AUS-NT": {
-            "countryName": "Australia",
-            "zoneName": "Territorio del Norte"
-        },
-        "AUS-QLD": {
-            "countryName": "Australia",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australia",
-            "zoneName": "Australia Meridional"
-        },
-        "AUS-TAS": {
-            "countryName": "Australia",
-            "zoneName": "Tasmania"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmania",
-            "zoneName": "Isla King"
-        },
-        "AUS-VIC": {
-            "countryName": "Australia",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australia",
-            "zoneName": "Australia Occidental"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "countryName": "Finlandia",
-            "zoneName": "Islas Åland"
-        },
-        "AZ": {
-            "zoneName": "Azerbaiyán"
-        },
-        "BA": {
-            "zoneName": "Bosnia y Herzegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Bélgica"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgaria"
-        },
-        "BH": {
-            "zoneName": "Baréin"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benín"
-        },
-        "BM": {
-            "zoneName": "Bermudas"
-        },
-        "BN": {
-            "zoneName": "Brunéi"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, San Eustaquio y Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brasil",
-            "zoneName": "Centro de Brasil"
-        },
-        "BR-N": {
-            "countryName": "Brasil",
-            "zoneName": "Norte de Brasil"
-        },
-        "BR-NE": {
-            "countryName": "Brasil",
-            "zoneName": "Noreste de Brasil"
-        },
-        "BR-S": {
-            "countryName": "Brasil",
-            "zoneName": "Sur de Brasil"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Bután"
-        },
-        "BV": {
-            "zoneName": "Isla Bouvet"
-        },
-        "BW": {
-            "zoneName": "Botsuana"
-        },
-        "BY": {
-            "zoneName": "Bielorrusia"
-        },
-        "BZ": {
-            "zoneName": "Belice"
-        },
-        "CA-AB": {
-            "countryName": "Canadá",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Canadá",
-            "zoneName": "Columbia Británica"
-        },
-        "CA-MB": {
-            "countryName": "Canadá",
-            "zoneName": "Manitoba"
-        },
-        "CA-NB": {
-            "countryName": "Canadá",
-            "zoneName": "Nuevo Brunswick"
-        },
-        "CA-NL": {
-            "countryName": "Canadá",
-            "zoneName": "Terranova y Labrador"
-        },
-        "CA-NS": {
-            "countryName": "Canadá",
-            "zoneName": "Nueva Escocia"
-        },
-        "CA-NT": {
-            "countryName": "Canadá",
-            "zoneName": "Territorios del Noroeste"
-        },
-        "CA-NU": {
-            "countryName": "Canadá",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Canadá",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Canadá",
-            "zoneName": "Isla del Príncipe Eduardo"
-        },
-        "CA-QC": {
-            "countryName": "Canadá",
-            "zoneName": "Quebec"
-        },
-        "CA-SK": {
-            "countryName": "Canadá",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Canadá",
-            "zoneName": "Yucón"
-        },
-        "CC": {
-            "zoneName": "Islas Cocos"
-        },
-        "CD": {
-            "zoneName": "República Democrática del Congo"
-        },
-        "CF": {
-            "zoneName": "República Centroafricana"
-        },
-        "CG": {
-            "zoneName": "Congo"
-        },
-        "CH": {
-            "zoneName": "Suiza"
-        },
-        "CI": {
-            "zoneName": "Costa de Marfil"
-        },
-        "CK": {
-            "zoneName": "Islas Cook"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Aysén"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Magallanes"
-        },
-        "CL-SEN": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico Nacional"
-        },
-        "CL-CHP": {
-            "countryName": "Chile",
-            "zoneName": "Isla de Pascua"
-        },
-        "CM": {
-            "zoneName": "Camerún"
-        },
-        "CN": {
-            "zoneName": "China"
-        },
-        "CO": {
-            "zoneName": "Colombia"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Cuba"
-        },
-        "CV": {
-            "zoneName": "Cabo Verde"
-        },
-        "CW": {
-            "zoneName": "Curazao"
-        },
-        "CX": {
-            "zoneName": "Isla de Navidad"
-        },
-        "CY": {
-            "zoneName": "Chipre"
-        },
-        "CZ": {
-            "zoneName": "Rep. Checa"
-        },
-        "DE": {
-            "zoneName": "Alemania"
-        },
-        "DJ": {
-            "zoneName": "Yibuti"
-        },
-        "DK": {
-            "zoneName": "Dinamarca"
-        },
-        "DK-BHM": {
-            "countryName": "Dinamarca",
-            "zoneName": "Bornholm"
-        },
-        "DK-DK1": {
-            "countryName": "Dinamarca",
-            "zoneName": "Dinamarca occidental"
-        },
-        "DK-DK2": {
-            "countryName": "Dinamarca",
-            "zoneName": "Dinamarca oriental"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "República Dominicana"
-        },
-        "DZ": {
-            "zoneName": "Argelia"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Estonia"
-        },
-        "EG": {
-            "zoneName": "Egipto"
-        },
-        "EH": {
-            "zoneName": "Sahara Occidental"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "España"
-        },
-        "ES-IB-FO": {
-            "countryName": "España",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "España",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "España",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "España",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "España",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "España",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "España",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "España",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "España",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "España",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Etiopía"
-        },
-        "FI": {
-            "zoneName": "Finlandia"
-        },
-        "FJ": {
-            "zoneName": "Fiyi"
-        },
-        "FK": {
-            "zoneName": "Islas Malvinas"
-        },
-        "FM": {
-            "zoneName": "Micronesia"
-        },
-        "FO": {
-            "zoneName": "Islas Feroe"
-        },
-        "FR": {
-            "zoneName": "Francia"
-        },
-        "FR-COR": {
-            "countryName": "Francia",
-            "zoneName": "Córcega"
-        },
-        "GA": {
-            "zoneName": "Gabón"
-        },
-        "GB": {
-            "zoneName": "Reino Unido"
-        },
-        "GB-NIR": {
-            "zoneName": "Irlanda del Norte"
-        },
-        "GB-ORK": {
-            "countryName": "Reino Unido",
-            "zoneName": "Islas Orcadas"
-        },
-        "GB-SHI": {
-            "countryName": "Reino Unido",
-            "zoneName": "Islas Shetland"
-        },
-        "GB-ZET": {
-            "countryName": "Reino Unido",
-            "zoneName": "Islas Shetland"
-        },
-        "GD": {
-            "zoneName": "Granada"
-        },
-        "GE": {
-            "zoneName": "Georgia"
-        },
-        "GF": {
-            "zoneName": "Guayana Francesa"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Groenlandia"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadalupe"
-        },
-        "GQ": {
-            "zoneName": "Guinea Ecuatorial"
-        },
-        "GR": {
-            "zoneName": "Grecia"
-        },
-        "GR-IS": {
-            "countryName": "Grecia",
-            "zoneName": "Islas del Egeo"
-        },
-        "GS": {
-            "zoneName": "Islas Georgias del Sur y Sándwich del Sur"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bisáu"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Islas Heard y McDonald"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Croacia"
-        },
-        "HT": {
-            "zoneName": "Haití"
-        },
-        "HU": {
-            "zoneName": "Hungría"
-        },
-        "ID": {
-            "zoneName": "Indonesia"
-        },
-        "IE": {
-            "zoneName": "Irlanda"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Isla de Man"
-        },
-        "IN-AN": {
-            "countryName": "India",
-            "zoneName": "Islas de Andamán y Nicobar"
-        },
-        "IN-AP": {
-            "countryName": "India",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "India",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "India",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "India",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "India",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "India",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "India",
-            "zoneName": "Dadra y Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "India",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "India",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "India",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "India",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "India",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "India",
-            "zoneName": "Jammu y Cachemira"
-        },
-        "IN-KA": {
-            "countryName": "India",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "India",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "India",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "India",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "India",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "India",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "India",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "India",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "India",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "India",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "India",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "India",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "India",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "India",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "India",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "India",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "India",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "India",
-            "zoneName": "Bengala Occidental"
-        },
-        "IO": {
-            "zoneName": "Territorio Británico del Océano Índico"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistán"
-        },
-        "IR": {
-            "zoneName": "Irán"
-        },
-        "IS": {
-            "zoneName": "Islandia"
-        },
-        "IT": {
-            "zoneName": "Italia"
-        },
-        "IT-CNO": {
-            "countryName": "Italia",
-            "zoneName": "Centro-norte"
-        },
-        "IT-CSO": {
-            "countryName": "Italia",
-            "zoneName": "Centro-sur"
-        },
-        "IT-NO": {
-            "countryName": "Italia",
-            "zoneName": "Norte"
-        },
-        "IT-SAR": {
-            "countryName": "Italia",
-            "zoneName": "Cerdeña"
-        },
-        "IT-SIC": {
-            "countryName": "Italia",
-            "zoneName": "Sicilia"
-        },
-        "IT-SO": {
-            "countryName": "Italia",
-            "zoneName": "Sur"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaica"
-        },
-        "JO": {
-            "zoneName": "Jordania"
-        },
-        "JP-CB": {
-            "countryName": "Japón",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japón",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japón",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Japón",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japón",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japón",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Japón",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japón",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japón",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japón",
-            "zoneName": "Tokio"
-        },
-        "KE": {
-            "zoneName": "Kenia"
-        },
-        "KG": {
-            "zoneName": "Kirguistán"
-        },
-        "KH": {
-            "zoneName": "Camboya"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comoras"
-        },
-        "KN": {
-            "zoneName": "San Cristóbal y Nieves"
-        },
-        "KP": {
-            "zoneName": "Corea del Norte"
-        },
-        "KR": {
-            "zoneName": "Corea del Sur"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Islas Caimán"
-        },
-        "KZ": {
-            "zoneName": "Kazajistán"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Líbano"
-        },
-        "LC": {
-            "zoneName": "Santa Lucía"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesoto"
-        },
-        "LT": {
-            "zoneName": "Lituania"
-        },
-        "LU": {
-            "zoneName": "Luxemburgo"
-        },
-        "LV": {
-            "zoneName": "Letonia"
-        },
-        "LY": {
-            "zoneName": "Libia"
-        },
-        "MA": {
-            "zoneName": "Marruecos"
-        },
-        "MC": {
-            "zoneName": "Mónaco"
-        },
-        "MD": {
-            "zoneName": "Moldavia"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Isla de San Martín",
-            "zoneName": "Francia"
-        },
-        "MG": {
-            "zoneName": "Madagascar"
-        },
-        "MH": {
-            "zoneName": "Islas Marshall"
-        },
-        "MK": {
-            "zoneName": "Macedonia del Norte"
-        },
-        "ML": {
-            "zoneName": "Malí"
-        },
-        "MM": {
-            "zoneName": "Birmania"
-        },
-        "MN": {
-            "zoneName": "Mongolia"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Islas Marianas del Norte"
-        },
-        "MQ": {
-            "zoneName": "Martinica"
-        },
-        "MR": {
-            "zoneName": "Mauritania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauricio"
-        },
-        "MV": {
-            "zoneName": "Maldivas"
-        },
-        "MW": {
-            "zoneName": "Malaui"
-        },
-        "MX": {
-            "zoneName": "México"
-        },
-        "MX-BC": {
-            "countryName": "México",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "México",
-            "zoneName": "Central"
-        },
-        "MX-NE": {
-            "countryName": "México",
-            "zoneName": "Noreste"
-        },
-        "MX-NO": {
-            "countryName": "México",
-            "zoneName": "Norte"
-        },
-        "MX-NW": {
-            "countryName": "México",
-            "zoneName": "Noroeste"
-        },
-        "MX-OC": {
-            "countryName": "México",
-            "zoneName": "Occidental"
-        },
-        "MX-OR": {
-            "countryName": "México",
-            "zoneName": "Oriental"
-        },
-        "MX-PN": {
-            "countryName": "México",
-            "zoneName": "Peninsula"
-        },
-        "MY-EM": {
-            "countryName": "Malasia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malasia",
-            "zoneName": "Península"
-        },
-        "MZ": {
-            "zoneName": "Mozambique"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "Nueva Caledonia"
-        },
-        "NE": {
-            "zoneName": "Níger"
-        },
-        "NF": {
-            "zoneName": "Isla Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Alto Karabaj"
-        },
-        "NL": {
-            "zoneName": "Holanda"
-        },
-        "NO-NO1": {
-            "countryName": "Noruega",
-            "zoneName": "Sureste"
-        },
-        "NO-NO2": {
-            "countryName": "Noruega",
-            "zoneName": "Suroeste"
-        },
-        "NO-NO3": {
-            "countryName": "Noruega",
-            "zoneName": "Centro"
-        },
-        "NO-NO4": {
-            "countryName": "Noruega",
-            "zoneName": "Norte"
-        },
-        "NO-NO5": {
-            "countryName": "Noruega",
-            "zoneName": "Oeste"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Nueva Zelanda"
-        },
-        "NZ-NZA": {
-            "countryName": "Nueva Zelanda",
-            "zoneName": "Islas Auckland"
-        },
-        "NZ-NZC": {
-            "countryName": "Nueva Zelanda",
-            "zoneName": "Islas Chatham"
-        },
-        "OM": {
-            "zoneName": "Omán"
-        },
-        "PA": {
-            "zoneName": "Panamá"
-        },
-        "PE": {
-            "zoneName": "Perú"
-        },
-        "PF": {
-            "zoneName": "Polinesia Francesa"
-        },
-        "PG": {
-            "zoneName": "Papúa Nueva Guinea"
-        },
-        "PH": {
-            "zoneName": "Filipinas"
-        },
-        "PK": {
-            "zoneName": "Pakistán"
-        },
-        "PL": {
-            "zoneName": "Polonia"
-        },
-        "PM": {
-            "zoneName": "San Pedro y Miquelón"
-        },
-        "PN": {
-            "zoneName": "Islas Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Palestina"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Azores"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Catar"
-        },
-        "RE": {
-            "zoneName": "Reunión"
-        },
-        "RO": {
-            "zoneName": "Rumanía"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Rusia"
-        },
-        "RU-1": {
-            "countryName": "Rusia",
-            "zoneName": "Rusia europea y Urales"
-        },
-        "RU-2": {
-            "countryName": "Rusia",
-            "zoneName": "Siberia"
-        },
-        "RU-AS": {
-            "zoneName": "Rusia"
-        },
-        "RU-EU": {
-            "zoneName": "Rusia"
-        },
-        "RU-KGD": {
-            "countryName": "Rusia",
-            "zoneName": "Kaliningrado"
-        },
-        "RW": {
-            "zoneName": "Ruanda"
-        },
-        "SA": {
-            "zoneName": "Arabia Saudí"
-        },
-        "SB": {
-            "zoneName": "Islas Salomón"
-        },
-        "SC": {
-            "zoneName": "Seychelles"
-        },
-        "SD": {
-            "zoneName": "Sudán"
-        },
-        "SE": {
-            "zoneName": "Suecia"
-        },
-        "SG": {
-            "zoneName": "Singapur"
-        },
-        "SH": {
-            "zoneName": "Santa Elena, Ascensión y Tristán de Acuña"
-        },
-        "SI": {
-            "zoneName": "Eslovenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard y Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Eslovaquia"
-        },
-        "SL": {
-            "zoneName": "Sierra Leona"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Surinam"
-        },
-        "SS": {
-            "zoneName": "Sudán del Sur"
-        },
-        "ST": {
-            "zoneName": "Santo Tomé y Príncipe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Países Bajos"
-        },
-        "SY": {
-            "zoneName": "Siria"
-        },
-        "SZ": {
-            "zoneName": "Suazilandia"
-        },
-        "TC": {
-            "zoneName": "Islas Turcas y Caicos"
-        },
-        "TD": {
-            "zoneName": "Chad"
-        },
-        "TF": {
-            "zoneName": "Territorios Australes Franceses"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Tailandia"
-        },
-        "TJ": {
-            "zoneName": "Tayikistán"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor Oriental"
-        },
-        "TM": {
-            "zoneName": "Turkmenistán"
-        },
-        "TN": {
-            "zoneName": "Túnez"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turquía"
-        },
-        "TT": {
-            "zoneName": "Trinidad y Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwán"
-        },
-        "TZ": {
-            "zoneName": "Tanzania"
-        },
-        "UA": {
-            "zoneName": "Ucrania"
-        },
-        "UA-CR": {
-            "countryName": "Ucrania",
-            "zoneName": "Crimea"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Islas Ultramarinas Menores de Estados Unidos"
-        },
-        "US-HI": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Hawái"
-        },
-        "US-HI-KA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Oahu"
-        },
-        "US-CAL-BANC": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Balancing Authority Of Northern California"
-        },
-        "US-CAL-CISO": {
-            "countryName": "Estados Unidos",
-            "zoneName": "California Independent System Operator"
-        },
-        "US-CAL-IID": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Imperial Irrigation District"
-        },
-        "US-CAL-LDWP": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Los Angeles Department Of Water And Power"
-        },
-        "US-CAL-TIDC": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Duke Energy Carolinas"
-        },
-        "US-CAR-SC": {
-            "countryName": "Estados Unidos",
-            "zoneName": "South Carolina Public Service Authority"
-        },
-        "US-CAR-SCEG": {
-            "countryName": "Estados Unidos",
-            "zoneName": "South Carolina Electric & Gas Company"
-        },
-        "US-CAR-YAD": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
-        },
-        "US-CENT-SPA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Southwestern Power Administration"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Ciudad de Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "JEA"
-        },
-        "US-FLA-NSB": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Utilities Commission Of New Smyrna Beach"
-        },
-        "US-FLA-SEC": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Ciudad de Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "Estados Unidos",
-            "zoneName": "PJM Interconnection, Llc"
-        },
-        "US-MIDW-AECI": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Associated Electric Cooperative, Inc."
-        },
-        "US-MIDW-GLHB": {
-            "countryName": "Estados Unidos",
-            "zoneName": "GridLiance"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Emiratos Árabes Unidos" },
+        "AF": { "zoneName": "Afganistán" },
+        "AG": { "zoneName": "Antigua y Barbuda" },
+        "AI": { "zoneName": "Anguila" },
+        "AL": { "zoneName": "Albania" },
+        "AM": { "zoneName": "Armenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antártida" },
+        "AS": { "zoneName": "Samoa Americana" },
+        "AT": { "zoneName": "Austria" },
+        "AR": { "zoneName": "Argentina" },
+        "AUS-NSW": { "countryName": "Australia", "zoneName": "Nueva Gales del Sur" },
+        "AUS-NT": { "countryName": "Australia", "zoneName": "Territorio del Norte" },
+        "AUS-QLD": { "countryName": "Australia", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australia", "zoneName": "Australia Meridional" },
+        "AUS-TAS": { "countryName": "Australia", "zoneName": "Tasmania" },
+        "AUS-TAS-KI": { "countryName": "Tasmania", "zoneName": "Isla King" },
+        "AUS-VIC": { "countryName": "Australia", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australia", "zoneName": "Australia Occidental" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "countryName": "Finlandia", "zoneName": "Islas Åland" },
+        "AZ": { "zoneName": "Azerbaiyán" },
+        "BA": { "zoneName": "Bosnia y Herzegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Bélgica" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgaria" },
+        "BH": { "zoneName": "Baréin" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benín" },
+        "BM": { "zoneName": "Bermudas" },
+        "BN": { "zoneName": "Brunéi" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Bonaire, San Eustaquio y Saba" },
+        "BR-CS": { "countryName": "Brasil", "zoneName": "Centro de Brasil" },
+        "BR-N": { "countryName": "Brasil", "zoneName": "Norte de Brasil" },
+        "BR-NE": { "countryName": "Brasil", "zoneName": "Noreste de Brasil" },
+        "BR-S": { "countryName": "Brasil", "zoneName": "Sur de Brasil" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Bután" },
+        "BV": { "zoneName": "Isla Bouvet" },
+        "BW": { "zoneName": "Botsuana" },
+        "BY": { "zoneName": "Bielorrusia" },
+        "BZ": { "zoneName": "Belice" },
+        "CA-AB": { "countryName": "Canadá", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Canadá", "zoneName": "Columbia Británica" },
+        "CA-MB": { "countryName": "Canadá", "zoneName": "Manitoba" },
+        "CA-NB": { "countryName": "Canadá", "zoneName": "Nuevo Brunswick" },
+        "CA-NL": { "countryName": "Canadá", "zoneName": "Terranova y Labrador" },
+        "CA-NS": { "countryName": "Canadá", "zoneName": "Nueva Escocia" },
+        "CA-NT": { "countryName": "Canadá", "zoneName": "Territorios del Noroeste" },
+        "CA-NU": { "countryName": "Canadá", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Canadá", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Canadá", "zoneName": "Isla del Príncipe Eduardo" },
+        "CA-QC": { "countryName": "Canadá", "zoneName": "Quebec" },
+        "CA-SK": { "countryName": "Canadá", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Canadá", "zoneName": "Yucón" },
+        "CC": { "zoneName": "Islas Cocos" },
+        "CD": { "zoneName": "República Democrática del Congo" },
+        "CF": { "zoneName": "República Centroafricana" },
+        "CG": { "zoneName": "Congo" },
+        "CH": { "zoneName": "Suiza" },
+        "CI": { "zoneName": "Costa de Marfil" },
+        "CK": { "zoneName": "Islas Cook" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Aysén" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Magallanes" },
+        "CL-SEN": { "countryName": "Chile", "zoneName": "Sistema Eléctrico Nacional" },
+        "CL-CHP": { "countryName": "Chile", "zoneName": "Isla de Pascua" },
+        "CM": { "zoneName": "Camerún" },
+        "CN": { "zoneName": "China" },
+        "CO": { "zoneName": "Colombia" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Cuba" },
+        "CV": { "zoneName": "Cabo Verde" },
+        "CW": { "zoneName": "Curazao" },
+        "CX": { "zoneName": "Isla de Navidad" },
+        "CY": { "zoneName": "Chipre" },
+        "CZ": { "zoneName": "Rep. Checa" },
+        "DE": { "zoneName": "Alemania" },
+        "DJ": { "zoneName": "Yibuti" },
+        "DK": { "zoneName": "Dinamarca" },
+        "DK-BHM": { "countryName": "Dinamarca", "zoneName": "Bornholm" },
+        "DK-DK1": { "countryName": "Dinamarca", "zoneName": "Dinamarca occidental" },
+        "DK-DK2": { "countryName": "Dinamarca", "zoneName": "Dinamarca oriental" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "República Dominicana" },
+        "DZ": { "zoneName": "Argelia" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Estonia" },
+        "EG": { "zoneName": "Egipto" },
+        "EH": { "zoneName": "Sahara Occidental" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "España" },
+        "ES-IB-FO": { "countryName": "España", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "España", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "España", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "España", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "España", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "España", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "España", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "España", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "España", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "España", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Etiopía" },
+        "FI": { "zoneName": "Finlandia" },
+        "FJ": { "zoneName": "Fiyi" },
+        "FK": { "zoneName": "Islas Malvinas" },
+        "FM": { "zoneName": "Micronesia" },
+        "FO": { "zoneName": "Islas Feroe" },
+        "FR": { "zoneName": "Francia" },
+        "FR-COR": { "countryName": "Francia", "zoneName": "Córcega" },
+        "GA": { "zoneName": "Gabón" },
+        "GB": { "zoneName": "Reino Unido" },
+        "GB-NIR": { "zoneName": "Irlanda del Norte" },
+        "GB-ORK": { "countryName": "Reino Unido", "zoneName": "Islas Orcadas" },
+        "GB-SHI": { "countryName": "Reino Unido", "zoneName": "Islas Shetland" },
+        "GB-ZET": { "countryName": "Reino Unido", "zoneName": "Islas Shetland" },
+        "GD": { "zoneName": "Granada" },
+        "GE": { "zoneName": "Georgia" },
+        "GF": { "zoneName": "Guayana Francesa" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Groenlandia" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadalupe" },
+        "GQ": { "zoneName": "Guinea Ecuatorial" },
+        "GR": { "zoneName": "Grecia" },
+        "GR-IS": { "countryName": "Grecia", "zoneName": "Islas del Egeo" },
+        "GS": { "zoneName": "Islas Georgias del Sur y Sándwich del Sur" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bisáu" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Islas Heard y McDonald" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Croacia" },
+        "HT": { "zoneName": "Haití" },
+        "HU": { "zoneName": "Hungría" },
+        "ID": { "zoneName": "Indonesia" },
+        "IE": { "zoneName": "Irlanda" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Isla de Man" },
+        "IN-AN": { "countryName": "India", "zoneName": "Islas de Andamán y Nicobar" },
+        "IN-AP": { "countryName": "India", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "India", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "India", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "India", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "India", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "India", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "India", "zoneName": "Dadra y Nagar Haveli" },
+        "IN-GA": { "countryName": "India", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "India", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "India", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "India", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "India", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "India", "zoneName": "Jammu y Cachemira" },
+        "IN-KA": { "countryName": "India", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "India", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "India", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "India", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "India", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "India", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "India", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "India", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "India", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "India", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "India", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "India", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "India", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "India", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "India", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "India", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "India", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "India", "zoneName": "Bengala Occidental" },
+        "IO": { "zoneName": "Territorio Británico del Océano Índico" },
+        "IQ": { "zoneName": "Irak" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistán" },
+        "IR": { "zoneName": "Irán" },
+        "IS": { "zoneName": "Islandia" },
+        "IT": { "zoneName": "Italia" },
+        "IT-CNO": { "countryName": "Italia", "zoneName": "Centro-norte" },
+        "IT-CSO": { "countryName": "Italia", "zoneName": "Centro-sur" },
+        "IT-NO": { "countryName": "Italia", "zoneName": "Norte" },
+        "IT-SAR": { "countryName": "Italia", "zoneName": "Cerdeña" },
+        "IT-SIC": { "countryName": "Italia", "zoneName": "Sicilia" },
+        "IT-SO": { "countryName": "Italia", "zoneName": "Sur" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaica" },
+        "JO": { "zoneName": "Jordania" },
+        "JP-CB": { "countryName": "Japón", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Japón", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Japón", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Japón", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japón", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japón", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Japón", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japón", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japón", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Japón", "zoneName": "Tokio" },
+        "KE": { "zoneName": "Kenia" },
+        "KG": { "zoneName": "Kirguistán" },
+        "KH": { "zoneName": "Camboya" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comoras" },
+        "KN": { "zoneName": "San Cristóbal y Nieves" },
+        "KP": { "zoneName": "Corea del Norte" },
+        "KR": { "zoneName": "Corea del Sur" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Islas Caimán" },
+        "KZ": { "zoneName": "Kazajistán" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Líbano" },
+        "LC": { "zoneName": "Santa Lucía" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesoto" },
+        "LT": { "zoneName": "Lituania" },
+        "LU": { "zoneName": "Luxemburgo" },
+        "LV": { "zoneName": "Letonia" },
+        "LY": { "zoneName": "Libia" },
+        "MA": { "zoneName": "Marruecos" },
+        "MC": { "zoneName": "Mónaco" },
+        "MD": { "zoneName": "Moldavia" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Isla de San Martín", "zoneName": "Francia" },
+        "MG": { "zoneName": "Madagascar" },
+        "MH": { "zoneName": "Islas Marshall" },
+        "MK": { "zoneName": "Macedonia del Norte" },
+        "ML": { "zoneName": "Malí" },
+        "MM": { "zoneName": "Birmania" },
+        "MN": { "zoneName": "Mongolia" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Islas Marianas del Norte" },
+        "MQ": { "zoneName": "Martinica" },
+        "MR": { "zoneName": "Mauritania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauricio" },
+        "MV": { "zoneName": "Maldivas" },
+        "MW": { "zoneName": "Malaui" },
+        "MX": { "zoneName": "México" },
+        "MX-BC": { "countryName": "México", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "México", "zoneName": "Central" },
+        "MX-NE": { "countryName": "México", "zoneName": "Noreste" },
+        "MX-NO": { "countryName": "México", "zoneName": "Norte" },
+        "MX-NW": { "countryName": "México", "zoneName": "Noroeste" },
+        "MX-OC": { "countryName": "México", "zoneName": "Occidental" },
+        "MX-OR": { "countryName": "México", "zoneName": "Oriental" },
+        "MX-PN": { "countryName": "México", "zoneName": "Peninsula" },
+        "MY-EM": { "countryName": "Malasia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malasia", "zoneName": "Península" },
+        "MZ": { "zoneName": "Mozambique" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "Nueva Caledonia" },
+        "NE": { "zoneName": "Níger" },
+        "NF": { "zoneName": "Isla Norfolk" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Alto Karabaj" },
+        "NL": { "zoneName": "Holanda" },
+        "NO-NO1": { "countryName": "Noruega", "zoneName": "Sureste" },
+        "NO-NO2": { "countryName": "Noruega", "zoneName": "Suroeste" },
+        "NO-NO3": { "countryName": "Noruega", "zoneName": "Centro" },
+        "NO-NO4": { "countryName": "Noruega", "zoneName": "Norte" },
+        "NO-NO5": { "countryName": "Noruega", "zoneName": "Oeste" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Nueva Zelanda" },
+        "NZ-NZA": { "countryName": "Nueva Zelanda", "zoneName": "Islas Auckland" },
+        "NZ-NZC": { "countryName": "Nueva Zelanda", "zoneName": "Islas Chatham" },
+        "OM": { "zoneName": "Omán" },
+        "PA": { "zoneName": "Panamá" },
+        "PE": { "zoneName": "Perú" },
+        "PF": { "zoneName": "Polinesia Francesa" },
+        "PG": { "zoneName": "Papúa Nueva Guinea" },
+        "PH": { "zoneName": "Filipinas" },
+        "PK": { "zoneName": "Pakistán" },
+        "PL": { "zoneName": "Polonia" },
+        "PM": { "zoneName": "San Pedro y Miquelón" },
+        "PN": { "zoneName": "Islas Pitcairn" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Palestina" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Azores" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Catar" },
+        "RE": { "zoneName": "Reunión" },
+        "RO": { "zoneName": "Rumanía" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Rusia" },
+        "RU-1": { "countryName": "Rusia", "zoneName": "Rusia europea y Urales" },
+        "RU-2": { "countryName": "Rusia", "zoneName": "Siberia" },
+        "RU-AS": { "zoneName": "Rusia" },
+        "RU-EU": { "zoneName": "Rusia" },
+        "RU-KGD": { "countryName": "Rusia", "zoneName": "Kaliningrado" },
+        "RW": { "zoneName": "Ruanda" },
+        "SA": { "zoneName": "Arabia Saudí" },
+        "SB": { "zoneName": "Islas Salomón" },
+        "SC": { "zoneName": "Seychelles" },
+        "SD": { "zoneName": "Sudán" },
+        "SE": { "zoneName": "Suecia" },
+        "SG": { "zoneName": "Singapur" },
+        "SH": { "zoneName": "Santa Elena, Ascensión y Tristán de Acuña" },
+        "SI": { "zoneName": "Eslovenia" },
+        "SJ": { "zoneName": "Svalbard y Jan Mayen" },
+        "SK": { "zoneName": "Eslovaquia" },
+        "SL": { "zoneName": "Sierra Leona" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Surinam" },
+        "SS": { "zoneName": "Sudán del Sur" },
+        "ST": { "zoneName": "Santo Tomé y Príncipe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Países Bajos" },
+        "SY": { "zoneName": "Siria" },
+        "SZ": { "zoneName": "Suazilandia" },
+        "TC": { "zoneName": "Islas Turcas y Caicos" },
+        "TD": { "zoneName": "Chad" },
+        "TF": { "zoneName": "Territorios Australes Franceses" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Tailandia" },
+        "TJ": { "zoneName": "Tayikistán" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor Oriental" },
+        "TM": { "zoneName": "Turkmenistán" },
+        "TN": { "zoneName": "Túnez" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turquía" },
+        "TT": { "zoneName": "Trinidad y Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwán" },
+        "TZ": { "zoneName": "Tanzania" },
+        "UA": { "zoneName": "Ucrania" },
+        "UA-CR": { "countryName": "Ucrania", "zoneName": "Crimea" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Islas Ultramarinas Menores de Estados Unidos" },
+        "US-HI": { "countryName": "Estados Unidos", "zoneName": "Hawái" },
+        "US-HI-KA": { "countryName": "Estados Unidos", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Estados Unidos", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Estados Unidos", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Estados Unidos", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Estados Unidos", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Estados Unidos", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Estados Unidos", "zoneName": "Oahu" },
+        "US-CAL-BANC": { "countryName": "Estados Unidos", "zoneName": "Balancing Authority Of Northern California" },
+        "US-CAL-CISO": { "countryName": "Estados Unidos", "zoneName": "California Independent System Operator" },
+        "US-CAL-IID": { "countryName": "Estados Unidos", "zoneName": "Imperial Irrigation District" },
+        "US-CAL-LDWP": { "countryName": "Estados Unidos", "zoneName": "Los Angeles Department Of Water And Power" },
+        "US-CAL-TIDC": { "countryName": "Estados Unidos", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "Estados Unidos", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "Estados Unidos", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "Estados Unidos", "zoneName": "Duke Energy Carolinas" },
+        "US-CAR-SC": { "countryName": "Estados Unidos", "zoneName": "South Carolina Public Service Authority" },
+        "US-CAR-SCEG": { "countryName": "Estados Unidos", "zoneName": "South Carolina Electric & Gas Company" },
+        "US-CAR-YAD": { "countryName": "Estados Unidos", "zoneName": "Alcoa Power Generating, Inc. Yadkin Division" },
+        "US-CENT-SPA": { "countryName": "Estados Unidos", "zoneName": "Southwestern Power Administration" },
+        "US-CENT-SWPP": { "countryName": "Estados Unidos", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "Estados Unidos", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "Estados Unidos", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "Estados Unidos", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "Estados Unidos", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "Estados Unidos", "zoneName": "Ciudad de Homestead" },
+        "US-FLA-JEA": { "countryName": "Estados Unidos", "zoneName": "JEA" },
+        "US-FLA-NSB": { "countryName": "Estados Unidos", "zoneName": "Utilities Commission Of New Smyrna Beach" },
+        "US-FLA-SEC": { "countryName": "Estados Unidos", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "Estados Unidos", "zoneName": "Ciudad de Tallahassee" },
+        "US-FLA-TEC": { "countryName": "Estados Unidos", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "Estados Unidos", "zoneName": "PJM Interconnection, Llc" },
+        "US-MIDW-AECI": { "countryName": "Estados Unidos", "zoneName": "Associated Electric Cooperative, Inc." },
+        "US-MIDW-GLHB": { "countryName": "Estados Unidos", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "Estados Unidos",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1497,78 +575,24 @@
             "countryName": "Estados Unidos",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc.."
         },
-        "US-NE-ISNE": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "Estados Unidos",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "Estados Unidos",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
-        "US-NW-GCPD": {
-            "countryName": "Estados Unidos",
-            "zoneName": "PUD No. 2 Of Grant County, Washington"
-        },
-        "US-NW-GRID": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Portland General Electric Company"
-        },
-        "US-NW-PSCO": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Public Service Company Of Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NE-ISNE": { "countryName": "Estados Unidos", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "Estados Unidos", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "Estados Unidos", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "Estados Unidos", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "Estados Unidos", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "Estados Unidos", "zoneName": "PUD No. 1 Of Douglas County" },
+        "US-NW-GCPD": { "countryName": "Estados Unidos", "zoneName": "PUD No. 2 Of Grant County, Washington" },
+        "US-NW-GRID": { "countryName": "Estados Unidos", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "Estados Unidos", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "Estados Unidos", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "Estados Unidos", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "Estados Unidos", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "Estados Unidos", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "Estados Unidos", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "Estados Unidos", "zoneName": "Portland General Electric Company" },
+        "US-NW-PSCO": { "countryName": "Estados Unidos", "zoneName": "Public Service Company Of Colorado" },
+        "US-NW-PSEI": { "countryName": "Estados Unidos", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "Estados Unidos", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "Estados Unidos",
             "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
@@ -1577,130 +601,43 @@
             "countryName": "Estados Unidos",
             "zoneName": "Western Area Power Administration - Rocky Mountain Region"
         },
-        "US-NW-WAUW": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Western Area Power Administration UGP West"
-        },
-        "US-NW-WWA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "Estados Unidos",
-            "zoneName": "New York Independent System Operator"
-        },
-        "US-SE-AEC": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Southeastern Power Administration"
-        },
-        "US-SE-SOCO": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Southern Company Services, Inc. - Trans"
-        },
-        "US-SW-AZPS": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "Estados Unidos",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Gila River Power, LLC"
-        },
-        "US-SW-HGMA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "New Harquahala Generating Company, LLC"
-        },
-        "US-SW-PNM": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Public Service Company Of New Mexico"
-        },
-        "US-SW-SRP": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-NW-WAUW": { "countryName": "Estados Unidos", "zoneName": "Western Area Power Administration UGP West" },
+        "US-NW-WWA": { "countryName": "Estados Unidos", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "Estados Unidos", "zoneName": "New York Independent System Operator" },
+        "US-SE-AEC": { "countryName": "Estados Unidos", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "Estados Unidos", "zoneName": "Southeastern Power Administration" },
+        "US-SE-SOCO": { "countryName": "Estados Unidos", "zoneName": "Southern Company Services, Inc. - Trans" },
+        "US-SW-AZPS": { "countryName": "Estados Unidos", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "Estados Unidos", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "Estados Unidos", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "Estados Unidos", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "Estados Unidos", "zoneName": "Gila River Power, LLC" },
+        "US-SW-HGMA": { "countryName": "Estados Unidos", "zoneName": "New Harquahala Generating Company, LLC" },
+        "US-SW-PNM": { "countryName": "Estados Unidos", "zoneName": "Public Service Company Of New Mexico" },
+        "US-SW-SRP": { "countryName": "Estados Unidos", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "Estados Unidos", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "Estados Unidos",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Tennessee Valley Authority"
-        },
-        "US-TEX-ERCO": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Electric Reliability Council Of Texas, Inc."
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistán"
-        },
-        "VA": {
-            "zoneName": "Ciudad del Vaticano"
-        },
-        "VC": {
-            "zoneName": "San Vicente y las Granadinas"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Islas Vírgenes",
-            "zoneName": "Islas Vírgenes"
-        },
-        "VI": {
-            "countryName": "Estados Unidos",
-            "zoneName": "Islas Vírgenes"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis y Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Chipre del Norte"
-        },
-        "YE": {
-            "zoneName": "Yemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Sudáfrica"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabue"
-        }
+        "US-TEN-TVA": { "countryName": "Estados Unidos", "zoneName": "Tennessee Valley Authority" },
+        "US-TEX-ERCO": { "countryName": "Estados Unidos", "zoneName": "Electric Reliability Council Of Texas, Inc." },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistán" },
+        "VA": { "zoneName": "Ciudad del Vaticano" },
+        "VC": { "zoneName": "San Vicente y las Granadinas" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Islas Vírgenes", "zoneName": "Islas Vírgenes" },
+        "VI": { "countryName": "Estados Unidos", "zoneName": "Islas Vírgenes" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis y Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Chipre del Norte" },
+        "YE": { "zoneName": "Yemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Sudáfrica" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabue" }
     }
 }

--- a/web/public/locales/et.json
+++ b/web/public/locales/et.json
@@ -6,15 +6,9 @@
         "datasources": "andmeallikaid",
         "contribute": "Aidake kaasa <a href=\"%s\" target=\"_blank\">lisades enda piirkond</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Piirkonnad",
-        "about": "Teave"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Piirkonnad", "about": "Teave" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Elektrienergia kliimamõju kaardistamine"
-        },
+        "view1": { "subtitle": "Elektrienergia kliimamõju kaardistamine" },
         "view2": {
             "header": "Vaadake reaalajas, kui palju CO₂ eraldub teie elektri tootmiseks.",
             "text": "Värvime piirkondi ümber maailma vastavalt nende elektritarbimise süsiniku intensiivsuse järgi (sisaldab kõiki kasvuhoonegaase). Mida rohelisem värv, seda kliimasäästlikum elekter."
@@ -51,14 +45,14 @@
         "search": "Otsige piirkondi"
     },
     "country-history": {
-        "carbonintensity24h": "Süsiniku intensiivsus viimase 24 tunni jooksul",
-        "emissions24h": "Heitkogused viimase 24 tunni jooksul",
-        "emissionsorigin24h": "Heitkoguste päritolu viimase 24 tunni jooksul",
-        "emissionsproduction24h": "Tootmisel tekkinud heitmed viimase 24 tunni jooksul",
-        "electricityorigin24h": "Elektrienergia päritolu viimase 24 tunni jooksul",
-        "electricityproduction24h": "Elektritootmine viimase 24 tunni jooksul",
-        "electricityprices24h": "Elektrihinnad viimase 24 tunni jooksul",
-        "Getdata": "Hangi läbi electricityMap API tundide kaupa ajaloo, reaalaja ja prognoosi andmeid"
+        "Getdata": "Hangi läbi electricityMap API tundide kaupa ajaloo, reaalaja ja prognoosi andmeid",
+        "carbonintensity": { "hourly": "Süsiniku intensiivsus viimase 24 tunni jooksul" },
+        "emissionsorigin": { "hourly": "Heitkoguste päritolu viimase 24 tunni jooksul" },
+        "emissionsproduction": { "hourly": "Tootmisel tekkinud heitmed viimase 24 tunni jooksul" },
+        "electricityorigin": { "hourly": "Elektrienergia päritolu viimase 24 tunni jooksul" },
+        "electricityproduction": { "hourly": "Elektritootmine viimase 24 tunni jooksul" },
+        "electricityprices": { "hourly": "Elektrihinnad viimase 24 tunni jooksul" },
+        "emissions": { "hourly": "Heitkogused viimase 24 tunni jooksul" }
     },
     "footer": {
         "foundbugs": "Leidsite vea või teil on idee? Andke nendest teada",
@@ -197,1325 +191,401 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> avaldab andmed ja pildid <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> keskkonnas teavitustöö raames. Sellega ei kinnitata õigsust ega anda garantiid ja jäetakse õigus sisu igal ajal muuta või osasid eemaldada ilma, et peaksime teid sellest teavitama. electricityMap ei võta selle eest vastutust ega vastuta kahjude või kulude eest, mis võivad tekkida electricityMap'ist või nendest saadud teabe ebatäpsuse, puudulikkuse, enneaegsuse või aegumise tagajärjel.  Ilma ametliku eelneva kirjaliku nõusolekuta ei ole lubatud seda veebisaiti ega selle üksikuid elemente teistele veebisaitidele lisada.<br><br> Kõik omandiõigused kuuluvad õiguslikult omanikele ja selle litsentsiandjatele. Nende materjalide, eriti energiaandmete kopeerimine, levitamine ja mis tahes muu kasutamine ei ole lubatud ilma electricityMap'i kirjaliku loata, välja arvatud ja ainult juhul, kui imperatiivsete õigusnormide määrustes on sätestatud teisiti (näiteks õigus tsiteerida), kui ei ole konkreetsete materjalide puhul sätestatud teisiti. <br><br>Seda lahtiütlust võidakse aeg-ajalt uuendada."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Araabia Ühendemiraadid"
-        },
-        "AF": {
-            "zoneName": "Afganistan"
-        },
-        "AG": {
-            "zoneName": "Antigua ja Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albaania"
-        },
-        "AM": {
-            "zoneName": "Armeenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarktika"
-        },
-        "AS": {
-            "zoneName": "Ameerika Samoa"
-        },
-        "AT": {
-            "zoneName": "Austria"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AUS-NSW": {
-            "countryName": "Austraalia",
-            "zoneName": "Uus-Lõuna-Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Austraalia",
-            "zoneName": "Põhjaterritoorium"
-        },
-        "AUS-QLD": {
-            "countryName": "Austraalia",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Austraalia",
-            "zoneName": "Lõuna-Austraalia"
-        },
-        "AUS-TAS": {
-            "countryName": "Austraalia",
-            "zoneName": "Tasmaania"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Austraalia",
-            "zoneName": "King' saar"
-        },
-        "AUS-TAS-FI": {
-            "countryName": "Austraalia",
-            "zoneName": "Flindersi saar"
-        },
-        "AUS-TAS-CBI": {
-            "countryName": "Austraalia",
-            "zoneName": "Cape Barreni saar"
-        },
-        "AUS-VIC": {
-            "countryName": "Austraalia",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Austraalia",
-            "zoneName": "Lääne-Austraalia"
-        },
-        "AUS-WA-RI": {
-            "countryName": "Austraalia",
-            "zoneName": "Rottnesti saar"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Ahvenamaa"
-        },
-        "AZ": {
-            "zoneName": "Aserbaidžaan"
-        },
-        "BA": {
-            "zoneName": "Bosnia ja Hertsegoviina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Belgia"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgaaria"
-        },
-        "BH": {
-            "zoneName": "Bahrein"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Boliivia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius ja Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brasiilia",
-            "zoneName": "Kesk-Brasiilia"
-        },
-        "BR-N": {
-            "countryName": "Brasiilia",
-            "zoneName": "Põhja-Brasiilia"
-        },
-        "BR-NE": {
-            "countryName": "Brasiilia",
-            "zoneName": "Kirde-Brasiilia"
-        },
-        "BR-S": {
-            "countryName": "Brasiilia",
-            "zoneName": "Lõuna-Brasiilia"
-        },
-        "BS": {
-            "zoneName": "Bahama"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Bouvet' saar"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Valgevene"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "Briti Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland ja Labrador"
-        },
-        "CA-NL-LB": {
-            "countryName": "Kanada",
-            "zoneName": "Labrador"
-        },
-        "CA-NL-NF": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Loodealad"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Prints Edwardi saar"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Kookossaared"
-        },
-        "CD": {
-            "zoneName": "Kongo Demokraatlik Vabariik"
-        },
-        "CF": {
-            "zoneName": "Kesk-Aafrika Vabariik"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Šveits"
-        },
-        "CI": {
-            "zoneName": "Elevandiluurannik"
-        },
-        "CK": {
-            "zoneName": "Cooki saared"
-        },
-        "CL-SEA": {
-            "countryName": "Tšilli",
-            "zoneName": "SEA"
-        },
-        "CL-SEM": {
-            "countryName": "Tšilli",
-            "zoneName": "SEM"
-        },
-        "CL-SEN": {
-            "countryName": "Tšilli",
-            "zoneName": "SEN"
-        },
-        "CL-CHP": {
-            "countryName": "Tšilli",
-            "zoneName": "Lihavõttesaar"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Hiina"
-        },
-        "CO": {
-            "zoneName": "Kolumbia"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Kuuba"
-        },
-        "CV": {
-            "zoneName": "Cabo Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Jõulusaar"
-        },
-        "CY": {
-            "zoneName": "Küpros"
-        },
-        "CZ": {
-            "zoneName": "Tšehhi"
-        },
-        "DE": {
-            "zoneName": "Saksamaa"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Taani"
-        },
-        "DK-DK1": {
-            "countryName": "Taani",
-            "zoneName": "Lääne-Taani"
-        },
-        "DK-DK2": {
-            "countryName": "Taani",
-            "zoneName": "Ida-Taani"
-        },
-        "DK-BHM": {
-            "countryName": "Taani",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "Dominikaani Vabariik"
-        },
-        "DZ": {
-            "zoneName": "Alžeeria"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Eesti"
-        },
-        "EG": {
-            "zoneName": "Egiptus"
-        },
-        "EH": {
-            "zoneName": "Lääne-Sahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Hispaania"
-        },
-        "ES-IB-FO": {
-            "countryName": "Hispaania",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Hispaania",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Hispaania",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Hispaania",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Hispaania",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Hispaania",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Hispaania",
-            "zoneName": "Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Hispaania",
-            "zoneName": "Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Hispaania",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Hispaania",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Etioopia"
-        },
-        "FI": {
-            "zoneName": "Soome"
-        },
-        "FJ": {
-            "zoneName": "Fidži"
-        },
-        "FK": {
-            "zoneName": "Falklandi saared"
-        },
-        "FM": {
-            "zoneName": "Mikroneesia"
-        },
-        "FO": {
-            "zoneName": "Fääri saared"
-        },
-        "FR": {
-            "zoneName": "Prantsusmaa"
-        },
-        "FR-COR": {
-            "countryName": "Prantsusmaa",
-            "zoneName": "Korsika"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Suurbritannia"
-        },
-        "GB-NIR": {
-            "zoneName": "Põhja-Iirimaa"
-        },
-        "GB-ORK": {
-            "countryName": "Suurbritannia",
-            "zoneName": "Orkney saared"
-        },
-        "GB-SHI": {
-            "countryName": "Suurbritannia",
-            "zoneName": "Shetlandi saared"
-        },
-        "GB-ZET": {
-            "countryName": "Suurbritannia",
-            "zoneName": "Shetlandi saared"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgia"
-        },
-        "GF": {
-            "zoneName": "Prantsuse Guajaana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Gröönimaa"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Ekvatoriaal-Guinea"
-        },
-        "GR": {
-            "zoneName": "Kreeka"
-        },
-        "GR-IS": {
-            "countryName": "Kreeka",
-            "zoneName": "Egeuse saared"
-        },
-        "GS": {
-            "zoneName": "Lõuna-Georgia ja Lõuna-Sandwichi saared"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Heardi ja McDonaldi saarte ala"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Horvaatia"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Ungari"
-        },
-        "ID": {
-            "zoneName": "Indoneesia"
-        },
-        "IE": {
-            "zoneName": "Iirimaa"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Man"
-        },
-        "IN-AN": {
-            "countryName": "India",
-            "zoneName": "Andamanid ja Nicobarid"
-        },
-        "IN-AP": {
-            "countryName": "India",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "India",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "India",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "India",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "India",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "India",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "India",
-            "zoneName": "Dadra ja Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "India",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "India",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "India",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "India",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "India",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "India",
-            "zoneName": "Jammu ja Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "India",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "India",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "India",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "India",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "India",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "India",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "India",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "India",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "India",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "India",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "India",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "India",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "India",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "India",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "India",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "India",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "India",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "India",
-            "zoneName": "Lääne-Bengali"
-        },
-        "IO": {
-            "zoneName": "Briti India ookeani ala"
-        },
-        "IQ": {
-            "zoneName": "Iraak"
-        },
-        "IQ-KUR": {
-            "countryName": "Iraak",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iraan"
-        },
-        "IS": {
-            "zoneName": "Island"
-        },
-        "IT": {
-            "zoneName": "Itaalia"
-        },
-        "IT-CNO": {
-            "countryName": "Itaalia",
-            "zoneName": "Põhja keskosa"
-        },
-        "IT-CSO": {
-            "countryName": "Itaalia",
-            "zoneName": "Lõuna keskosa"
-        },
-        "IT-NO": {
-            "countryName": "Itaalia",
-            "zoneName": "Põhi"
-        },
-        "IT-SAR": {
-            "countryName": "Itaalia",
-            "zoneName": "Sardinia"
-        },
-        "IT-SIC": {
-            "countryName": "Itaalia",
-            "zoneName": "Sicily"
-        },
-        "IT-SO": {
-            "countryName": "Itaalia",
-            "zoneName": "Lõuna"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaica"
-        },
-        "JO": {
-            "zoneName": "Jordaania"
-        },
-        "JP-CB": {
-            "countryName": "Jaapan",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Jaapan",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Jaapan",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Jaapan",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Jaapan",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Jaapan",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Jaapan",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Jaapan",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Jaapan",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Jaapan",
-            "zoneName": "Tōkyō"
-        },
-        "KE": {
-            "zoneName": "Keenia"
-        },
-        "KG": {
-            "zoneName": "Kõrgõzstan"
-        },
-        "KH": {
-            "zoneName": "Kambodža"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Komoorid"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts ja Nevis"
-        },
-        "KP": {
-            "zoneName": "Põhja-Korea"
-        },
-        "KR": {
-            "zoneName": "Lõuna-Korea"
-        },
-        "KW": {
-            "zoneName": "Kuveit"
-        },
-        "KY": {
-            "zoneName": "Kaimanisaared"
-        },
-        "KZ": {
-            "zoneName": "Kasahstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Liibanon"
-        },
-        "LC": {
-            "zoneName": "Saint Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Libeeria"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Leedu"
-        },
-        "LU": {
-            "zoneName": "Luksemburg"
-        },
-        "LV": {
-            "zoneName": "Läti"
-        },
-        "LY": {
-            "zoneName": "Liibüa"
-        },
-        "MA": {
-            "zoneName": "Maroko"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldova"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Saint-Martin",
-            "zoneName": "Prantsusmaa"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Marshalli Saared"
-        },
-        "MK": {
-            "zoneName": "Põhja-Makedoonia"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Mongoolia"
-        },
-        "MO": {
-            "zoneName": "Macau"
-        },
-        "MP": {
-            "zoneName": "Põhja-Mariaanid"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritaania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Maldiivid"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mehhiko"
-        },
-        "MX-BC": {
-            "countryName": "Mehhiko",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mehhiko",
-            "zoneName": "Kesk"
-        },
-        "MX-NE": {
-            "countryName": "Mehhiko",
-            "zoneName": "Kirre"
-        },
-        "MX-NO": {
-            "countryName": "Mehhiko",
-            "zoneName": "Põhi"
-        },
-        "MX-NW": {
-            "countryName": "Mehhiko",
-            "zoneName": "Loe"
-        },
-        "MX-OC": {
-            "countryName": "Mehhiko",
-            "zoneName": "Lääs"
-        },
-        "MX-OR": {
-            "countryName": "Mehhiko",
-            "zoneName": "Ida"
-        },
-        "MX-PN": {
-            "countryName": "Mehhiko",
-            "zoneName": "Peninsula"
-        },
-        "MY-EM": {
-            "countryName": "Malaisia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malaisia",
-            "zoneName": "Peninsula"
-        },
-        "MZ": {
-            "zoneName": "Mosambiik"
-        },
-        "NA": {
-            "zoneName": "Namiibia"
-        },
-        "NC": {
-            "zoneName": "Uus-Kaledoonia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolki saar"
-        },
-        "NG": {
-            "zoneName": "Nigeeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Mägi-Karabahh"
-        },
-        "NL": {
-            "zoneName": "Holland"
-        },
-        "NO-NO1": {
-            "countryName": "Norra",
-            "zoneName": "Kagu-Norra"
-        },
-        "NO-NO2": {
-            "countryName": "Norra",
-            "zoneName": "Edela-Norra"
-        },
-        "NO-NO3": {
-            "countryName": "Norra",
-            "zoneName": "Kesk-Norra"
-        },
-        "NO-NO4": {
-            "countryName": "Norra",
-            "zoneName": "Põhja-Norra"
-        },
-        "NO-NO5": {
-            "countryName": "Norra",
-            "zoneName": "Lääne-Norra"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Uus-Meremaa"
-        },
-        "NZ-NZA": {
-            "countryName": "Uus-Meremaa",
-            "zoneName": "Aucklandi saared"
-        },
-        "NZ-NZC": {
-            "countryName": "Uus-Meremaa",
-            "zoneName": "Chathami saared"
-        },
-        "NZ-NZST": {
-            "countryName": "Uus-Meremaa",
-            "zoneName": "Stewarti saar"
-        },
-        "OM": {
-            "zoneName": "Omaan"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peruu"
-        },
-        "PF": {
-            "zoneName": "Prantsuse Polüneesia"
-        },
-        "PG": {
-            "zoneName": "Paapua Uus-Guinea"
-        },
-        "PH": {
-            "zoneName": "Filipiinid"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Poola"
-        },
-        "PM": {
-            "zoneName": "Saint-Pierre ja Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Palestiina riik"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Assoorid"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Belau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Katar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Rumeenia"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Venemaa"
-        },
-        "RU-1": {
-            "countryName": "Venemaa",
-            "zoneName": "Venemaa Euroopa-osa ja Uural"
-        },
-        "RU-2": {
-            "countryName": "Venemaa",
-            "zoneName": "Siber"
-        },
-        "RU-EU": {
-            "zoneName": "Venemaa"
-        },
-        "RU-AS": {
-            "zoneName": "Venemaa"
-        },
-        "RU-KGD": {
-            "countryName": "Venemaa",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Saudi Araabia"
-        },
-        "SB": {
-            "zoneName": "Saalomoni Saared"
-        },
-        "SC": {
-            "zoneName": "Seišellid"
-        },
-        "SD": {
-            "zoneName": "Sudaan"
-        },
-        "SE": {
-            "zoneName": "Rootsi"
-        },
-        "SG": {
-            "zoneName": "Singapur"
-        },
-        "SH": {
-            "zoneName": "Saint Helena, Ascension ja Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Sloveenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard ja Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovakkia"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somaalia"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Lõuna-Sudaan"
-        },
-        "ST": {
-            "zoneName": "Sao Tome ja Principe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Holland"
-        },
-        "SY": {
-            "zoneName": "Süüria"
-        },
-        "SZ": {
-            "zoneName": "Svaasimaa"
-        },
-        "TC": {
-            "zoneName": "Turks ja Caicos"
-        },
-        "TD": {
-            "zoneName": "Tšaad"
-        },
-        "TF": {
-            "zoneName": "Prantsuse Lõunaalad"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Tai"
-        },
-        "TJ": {
-            "zoneName": "Tadžikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Türkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tuneesia"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Türgi"
-        },
-        "TT": {
-            "zoneName": "Trinidad ja Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tansaania"
-        },
-        "UA": {
-            "zoneName": "Ukraina"
-        },
-        "UA-CR": {
-            "countryName": "Krimm",
-            "zoneName": "Ukraina"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Ühendriikide hajasaared"
-        },
-        "US-HI-HA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Oahu"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Araabia Ühendemiraadid" },
+        "AF": { "zoneName": "Afganistan" },
+        "AG": { "zoneName": "Antigua ja Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albaania" },
+        "AM": { "zoneName": "Armeenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarktika" },
+        "AS": { "zoneName": "Ameerika Samoa" },
+        "AT": { "zoneName": "Austria" },
+        "AR": { "zoneName": "Argentina" },
+        "AUS-NSW": { "countryName": "Austraalia", "zoneName": "Uus-Lõuna-Wales" },
+        "AUS-NT": { "countryName": "Austraalia", "zoneName": "Põhjaterritoorium" },
+        "AUS-QLD": { "countryName": "Austraalia", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Austraalia", "zoneName": "Lõuna-Austraalia" },
+        "AUS-TAS": { "countryName": "Austraalia", "zoneName": "Tasmaania" },
+        "AUS-TAS-KI": { "countryName": "Austraalia", "zoneName": "King' saar" },
+        "AUS-TAS-FI": { "countryName": "Austraalia", "zoneName": "Flindersi saar" },
+        "AUS-TAS-CBI": { "countryName": "Austraalia", "zoneName": "Cape Barreni saar" },
+        "AUS-VIC": { "countryName": "Austraalia", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Austraalia", "zoneName": "Lääne-Austraalia" },
+        "AUS-WA-RI": { "countryName": "Austraalia", "zoneName": "Rottnesti saar" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Ahvenamaa" },
+        "AZ": { "zoneName": "Aserbaidžaan" },
+        "BA": { "zoneName": "Bosnia ja Hertsegoviina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Belgia" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgaaria" },
+        "BH": { "zoneName": "Bahrein" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Boliivia" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius ja Saba" },
+        "BR-CS": { "countryName": "Brasiilia", "zoneName": "Kesk-Brasiilia" },
+        "BR-N": { "countryName": "Brasiilia", "zoneName": "Põhja-Brasiilia" },
+        "BR-NE": { "countryName": "Brasiilia", "zoneName": "Kirde-Brasiilia" },
+        "BR-S": { "countryName": "Brasiilia", "zoneName": "Lõuna-Brasiilia" },
+        "BS": { "zoneName": "Bahama" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Bouvet' saar" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Valgevene" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "Briti Columbia" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland ja Labrador" },
+        "CA-NL-LB": { "countryName": "Kanada", "zoneName": "Labrador" },
+        "CA-NL-NF": { "countryName": "Kanada", "zoneName": "Newfoundland" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "New Brunswick" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Loodealad" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nova Scotia" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Prints Edwardi saar" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Kookossaared" },
+        "CD": { "zoneName": "Kongo Demokraatlik Vabariik" },
+        "CF": { "zoneName": "Kesk-Aafrika Vabariik" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Šveits" },
+        "CI": { "zoneName": "Elevandiluurannik" },
+        "CK": { "zoneName": "Cooki saared" },
+        "CL-SEA": { "countryName": "Tšilli", "zoneName": "SEA" },
+        "CL-SEM": { "countryName": "Tšilli", "zoneName": "SEM" },
+        "CL-SEN": { "countryName": "Tšilli", "zoneName": "SEN" },
+        "CL-CHP": { "countryName": "Tšilli", "zoneName": "Lihavõttesaar" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Hiina" },
+        "CO": { "zoneName": "Kolumbia" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Kuuba" },
+        "CV": { "zoneName": "Cabo Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Jõulusaar" },
+        "CY": { "zoneName": "Küpros" },
+        "CZ": { "zoneName": "Tšehhi" },
+        "DE": { "zoneName": "Saksamaa" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Taani" },
+        "DK-DK1": { "countryName": "Taani", "zoneName": "Lääne-Taani" },
+        "DK-DK2": { "countryName": "Taani", "zoneName": "Ida-Taani" },
+        "DK-BHM": { "countryName": "Taani", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "Dominikaani Vabariik" },
+        "DZ": { "zoneName": "Alžeeria" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Eesti" },
+        "EG": { "zoneName": "Egiptus" },
+        "EH": { "zoneName": "Lääne-Sahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Hispaania" },
+        "ES-IB-FO": { "countryName": "Hispaania", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Hispaania", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Hispaania", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Hispaania", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Hispaania", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Hispaania", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Hispaania", "zoneName": "Hierro" },
+        "ES-CN-IG": { "countryName": "Hispaania", "zoneName": "Gomera" },
+        "ES-CN-LP": { "countryName": "Hispaania", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Hispaania", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Etioopia" },
+        "FI": { "zoneName": "Soome" },
+        "FJ": { "zoneName": "Fidži" },
+        "FK": { "zoneName": "Falklandi saared" },
+        "FM": { "zoneName": "Mikroneesia" },
+        "FO": { "zoneName": "Fääri saared" },
+        "FR": { "zoneName": "Prantsusmaa" },
+        "FR-COR": { "countryName": "Prantsusmaa", "zoneName": "Korsika" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Suurbritannia" },
+        "GB-NIR": { "zoneName": "Põhja-Iirimaa" },
+        "GB-ORK": { "countryName": "Suurbritannia", "zoneName": "Orkney saared" },
+        "GB-SHI": { "countryName": "Suurbritannia", "zoneName": "Shetlandi saared" },
+        "GB-ZET": { "countryName": "Suurbritannia", "zoneName": "Shetlandi saared" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgia" },
+        "GF": { "zoneName": "Prantsuse Guajaana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Gröönimaa" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Ekvatoriaal-Guinea" },
+        "GR": { "zoneName": "Kreeka" },
+        "GR-IS": { "countryName": "Kreeka", "zoneName": "Egeuse saared" },
+        "GS": { "zoneName": "Lõuna-Georgia ja Lõuna-Sandwichi saared" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Heardi ja McDonaldi saarte ala" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Horvaatia" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Ungari" },
+        "ID": { "zoneName": "Indoneesia" },
+        "IE": { "zoneName": "Iirimaa" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Man" },
+        "IN-AN": { "countryName": "India", "zoneName": "Andamanid ja Nicobarid" },
+        "IN-AP": { "countryName": "India", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "India", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "India", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "India", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "India", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "India", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "India", "zoneName": "Dadra ja Nagar Haveli" },
+        "IN-GA": { "countryName": "India", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "India", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "India", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "India", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "India", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "India", "zoneName": "Jammu ja Kashmir" },
+        "IN-KA": { "countryName": "India", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "India", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "India", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "India", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "India", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "India", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "India", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "India", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "India", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "India", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "India", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "India", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "India", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "India", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "India", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "India", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "India", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "India", "zoneName": "Lääne-Bengali" },
+        "IO": { "zoneName": "Briti India ookeani ala" },
+        "IQ": { "zoneName": "Iraak" },
+        "IQ-KUR": { "countryName": "Iraak", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iraan" },
+        "IS": { "zoneName": "Island" },
+        "IT": { "zoneName": "Itaalia" },
+        "IT-CNO": { "countryName": "Itaalia", "zoneName": "Põhja keskosa" },
+        "IT-CSO": { "countryName": "Itaalia", "zoneName": "Lõuna keskosa" },
+        "IT-NO": { "countryName": "Itaalia", "zoneName": "Põhi" },
+        "IT-SAR": { "countryName": "Itaalia", "zoneName": "Sardinia" },
+        "IT-SIC": { "countryName": "Itaalia", "zoneName": "Sicily" },
+        "IT-SO": { "countryName": "Itaalia", "zoneName": "Lõuna" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaica" },
+        "JO": { "zoneName": "Jordaania" },
+        "JP-CB": { "countryName": "Jaapan", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Jaapan", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Jaapan", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Jaapan", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Jaapan", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Jaapan", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Jaapan", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Jaapan", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Jaapan", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Jaapan", "zoneName": "Tōkyō" },
+        "KE": { "zoneName": "Keenia" },
+        "KG": { "zoneName": "Kõrgõzstan" },
+        "KH": { "zoneName": "Kambodža" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Komoorid" },
+        "KN": { "zoneName": "Saint Kitts ja Nevis" },
+        "KP": { "zoneName": "Põhja-Korea" },
+        "KR": { "zoneName": "Lõuna-Korea" },
+        "KW": { "zoneName": "Kuveit" },
+        "KY": { "zoneName": "Kaimanisaared" },
+        "KZ": { "zoneName": "Kasahstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Liibanon" },
+        "LC": { "zoneName": "Saint Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Libeeria" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Leedu" },
+        "LU": { "zoneName": "Luksemburg" },
+        "LV": { "zoneName": "Läti" },
+        "LY": { "zoneName": "Liibüa" },
+        "MA": { "zoneName": "Maroko" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldova" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Saint-Martin", "zoneName": "Prantsusmaa" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Marshalli Saared" },
+        "MK": { "zoneName": "Põhja-Makedoonia" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Mongoolia" },
+        "MO": { "zoneName": "Macau" },
+        "MP": { "zoneName": "Põhja-Mariaanid" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritaania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Maldiivid" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mehhiko" },
+        "MX-BC": { "countryName": "Mehhiko", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mehhiko", "zoneName": "Kesk" },
+        "MX-NE": { "countryName": "Mehhiko", "zoneName": "Kirre" },
+        "MX-NO": { "countryName": "Mehhiko", "zoneName": "Põhi" },
+        "MX-NW": { "countryName": "Mehhiko", "zoneName": "Loe" },
+        "MX-OC": { "countryName": "Mehhiko", "zoneName": "Lääs" },
+        "MX-OR": { "countryName": "Mehhiko", "zoneName": "Ida" },
+        "MX-PN": { "countryName": "Mehhiko", "zoneName": "Peninsula" },
+        "MY-EM": { "countryName": "Malaisia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malaisia", "zoneName": "Peninsula" },
+        "MZ": { "zoneName": "Mosambiik" },
+        "NA": { "zoneName": "Namiibia" },
+        "NC": { "zoneName": "Uus-Kaledoonia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolki saar" },
+        "NG": { "zoneName": "Nigeeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Mägi-Karabahh" },
+        "NL": { "zoneName": "Holland" },
+        "NO-NO1": { "countryName": "Norra", "zoneName": "Kagu-Norra" },
+        "NO-NO2": { "countryName": "Norra", "zoneName": "Edela-Norra" },
+        "NO-NO3": { "countryName": "Norra", "zoneName": "Kesk-Norra" },
+        "NO-NO4": { "countryName": "Norra", "zoneName": "Põhja-Norra" },
+        "NO-NO5": { "countryName": "Norra", "zoneName": "Lääne-Norra" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Uus-Meremaa" },
+        "NZ-NZA": { "countryName": "Uus-Meremaa", "zoneName": "Aucklandi saared" },
+        "NZ-NZC": { "countryName": "Uus-Meremaa", "zoneName": "Chathami saared" },
+        "NZ-NZST": { "countryName": "Uus-Meremaa", "zoneName": "Stewarti saar" },
+        "OM": { "zoneName": "Omaan" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peruu" },
+        "PF": { "zoneName": "Prantsuse Polüneesia" },
+        "PG": { "zoneName": "Paapua Uus-Guinea" },
+        "PH": { "zoneName": "Filipiinid" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Poola" },
+        "PM": { "zoneName": "Saint-Pierre ja Miquelon" },
+        "PN": { "zoneName": "Pitcairn" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Palestiina riik" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Assoorid" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Belau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Katar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Rumeenia" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Venemaa" },
+        "RU-1": { "countryName": "Venemaa", "zoneName": "Venemaa Euroopa-osa ja Uural" },
+        "RU-2": { "countryName": "Venemaa", "zoneName": "Siber" },
+        "RU-EU": { "zoneName": "Venemaa" },
+        "RU-AS": { "zoneName": "Venemaa" },
+        "RU-KGD": { "countryName": "Venemaa", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Saudi Araabia" },
+        "SB": { "zoneName": "Saalomoni Saared" },
+        "SC": { "zoneName": "Seišellid" },
+        "SD": { "zoneName": "Sudaan" },
+        "SE": { "zoneName": "Rootsi" },
+        "SG": { "zoneName": "Singapur" },
+        "SH": { "zoneName": "Saint Helena, Ascension ja Tristan da Cunha" },
+        "SI": { "zoneName": "Sloveenia" },
+        "SJ": { "zoneName": "Svalbard ja Jan Mayen" },
+        "SK": { "zoneName": "Slovakkia" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somaalia" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Lõuna-Sudaan" },
+        "ST": { "zoneName": "Sao Tome ja Principe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Holland" },
+        "SY": { "zoneName": "Süüria" },
+        "SZ": { "zoneName": "Svaasimaa" },
+        "TC": { "zoneName": "Turks ja Caicos" },
+        "TD": { "zoneName": "Tšaad" },
+        "TF": { "zoneName": "Prantsuse Lõunaalad" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Tai" },
+        "TJ": { "zoneName": "Tadžikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Türkmenistan" },
+        "TN": { "zoneName": "Tuneesia" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Türgi" },
+        "TT": { "zoneName": "Trinidad ja Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tansaania" },
+        "UA": { "zoneName": "Ukraina" },
+        "UA-CR": { "countryName": "Krimm", "zoneName": "Ukraina" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Ühendriikide hajasaared" },
+        "US-HI-HA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Ameerika Ühendriigid", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Ameerika Ühendriigid", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Ameerika Ühendriigid", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Oahu" },
         "US-CAL-BANC": {
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "Balancing Authority Of Northern California"
         },
-        "US-CAL-CISO": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "California Independent System Operator"
-        },
-        "US-CAL-IID": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Imperial Irrigation District"
-        },
+        "US-CAL-CISO": { "countryName": "Ameerika Ühendriigid", "zoneName": "California Independent System Operator" },
+        "US-CAL-IID": { "countryName": "Ameerika Ühendriigid", "zoneName": "Imperial Irrigation District" },
         "US-CAL-LDWP": {
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "Los Angeles Department Of Water And Power"
         },
-        "US-CAL-TIDC": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Duke Energy Carolinas"
-        },
-        "US-CAR-SC": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "South Carolina Public Service Authority"
-        },
-        "US-CAR-SCEG": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "South Carolina Electric & Gas Company"
-        },
+        "US-CAL-TIDC": { "countryName": "Ameerika Ühendriigid", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "Ameerika Ühendriigid", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "Ameerika Ühendriigid", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "Ameerika Ühendriigid", "zoneName": "Duke Energy Carolinas" },
+        "US-CAR-SC": { "countryName": "Ameerika Ühendriigid", "zoneName": "South Carolina Public Service Authority" },
+        "US-CAR-SCEG": { "countryName": "Ameerika Ühendriigid", "zoneName": "South Carolina Electric & Gas Company" },
         "US-CAR-YAD": {
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
         },
-        "US-CENT-SPA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Southwestern Power Administration"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "City Of Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "JEA"
-        },
-        "US-FLA-NSB": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Utilities Commission Of New Smyrna Beach"
-        },
-        "US-FLA-SEC": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "City Of Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "PJM Interconnection, Llc"
-        },
-        "US-MIDW-AECI": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Associated Electric Cooperative, Inc."
-        },
-        "US-MIDW-GLHB": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "GridLiance"
-        },
+        "US-CENT-SPA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Southwestern Power Administration" },
+        "US-CENT-SWPP": { "countryName": "Ameerika Ühendriigid", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "Ameerika Ühendriigid", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "Ameerika Ühendriigid", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "Ameerika Ühendriigid", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "Ameerika Ühendriigid", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "Ameerika Ühendriigid", "zoneName": "City Of Homestead" },
+        "US-FLA-JEA": { "countryName": "Ameerika Ühendriigid", "zoneName": "JEA" },
+        "US-FLA-NSB": { "countryName": "Ameerika Ühendriigid", "zoneName": "Utilities Commission Of New Smyrna Beach" },
+        "US-FLA-SEC": { "countryName": "Ameerika Ühendriigid", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "Ameerika Ühendriigid", "zoneName": "City Of Tallahassee" },
+        "US-FLA-TEC": { "countryName": "Ameerika Ühendriigid", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "Ameerika Ühendriigid", "zoneName": "PJM Interconnection, Llc" },
+        "US-MIDW-AECI": { "countryName": "Ameerika Ühendriigid", "zoneName": "Associated Electric Cooperative, Inc." },
+        "US-MIDW-GLHB": { "countryName": "Ameerika Ühendriigid", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1524,78 +594,24 @@
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc.."
         },
-        "US-NE-ISNE": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
-        "US-NW-GCPD": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "PUD No. 2 Of Grant County, Washington"
-        },
-        "US-NW-GRID": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Portland General Electric Company"
-        },
-        "US-NW-PSCO": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Public Service Company Of Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NE-ISNE": { "countryName": "Ameerika Ühendriigid", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "Ameerika Ühendriigid", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "Ameerika Ühendriigid", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "Ameerika Ühendriigid", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "Ameerika Ühendriigid", "zoneName": "PUD No. 1 Of Douglas County" },
+        "US-NW-GCPD": { "countryName": "Ameerika Ühendriigid", "zoneName": "PUD No. 2 Of Grant County, Washington" },
+        "US-NW-GRID": { "countryName": "Ameerika Ühendriigid", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "Ameerika Ühendriigid", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "Ameerika Ühendriigid", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "Ameerika Ühendriigid", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "Ameerika Ühendriigid", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "Ameerika Ühendriigid", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "Ameerika Ühendriigid", "zoneName": "Portland General Electric Company" },
+        "US-NW-PSCO": { "countryName": "Ameerika Ühendriigid", "zoneName": "Public Service Company Of Colorado" },
+        "US-NW-PSEI": { "countryName": "Ameerika Ühendriigid", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "Ameerika Ühendriigid", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
@@ -1608,129 +624,46 @@
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "Western Area Power Administration UGP West"
         },
-        "US-NW-WWA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "New York Independent System Operator"
-        },
-        "US-SE-AEC": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Southeastern Power Administration"
-        },
-        "US-SE-SOCO": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Southern Company Services, Inc. - Trans"
-        },
-        "US-SW-AZPS": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Gila River Power, LLC"
-        },
-        "US-SW-HGMA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "New Harquahala Generating Company, LLC"
-        },
-        "US-SW-PNM": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Public Service Company Of New Mexico"
-        },
-        "US-SW-SRP": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-NW-WWA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "Ameerika Ühendriigid", "zoneName": "New York Independent System Operator" },
+        "US-SE-AEC": { "countryName": "Ameerika Ühendriigid", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Southeastern Power Administration" },
+        "US-SE-SOCO": { "countryName": "Ameerika Ühendriigid", "zoneName": "Southern Company Services, Inc. - Trans" },
+        "US-SW-AZPS": { "countryName": "Ameerika Ühendriigid", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "Ameerika Ühendriigid", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "Ameerika Ühendriigid", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Gila River Power, LLC" },
+        "US-SW-HGMA": { "countryName": "Ameerika Ühendriigid", "zoneName": "New Harquahala Generating Company, LLC" },
+        "US-SW-PNM": { "countryName": "Ameerika Ühendriigid", "zoneName": "Public Service Company Of New Mexico" },
+        "US-SW-SRP": { "countryName": "Ameerika Ühendriigid", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "Ameerika Ühendriigid", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Tennessee Valley Authority"
-        },
+        "US-TEN-TVA": { "countryName": "Ameerika Ühendriigid", "zoneName": "Tennessee Valley Authority" },
         "US-TEX-ERCO": {
             "countryName": "Ameerika Ühendriigid",
             "zoneName": "Electric Reliability Council Of Texas, Inc."
         },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Usbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatikani linn"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent ja Grenadiinid"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Neitsisaared",
-            "zoneName": "Neitsisaared"
-        },
-        "VI": {
-            "countryName": "Ameerika Ühendriigid",
-            "zoneName": "Neitsisaared"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis ja Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XK": {
-            "zoneName": "Kosovo"
-        },
-        "XX": {
-            "zoneName": "Põhja-Küpros"
-        },
-        "YE": {
-            "zoneName": "Jeemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Lõuna-Aafrika"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Usbekistan" },
+        "VA": { "zoneName": "Vatikani linn" },
+        "VC": { "zoneName": "Saint Vincent ja Grenadiinid" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Neitsisaared", "zoneName": "Neitsisaared" },
+        "VI": { "countryName": "Ameerika Ühendriigid", "zoneName": "Neitsisaared" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis ja Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XK": { "zoneName": "Kosovo" },
+        "XX": { "zoneName": "Põhja-Küpros" },
+        "YE": { "zoneName": "Jeemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Lõuna-Aafrika" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/fi.json
+++ b/web/public/locales/fi.json
@@ -6,15 +6,9 @@
         "datasources": "tietolähteet",
         "contribute": "Avusta <a href=\"%s\" target=\"_blank\">lisäämällä alueesi</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Alueet",
-        "about": "Tietoa"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Alueet", "about": "Tietoa" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Sähkön ilmastovaikutusten kartoittaminen"
-        },
+        "view1": { "subtitle": "Sähkön ilmastovaikutusten kartoittaminen" },
         "view2": {
             "header": "Katso, kuinka paljon hiilidioksidia vapautuu sähkön tuottamiseksi, reaaliajassa.",
             "text": "Värjäämme alueet ympäri maailmaa niiden kuluttaman sähkön hiili-intensiteetin perusteella (mukaan lukien kaikki kasvihuonekaasut). Mitä vihreämpi väri, sitä ilmastoystävällisempi sähkö."
@@ -50,14 +44,14 @@
         "search": "Etsi alueita"
     },
     "country-history": {
-        "carbonintensity24h": "Hiili-intensiteetti viimeisen 24 tunnin aikana",
-        "emissions24h": "Päästöt viimeisen 24 tunnin aikana",
-        "emissionsorigin24h": "Päästöjen alkuperä viimiesen 24 tunnin aikana",
-        "emissionsproduction24h": "Päästöt tuotettu viimiesen 24 tunnin aikana",
-        "electricityorigin24h": "Sähkön alkuperä viimeisen 24 tunnin aikana",
-        "electricityproduction24h": "Sähkön tuotanto viimeisen 24 tunnin aikana",
-        "electricityprices24h": "Sähkön hinnat viimeisen 24 tunnin aikana",
-        "Getdata": "Hanki pääsy historia-, marginaali- ja ennuste-API:hin"
+        "Getdata": "Hanki pääsy historia-, marginaali- ja ennuste-API:hin",
+        "carbonintensity": { "hourly": "Hiili-intensiteetti viimeisen 24 tunnin aikana" },
+        "emissionsorigin": { "hourly": "Päästöjen alkuperä viimiesen 24 tunnin aikana" },
+        "emissionsproduction": { "hourly": "Päästöt tuotettu viimiesen 24 tunnin aikana" },
+        "electricityorigin": { "hourly": "Sähkön alkuperä viimeisen 24 tunnin aikana" },
+        "electricityproduction": { "hourly": "Sähkön tuotanto viimeisen 24 tunnin aikana" },
+        "electricityprices": { "hourly": "Sähkön hinnat viimeisen 24 tunnin aikana" },
+        "emissions": { "hourly": "Päästöt viimeisen 24 tunnin aikana" }
     },
     "footer": {
         "foundbugs": "Löysitkö vikoja tai onko ideoita? Kerro niistä",
@@ -192,1297 +186,385 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> julkaisee tietoja ja kuvia <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> tiedotustarkoituksiin. Se ei väitä oikeellisuudesta eikä anna minkäänlaisia takuita, ja pidättää oikeuden muuttaa sisältöä milloin tahansa tai poistaa osia tarvitsematta ilmoittaa sinulle siitä. electricityMap ei ota vastuuta mistään vahingoista tai kuluista, jotka saattavat aiheutua sähkökartan tai sen perusteella saatujen tietojen epätarkkuudesta, epätäydellisyydestä, ajantasaisuudesta tai vanhenemisesta. Tätä verkkosivua tai sen yksittäisiä osia ei saa sisällyttää toiselle verkkosivulle ilman virallista etukäteen annettua kirjallista suostumusta. <br><br> Kaikki immateriaalioikeudet kuuluvat laillisille omistajille ja sen lisenssinantajille. Näiden materiaalien, erityisesti energiadatojen, kopiointi, jakelu ja muu käyttö ei ole sallittua ilman kirjallista lupaa electricityMap:lta, paitsi ja vain siinä määrin kuin pakollisen lain säännöksissä (kuten lainausoikeudessa) toisin määrätään, ellei määritelty toisin tietyille materiaaleille. <br> <br> Tämä vastuuvapauslauseke voidaan päivittää ajoittain."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Yhdistyneet arabiemiirikunnat"
-        },
-        "AF": {
-            "zoneName": "Afganistan"
-        },
-        "AG": {
-            "zoneName": "Antigua ja Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albania"
-        },
-        "AM": {
-            "zoneName": "Armenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarktika"
-        },
-        "AS": {
-            "zoneName": "Amerikan Samoa"
-        },
-        "AT": {
-            "zoneName": "Itävalta"
-        },
-        "AR": {
-            "zoneName": "Argentiina"
-        },
-        "AUS-NSW": {
-            "countryName": "Australia",
-            "zoneName": "Uusi Etelä-Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Australia",
-            "zoneName": "Pohjois-territorio"
-        },
-        "AUS-QLD": {
-            "countryName": "Australia",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australia",
-            "zoneName": "Etelä-Australia"
-        },
-        "AUS-TAS": {
-            "countryName": "Australia",
-            "zoneName": "Tasmania"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmania",
-            "zoneName": "King Island"
-        },
-        "AUS-VIC": {
-            "countryName": "Australia",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australia",
-            "zoneName": "Länsi-Australia"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Ahvenanmaa"
-        },
-        "AZ": {
-            "zoneName": "Azerbaidžan"
-        },
-        "BA": {
-            "zoneName": "Bosnia ja Hertsegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Belgia"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgaria"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Alankomaiden Karibia"
-        },
-        "BR-CS": {
-            "countryName": "Brasilia",
-            "zoneName": "Keski-Brasilia"
-        },
-        "BR-N": {
-            "countryName": "Brasilia",
-            "zoneName": "Pohjois-Brasilia"
-        },
-        "BR-NE": {
-            "countryName": "Brasilia",
-            "zoneName": "Koillis-Brasilia"
-        },
-        "BR-S": {
-            "countryName": "Brasilia",
-            "zoneName": "Etelä-Brasilia"
-        },
-        "BS": {
-            "zoneName": "Bahama"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Bouvet'nsaari"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Valko-Venäjä"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "Brittiläinen Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland ja Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Northwest Territories"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Prince Edward Island"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Quebec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Kookossaaret"
-        },
-        "CD": {
-            "zoneName": "Kongon demokraattinen tasavalta"
-        },
-        "CF": {
-            "zoneName": "Keski-Afrikan tasavalta"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Sveitsi"
-        },
-        "CI": {
-            "zoneName": "Norsunluurannikko"
-        },
-        "CK": {
-            "zoneName": "Cookinsaaret"
-        },
-        "CL-SING-SIC": {
-            "countryName": "Chile",
-            "zoneName": "SING/SIC"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "SEA"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Kiina"
-        },
-        "CO": {
-            "zoneName": "Kolumbia"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Kuuba"
-        },
-        "CV": {
-            "zoneName": "Kap Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Joulusaari"
-        },
-        "CY": {
-            "zoneName": "Kypros"
-        },
-        "CZ": {
-            "zoneName": "Tsekki"
-        },
-        "DE": {
-            "zoneName": "Saksa"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Tanska"
-        },
-        "DK-DK1": {
-            "countryName": "Tanska",
-            "zoneName": "Länsi-Tanska"
-        },
-        "DK-DK2": {
-            "countryName": "DeTanskanmark",
-            "zoneName": "Itä-Tanska"
-        },
-        "DK-BHM": {
-            "countryName": "Tanska",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "Dominikaaninen tasavalta"
-        },
-        "DZ": {
-            "zoneName": "Algeria"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Viro"
-        },
-        "EG": {
-            "zoneName": "Egypti"
-        },
-        "EH": {
-            "zoneName": "Länsi-Sahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Espanja"
-        },
-        "ES-IB-FO": {
-            "countryName": "Espanja",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Espanja",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Espanja",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Espanja",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Espanja",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Espanja",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Espanja",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Espanja",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Espanja",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Espanja",
-            "zoneName": "Teneriffa"
-        },
-        "ET": {
-            "zoneName": "Etiopia"
-        },
-        "FI": {
-            "zoneName": "Suomi"
-        },
-        "FJ": {
-            "zoneName": "Fidži"
-        },
-        "FK": {
-            "zoneName": "Falklandinsaaret"
-        },
-        "FM": {
-            "zoneName": "Mikronesia"
-        },
-        "FO": {
-            "zoneName": "Färsaaret"
-        },
-        "FR": {
-            "zoneName": "Ranska"
-        },
-        "FR-COR": {
-            "countryName": "Ranska",
-            "zoneName": "Korsika"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Iso-Britannia"
-        },
-        "GB-NIR": {
-            "zoneName": "Pohjois-Irlanti"
-        },
-        "GB-ORK": {
-            "countryName": "Iso-Britannia",
-            "zoneName": "Orkneysaaret"
-        },
-        "GB-SHI": {
-            "countryName": "Iso-Britannia",
-            "zoneName": "Shetlandinsaaret"
-        },
-        "GB-ZET": {
-            "countryName": "Iso-Britannia",
-            "zoneName": "Shetland Islands"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgia"
-        },
-        "GF": {
-            "zoneName": "Ranskan Guayana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Grönlanti"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Päiväntasaajan Guinea"
-        },
-        "GR": {
-            "zoneName": "Kreikka"
-        },
-        "GR-IS": {
-            "countryName": "Kreikka",
-            "zoneName": "Egeanmeren saaret"
-        },
-        "GS": {
-            "zoneName": "Etelä-Georgia ja Eteläiset Sandwichsaaret"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Heard ja McDonaldinsaaret"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Kroatia"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Unkari"
-        },
-        "ID": {
-            "zoneName": "Indonesia"
-        },
-        "IE": {
-            "zoneName": "Irlanti"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Mansaari"
-        },
-        "IN-AN": {
-            "countryName": "Intia",
-            "zoneName": "Andamaanit ja Nikobaarit"
-        },
-        "IN-AP": {
-            "countryName": "Intia",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Intia",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Intia",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "Intia",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Intia",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Intia",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "Intia",
-            "zoneName": "Dadra ja Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "Intia",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Intia",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "Intia",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Intia",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "Intia",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Intia",
-            "zoneName": "Jammu ja Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "Intia",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Intia",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Intia",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "Intia",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Intia",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Intia",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Intia",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Intia",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Intia",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "Intia",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "Intia",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "Intia",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "Intia",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "Intia",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "Intia",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Intia",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Intia",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Intia",
-            "zoneName": "Länsi-Bengali"
-        },
-        "IO": {
-            "zoneName": "Brittiläinen Intian valtameren alue"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Islanti"
-        },
-        "IT": {
-            "zoneName": "Italia"
-        },
-        "IT-CNO": {
-            "countryName": "Italia",
-            "zoneName": "Keski-Pohjoinen"
-        },
-        "IT-CSO": {
-            "countryName": "Italia",
-            "zoneName": "Keski-Etelä"
-        },
-        "IT-NO": {
-            "countryName": "Italia",
-            "zoneName": "Pohjoinen"
-        },
-        "IT-SAR": {
-            "countryName": "Italia",
-            "zoneName": "Sardinia"
-        },
-        "IT-SIC": {
-            "countryName": "Italia",
-            "zoneName": "Sisilia"
-        },
-        "IT-SO": {
-            "countryName": "Italia",
-            "zoneName": "Etelä"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaika"
-        },
-        "JO": {
-            "zoneName": "Jordania"
-        },
-        "JP-CB": {
-            "countryName": "Japani",
-            "zoneName": "Chubu"
-        },
-        "JP-CG": {
-            "countryName": "Japani",
-            "zoneName": "Chugoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japani",
-            "zoneName": "Hokkaido"
-        },
-        "JP-HR": {
-            "countryName": "Japani",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japani",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japani",
-            "zoneName": "Kyushu"
-        },
-        "JP-ON": {
-            "countryName": "Japani",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japani",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japani",
-            "zoneName": "Tohoku"
-        },
-        "JP-TK": {
-            "countryName": "Japani",
-            "zoneName": "Tokio"
-        },
-        "KE": {
-            "zoneName": "Kenia"
-        },
-        "KG": {
-            "zoneName": "Kirgisia"
-        },
-        "KH": {
-            "zoneName": "Kambodia"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Komorit"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts ja Nevis"
-        },
-        "KP": {
-            "zoneName": "Pohjois-Korea"
-        },
-        "KR": {
-            "zoneName": "Etelä-Korea"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Caymansaaret"
-        },
-        "KZ": {
-            "zoneName": "Kazakstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Libanon"
-        },
-        "LC": {
-            "zoneName": "Saint Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Liettua"
-        },
-        "LU": {
-            "zoneName": "Luxemburg"
-        },
-        "LV": {
-            "zoneName": "Latvia"
-        },
-        "LY": {
-            "zoneName": "Libya"
-        },
-        "MA": {
-            "zoneName": "Marokko"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldova"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Saint-Martin",
-            "zoneName": "Ranska"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Marshallinsaaret"
-        },
-        "MK": {
-            "zoneName": "Pohjois-Makedonia"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Mongolia"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Pohjois-Mariaanit"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Malediivit"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "countryName": "Meksiko"
-        },
-        "MX-BC": {
-            "countryName": "Meksiko",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Meksiko",
-            "zoneName": "Keski"
-        },
-        "MX-NE": {
-            "countryName": "Meksiko",
-            "zoneName": "Koillinen"
-        },
-        "MX-NO": {
-            "countryName": "Meksiko",
-            "zoneName": "Pohjoinen"
-        },
-        "MX-NW": {
-            "countryName": "Meksiko",
-            "zoneName": "Luode"
-        },
-        "MX-OC": {
-            "countryName": "Meksiko",
-            "zoneName": "Länsimainen"
-        },
-        "MX-OR": {
-            "countryName": "Meksiko",
-            "zoneName": "Itämainen"
-        },
-        "MX-PN": {
-            "countryName": "Meksiko",
-            "zoneName": "Niemi"
-        },
-        "MY-EM": {
-            "countryName": "Malesia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malesia",
-            "zoneName": "Niemi"
-        },
-        "MZ": {
-            "zoneName": "Mosambik"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "Uus-Kaledonia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolkinsaari"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabakh"
-        },
-        "NL": {
-            "zoneName": "Alankomaat"
-        },
-        "NO-NO1": {
-            "countryName": "Norja",
-            "zoneName": "Kaakkois-Norja"
-        },
-        "NO-NO2": {
-            "countryName": "Norja",
-            "zoneName": "Lounas-Norja"
-        },
-        "NO-NO3": {
-            "countryName": "Norja",
-            "zoneName": "Keski-Norja"
-        },
-        "NO-NO4": {
-            "countryName": "Norja",
-            "zoneName": "Pohjois-Norja"
-        },
-        "NO-NO5": {
-            "countryName": "Norja",
-            "zoneName": "Länsi-Norja"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Uusi-Seelanti"
-        },
-        "NZ-NZA": {
-            "countryName": "Uusi-Seelanti",
-            "zoneName": "Aucklandsaaret"
-        },
-        "NZ-NZC": {
-            "countryName": "Uusi-Seelanti",
-            "zoneName": "Chathamsaaret"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Ranskan Polynesia"
-        },
-        "PG": {
-            "zoneName": "Papua-Uusi-Guinea"
-        },
-        "PH": {
-            "zoneName": "Filippiinit"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Puola"
-        },
-        "PM": {
-            "zoneName": "Saint Pierre ja Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairnsaaret"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Palestiina"
-        },
-        "PT": {
-            "zoneName": "Portugali"
-        },
-        "PT-AC": {
-            "countryName": "Portugali",
-            "zoneName": "Azores"
-        },
-        "PT-MA": {
-            "countryName": "Portugali",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Qatar"
-        },
-        "RE": {
-            "zoneName": "Reunion"
-        },
-        "RO": {
-            "zoneName": "Romania"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Venäjä"
-        },
-        "RU-1": {
-            "countryName": "Venäjä",
-            "zoneName": "Euroopan Venäjä ja Ural"
-        },
-        "RU-2": {
-            "countryName": "Venäjä",
-            "zoneName": "Siperia"
-        },
-        "RU-EU": {
-            "zoneName": "Venäjä"
-        },
-        "RU-AS": {
-            "zoneName": "Venäjä"
-        },
-        "RU-KGD": {
-            "countryName": "Venäjä",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Ruanda"
-        },
-        "SA": {
-            "zoneName": "Saudi-Arabia"
-        },
-        "SB": {
-            "zoneName": "Salomonsaaret"
-        },
-        "SC": {
-            "zoneName": "Seychellit"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Ruotsi"
-        },
-        "SG": {
-            "zoneName": "Singapore"
-        },
-        "SH": {
-            "zoneName": "Saint Helena, Ascension ja Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard ja Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovakia"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Etelä-Sudan"
-        },
-        "ST": {
-            "zoneName": "Sao Tome ja Principe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Alankomaat"
-        },
-        "SY": {
-            "zoneName": "Syyria"
-        },
-        "SZ": {
-            "zoneName": "Swazimaa"
-        },
-        "TC": {
-            "zoneName": "Turks- ja Caicossaaret"
-        },
-        "TD": {
-            "zoneName": "Tšad"
-        },
-        "TF": {
-            "zoneName": "Ranskan eteläiset alueet"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thaimaa"
-        },
-        "TJ": {
-            "zoneName": "Tadžikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunisia"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turkki"
-        },
-        "TT": {
-            "zoneName": "Trinidad ja Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tansania"
-        },
-        "UA": {
-            "zoneName": "Ukraina"
-        },
-        "UA-CR": {
-            "countryName": "Krim",
-            "zoneName": "Ukraina"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Yhdysvaltain pienet erillissaaret"
-        },
-        "US-HI-HA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Havaiji"
-        },
-        "US-HI-KA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Oahu"
-        },
-        "US-CAL-BANC": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Balancing Authority Of Northern California"
-        },
-        "US-CAL-CISO": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "California Independent System Operator"
-        },
-        "US-CAL-IID": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Imperial Irrigation District"
-        },
-        "US-CAL-LDWP": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Los Angeles Department Of Water And Power"
-        },
-        "US-CAL-TIDC": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Duke Energy Carolinas"
-        },
-        "US-CAR-SC": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "South Carolina Public Service Authority"
-        },
-        "US-CAR-SCEG": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "South Carolina Electric & Gas Company"
-        },
-        "US-CAR-YAD": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
-        },
-        "US-CENT-SPA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Southwestern Power Administration"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "City Of Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "JEA"
-        },
-        "US-FLA-NSB": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Utilities Commission Of New Smyrna Beach"
-        },
-        "US-FLA-SEC": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "City Of Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "PJM Interconnection, Llc"
-        },
-        "US-MIDW-AECI": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Associated Electric Cooperative, Inc."
-        },
-        "US-MIDW-GLHB": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "GridLiance"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Yhdistyneet arabiemiirikunnat" },
+        "AF": { "zoneName": "Afganistan" },
+        "AG": { "zoneName": "Antigua ja Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albania" },
+        "AM": { "zoneName": "Armenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarktika" },
+        "AS": { "zoneName": "Amerikan Samoa" },
+        "AT": { "zoneName": "Itävalta" },
+        "AR": { "zoneName": "Argentiina" },
+        "AUS-NSW": { "countryName": "Australia", "zoneName": "Uusi Etelä-Wales" },
+        "AUS-NT": { "countryName": "Australia", "zoneName": "Pohjois-territorio" },
+        "AUS-QLD": { "countryName": "Australia", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australia", "zoneName": "Etelä-Australia" },
+        "AUS-TAS": { "countryName": "Australia", "zoneName": "Tasmania" },
+        "AUS-TAS-KI": { "countryName": "Tasmania", "zoneName": "King Island" },
+        "AUS-VIC": { "countryName": "Australia", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australia", "zoneName": "Länsi-Australia" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Ahvenanmaa" },
+        "AZ": { "zoneName": "Azerbaidžan" },
+        "BA": { "zoneName": "Bosnia ja Hertsegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Belgia" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgaria" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Alankomaiden Karibia" },
+        "BR-CS": { "countryName": "Brasilia", "zoneName": "Keski-Brasilia" },
+        "BR-N": { "countryName": "Brasilia", "zoneName": "Pohjois-Brasilia" },
+        "BR-NE": { "countryName": "Brasilia", "zoneName": "Koillis-Brasilia" },
+        "BR-S": { "countryName": "Brasilia", "zoneName": "Etelä-Brasilia" },
+        "BS": { "zoneName": "Bahama" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Bouvet'nsaari" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Valko-Venäjä" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "Brittiläinen Columbia" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland ja Labrador" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "New Brunswick" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Northwest Territories" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nova Scotia" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Prince Edward Island" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Quebec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Kookossaaret" },
+        "CD": { "zoneName": "Kongon demokraattinen tasavalta" },
+        "CF": { "zoneName": "Keski-Afrikan tasavalta" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Sveitsi" },
+        "CI": { "zoneName": "Norsunluurannikko" },
+        "CK": { "zoneName": "Cookinsaaret" },
+        "CL-SING-SIC": { "countryName": "Chile", "zoneName": "SING/SIC" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "SEA" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Kiina" },
+        "CO": { "zoneName": "Kolumbia" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Kuuba" },
+        "CV": { "zoneName": "Kap Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Joulusaari" },
+        "CY": { "zoneName": "Kypros" },
+        "CZ": { "zoneName": "Tsekki" },
+        "DE": { "zoneName": "Saksa" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Tanska" },
+        "DK-DK1": { "countryName": "Tanska", "zoneName": "Länsi-Tanska" },
+        "DK-DK2": { "countryName": "DeTanskanmark", "zoneName": "Itä-Tanska" },
+        "DK-BHM": { "countryName": "Tanska", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "Dominikaaninen tasavalta" },
+        "DZ": { "zoneName": "Algeria" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Viro" },
+        "EG": { "zoneName": "Egypti" },
+        "EH": { "zoneName": "Länsi-Sahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Espanja" },
+        "ES-IB-FO": { "countryName": "Espanja", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Espanja", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Espanja", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Espanja", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Espanja", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Espanja", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Espanja", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Espanja", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "Espanja", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Espanja", "zoneName": "Teneriffa" },
+        "ET": { "zoneName": "Etiopia" },
+        "FI": { "zoneName": "Suomi" },
+        "FJ": { "zoneName": "Fidži" },
+        "FK": { "zoneName": "Falklandinsaaret" },
+        "FM": { "zoneName": "Mikronesia" },
+        "FO": { "zoneName": "Färsaaret" },
+        "FR": { "zoneName": "Ranska" },
+        "FR-COR": { "countryName": "Ranska", "zoneName": "Korsika" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Iso-Britannia" },
+        "GB-NIR": { "zoneName": "Pohjois-Irlanti" },
+        "GB-ORK": { "countryName": "Iso-Britannia", "zoneName": "Orkneysaaret" },
+        "GB-SHI": { "countryName": "Iso-Britannia", "zoneName": "Shetlandinsaaret" },
+        "GB-ZET": { "countryName": "Iso-Britannia", "zoneName": "Shetland Islands" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgia" },
+        "GF": { "zoneName": "Ranskan Guayana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Grönlanti" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Päiväntasaajan Guinea" },
+        "GR": { "zoneName": "Kreikka" },
+        "GR-IS": { "countryName": "Kreikka", "zoneName": "Egeanmeren saaret" },
+        "GS": { "zoneName": "Etelä-Georgia ja Eteläiset Sandwichsaaret" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Heard ja McDonaldinsaaret" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Kroatia" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Unkari" },
+        "ID": { "zoneName": "Indonesia" },
+        "IE": { "zoneName": "Irlanti" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Mansaari" },
+        "IN-AN": { "countryName": "Intia", "zoneName": "Andamaanit ja Nikobaarit" },
+        "IN-AP": { "countryName": "Intia", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Intia", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Intia", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "Intia", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Intia", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Intia", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "Intia", "zoneName": "Dadra ja Nagar Haveli" },
+        "IN-GA": { "countryName": "Intia", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Intia", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "Intia", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Intia", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "Intia", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Intia", "zoneName": "Jammu ja Kashmir" },
+        "IN-KA": { "countryName": "Intia", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Intia", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Intia", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "Intia", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Intia", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Intia", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Intia", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Intia", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Intia", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "Intia", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "Intia", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "Intia", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "Intia", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "Intia", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "Intia", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Intia", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Intia", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Intia", "zoneName": "Länsi-Bengali" },
+        "IO": { "zoneName": "Brittiläinen Intian valtameren alue" },
+        "IQ": { "zoneName": "Irak" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Islanti" },
+        "IT": { "zoneName": "Italia" },
+        "IT-CNO": { "countryName": "Italia", "zoneName": "Keski-Pohjoinen" },
+        "IT-CSO": { "countryName": "Italia", "zoneName": "Keski-Etelä" },
+        "IT-NO": { "countryName": "Italia", "zoneName": "Pohjoinen" },
+        "IT-SAR": { "countryName": "Italia", "zoneName": "Sardinia" },
+        "IT-SIC": { "countryName": "Italia", "zoneName": "Sisilia" },
+        "IT-SO": { "countryName": "Italia", "zoneName": "Etelä" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaika" },
+        "JO": { "zoneName": "Jordania" },
+        "JP-CB": { "countryName": "Japani", "zoneName": "Chubu" },
+        "JP-CG": { "countryName": "Japani", "zoneName": "Chugoku" },
+        "JP-HKD": { "countryName": "Japani", "zoneName": "Hokkaido" },
+        "JP-HR": { "countryName": "Japani", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japani", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japani", "zoneName": "Kyushu" },
+        "JP-ON": { "countryName": "Japani", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japani", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japani", "zoneName": "Tohoku" },
+        "JP-TK": { "countryName": "Japani", "zoneName": "Tokio" },
+        "KE": { "zoneName": "Kenia" },
+        "KG": { "zoneName": "Kirgisia" },
+        "KH": { "zoneName": "Kambodia" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Komorit" },
+        "KN": { "zoneName": "Saint Kitts ja Nevis" },
+        "KP": { "zoneName": "Pohjois-Korea" },
+        "KR": { "zoneName": "Etelä-Korea" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Caymansaaret" },
+        "KZ": { "zoneName": "Kazakstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Libanon" },
+        "LC": { "zoneName": "Saint Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Liettua" },
+        "LU": { "zoneName": "Luxemburg" },
+        "LV": { "zoneName": "Latvia" },
+        "LY": { "zoneName": "Libya" },
+        "MA": { "zoneName": "Marokko" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldova" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Saint-Martin", "zoneName": "Ranska" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Marshallinsaaret" },
+        "MK": { "zoneName": "Pohjois-Makedonia" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Mongolia" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Pohjois-Mariaanit" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Malediivit" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "countryName": "Meksiko" },
+        "MX-BC": { "countryName": "Meksiko", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Meksiko", "zoneName": "Keski" },
+        "MX-NE": { "countryName": "Meksiko", "zoneName": "Koillinen" },
+        "MX-NO": { "countryName": "Meksiko", "zoneName": "Pohjoinen" },
+        "MX-NW": { "countryName": "Meksiko", "zoneName": "Luode" },
+        "MX-OC": { "countryName": "Meksiko", "zoneName": "Länsimainen" },
+        "MX-OR": { "countryName": "Meksiko", "zoneName": "Itämainen" },
+        "MX-PN": { "countryName": "Meksiko", "zoneName": "Niemi" },
+        "MY-EM": { "countryName": "Malesia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malesia", "zoneName": "Niemi" },
+        "MZ": { "zoneName": "Mosambik" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "Uus-Kaledonia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolkinsaari" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Nagorno-Karabakh" },
+        "NL": { "zoneName": "Alankomaat" },
+        "NO-NO1": { "countryName": "Norja", "zoneName": "Kaakkois-Norja" },
+        "NO-NO2": { "countryName": "Norja", "zoneName": "Lounas-Norja" },
+        "NO-NO3": { "countryName": "Norja", "zoneName": "Keski-Norja" },
+        "NO-NO4": { "countryName": "Norja", "zoneName": "Pohjois-Norja" },
+        "NO-NO5": { "countryName": "Norja", "zoneName": "Länsi-Norja" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Uusi-Seelanti" },
+        "NZ-NZA": { "countryName": "Uusi-Seelanti", "zoneName": "Aucklandsaaret" },
+        "NZ-NZC": { "countryName": "Uusi-Seelanti", "zoneName": "Chathamsaaret" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Ranskan Polynesia" },
+        "PG": { "zoneName": "Papua-Uusi-Guinea" },
+        "PH": { "zoneName": "Filippiinit" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Puola" },
+        "PM": { "zoneName": "Saint Pierre ja Miquelon" },
+        "PN": { "zoneName": "Pitcairnsaaret" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Palestiina" },
+        "PT": { "zoneName": "Portugali" },
+        "PT-AC": { "countryName": "Portugali", "zoneName": "Azores" },
+        "PT-MA": { "countryName": "Portugali", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Qatar" },
+        "RE": { "zoneName": "Reunion" },
+        "RO": { "zoneName": "Romania" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Venäjä" },
+        "RU-1": { "countryName": "Venäjä", "zoneName": "Euroopan Venäjä ja Ural" },
+        "RU-2": { "countryName": "Venäjä", "zoneName": "Siperia" },
+        "RU-EU": { "zoneName": "Venäjä" },
+        "RU-AS": { "zoneName": "Venäjä" },
+        "RU-KGD": { "countryName": "Venäjä", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Ruanda" },
+        "SA": { "zoneName": "Saudi-Arabia" },
+        "SB": { "zoneName": "Salomonsaaret" },
+        "SC": { "zoneName": "Seychellit" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Ruotsi" },
+        "SG": { "zoneName": "Singapore" },
+        "SH": { "zoneName": "Saint Helena, Ascension ja Tristan da Cunha" },
+        "SI": { "zoneName": "Slovenia" },
+        "SJ": { "zoneName": "Svalbard ja Jan Mayen" },
+        "SK": { "zoneName": "Slovakia" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Etelä-Sudan" },
+        "ST": { "zoneName": "Sao Tome ja Principe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Alankomaat" },
+        "SY": { "zoneName": "Syyria" },
+        "SZ": { "zoneName": "Swazimaa" },
+        "TC": { "zoneName": "Turks- ja Caicossaaret" },
+        "TD": { "zoneName": "Tšad" },
+        "TF": { "zoneName": "Ranskan eteläiset alueet" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thaimaa" },
+        "TJ": { "zoneName": "Tadžikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunisia" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turkki" },
+        "TT": { "zoneName": "Trinidad ja Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tansania" },
+        "UA": { "zoneName": "Ukraina" },
+        "UA-CR": { "countryName": "Krim", "zoneName": "Ukraina" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Yhdysvaltain pienet erillissaaret" },
+        "US-HI-HA": { "countryName": "Yhdysvallat", "zoneName": "Havaiji" },
+        "US-HI-KA": { "countryName": "Yhdysvallat", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Yhdysvallat", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Yhdysvallat", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Yhdysvallat", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Yhdysvallat", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Yhdysvallat", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Yhdysvallat", "zoneName": "Oahu" },
+        "US-CAL-BANC": { "countryName": "Yhdysvallat", "zoneName": "Balancing Authority Of Northern California" },
+        "US-CAL-CISO": { "countryName": "Yhdysvallat", "zoneName": "California Independent System Operator" },
+        "US-CAL-IID": { "countryName": "Yhdysvallat", "zoneName": "Imperial Irrigation District" },
+        "US-CAL-LDWP": { "countryName": "Yhdysvallat", "zoneName": "Los Angeles Department Of Water And Power" },
+        "US-CAL-TIDC": { "countryName": "Yhdysvallat", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "Yhdysvallat", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "Yhdysvallat", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "Yhdysvallat", "zoneName": "Duke Energy Carolinas" },
+        "US-CAR-SC": { "countryName": "Yhdysvallat", "zoneName": "South Carolina Public Service Authority" },
+        "US-CAR-SCEG": { "countryName": "Yhdysvallat", "zoneName": "South Carolina Electric & Gas Company" },
+        "US-CAR-YAD": { "countryName": "Yhdysvallat", "zoneName": "Alcoa Power Generating, Inc. Yadkin Division" },
+        "US-CENT-SPA": { "countryName": "Yhdysvallat", "zoneName": "Southwestern Power Administration" },
+        "US-CENT-SWPP": { "countryName": "Yhdysvallat", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "Yhdysvallat", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "Yhdysvallat", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "Yhdysvallat", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "Yhdysvallat", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "Yhdysvallat", "zoneName": "City Of Homestead" },
+        "US-FLA-JEA": { "countryName": "Yhdysvallat", "zoneName": "JEA" },
+        "US-FLA-NSB": { "countryName": "Yhdysvallat", "zoneName": "Utilities Commission Of New Smyrna Beach" },
+        "US-FLA-SEC": { "countryName": "Yhdysvallat", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "Yhdysvallat", "zoneName": "City Of Tallahassee" },
+        "US-FLA-TEC": { "countryName": "Yhdysvallat", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "Yhdysvallat", "zoneName": "PJM Interconnection, Llc" },
+        "US-MIDW-AECI": { "countryName": "Yhdysvallat", "zoneName": "Associated Electric Cooperative, Inc." },
+        "US-MIDW-GLHB": { "countryName": "Yhdysvallat", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "Yhdysvallat",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1491,78 +573,24 @@
             "countryName": "Yhdysvallat",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc.."
         },
-        "US-NE-ISNE": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
-        "US-NW-GCPD": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "PUD No. 2 Of Grant County, Washington"
-        },
-        "US-NW-GRID": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Portland General Electric Company"
-        },
-        "US-NW-PSCO": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Public Service Company Of Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NE-ISNE": { "countryName": "Yhdysvallat", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "Yhdysvallat", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "Yhdysvallat", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "Yhdysvallat", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "Yhdysvallat", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "Yhdysvallat", "zoneName": "PUD No. 1 Of Douglas County" },
+        "US-NW-GCPD": { "countryName": "Yhdysvallat", "zoneName": "PUD No. 2 Of Grant County, Washington" },
+        "US-NW-GRID": { "countryName": "Yhdysvallat", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "Yhdysvallat", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "Yhdysvallat", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "Yhdysvallat", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "Yhdysvallat", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "Yhdysvallat", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "Yhdysvallat", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "Yhdysvallat", "zoneName": "Portland General Electric Company" },
+        "US-NW-PSCO": { "countryName": "Yhdysvallat", "zoneName": "Public Service Company Of Colorado" },
+        "US-NW-PSEI": { "countryName": "Yhdysvallat", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "Yhdysvallat", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "Yhdysvallat",
             "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
@@ -1571,130 +599,43 @@
             "countryName": "Yhdysvallat",
             "zoneName": "Western Area Power Administration - Rocky Mountain Region"
         },
-        "US-NW-WAUW": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Western Area Power Administration UGP West"
-        },
-        "US-NW-WWA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "New York Independent System Operator"
-        },
-        "US-SE-AEC": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Southeastern Power Administration"
-        },
-        "US-SE-SOCO": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Southern Company Services, Inc. - Trans"
-        },
-        "US-SW-AZPS": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Gila River Power, LLC"
-        },
-        "US-SW-HGMA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "New Harquahala Generating Company, LLC"
-        },
-        "US-SW-PNM": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Public Service Company Of New Mexico"
-        },
-        "US-SW-SRP": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-NW-WAUW": { "countryName": "Yhdysvallat", "zoneName": "Western Area Power Administration UGP West" },
+        "US-NW-WWA": { "countryName": "Yhdysvallat", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "Yhdysvallat", "zoneName": "New York Independent System Operator" },
+        "US-SE-AEC": { "countryName": "Yhdysvallat", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "Yhdysvallat", "zoneName": "Southeastern Power Administration" },
+        "US-SE-SOCO": { "countryName": "Yhdysvallat", "zoneName": "Southern Company Services, Inc. - Trans" },
+        "US-SW-AZPS": { "countryName": "Yhdysvallat", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "Yhdysvallat", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "Yhdysvallat", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "Yhdysvallat", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "Yhdysvallat", "zoneName": "Gila River Power, LLC" },
+        "US-SW-HGMA": { "countryName": "Yhdysvallat", "zoneName": "New Harquahala Generating Company, LLC" },
+        "US-SW-PNM": { "countryName": "Yhdysvallat", "zoneName": "Public Service Company Of New Mexico" },
+        "US-SW-SRP": { "countryName": "Yhdysvallat", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "Yhdysvallat", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "Yhdysvallat",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Tennessee Valley Authority"
-        },
-        "US-TEX-ERCO": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Electric Reliability Council Of Texas, Inc."
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatikaanivaltio"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent ja Grenadiinit"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Neitsytsaaret",
-            "zoneName": "Neitsytsaaret"
-        },
-        "VI": {
-            "countryName": "Yhdysvallat",
-            "zoneName": "Neitsytsaaret"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis ja Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Pohjois-Kypros"
-        },
-        "YE": {
-            "zoneName": "Jemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Etelä-Afrikka"
-        },
-        "ZM": {
-            "zoneName": "Sambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "US-TEN-TVA": { "countryName": "Yhdysvallat", "zoneName": "Tennessee Valley Authority" },
+        "US-TEX-ERCO": { "countryName": "Yhdysvallat", "zoneName": "Electric Reliability Council Of Texas, Inc." },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Vatikaanivaltio" },
+        "VC": { "zoneName": "Saint Vincent ja Grenadiinit" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Neitsytsaaret", "zoneName": "Neitsytsaaret" },
+        "VI": { "countryName": "Yhdysvallat", "zoneName": "Neitsytsaaret" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis ja Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Pohjois-Kypros" },
+        "YE": { "zoneName": "Jemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Etelä-Afrikka" },
+        "ZM": { "zoneName": "Sambia" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/fr.json
+++ b/web/public/locales/fr.json
@@ -6,15 +6,9 @@
         "datasources": "source des données",
         "contribute": "Contribuez en <a href=\"%s\" target=\"_blank\">ajoutant votre pays</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Zones",
-        "about": "À propos"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Zones", "about": "À propos" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Cartographie de l’impact de l’électricité sur le climat"
-        },
+        "view1": { "subtitle": "Cartographie de l’impact de l’électricité sur le climat" },
         "view2": {
             "header": "Visualisez la quantité de CO₂ émise pour produire votre électricité, en temps réel.",
             "text": "Les régions du monde sont colorées en fonction de l’intensité en carbone (incluant tous les gaz à effet de serre) de l’électricité qui y est consommée. Des couleurs plus vertes signifient une électricité plus respectueuse du climat."
@@ -51,14 +45,14 @@
         "search": "Rechercher une zone"
     },
     "country-history": {
-        "carbonintensity24h": "Intensité carbone des 24 dernières heures",
-        "emissionsorigin24h": "Origine des émissions des 24 dernières heures",
-        "emissionsproduction24h": "Émissions produites dans les 24 dernières heures",
-        "electricityorigin24h": "Origine de l’électricité des 24 dernières heures",
-        "electricityproduction24h": "Production électrique des 24 dernières heures",
-        "electricityprices24h": "Prix de l’électricité des 24 dernières heures",
         "Getdata": "Obtenir l’historique et l’API de prévision + marginal",
-        "emissions24h": "Émissions des 24 dernières heures"
+        "carbonintensity": { "hourly": "Intensité carbone des 24 dernières heures" },
+        "emissionsorigin": { "hourly": "Origine des émissions des 24 dernières heures" },
+        "emissionsproduction": { "hourly": "Émissions produites dans les 24 dernières heures" },
+        "electricityorigin": { "hourly": "Origine de l’électricité des 24 dernières heures" },
+        "electricityproduction": { "hourly": "Production électrique des 24 dernières heures" },
+        "electricityprices": { "hourly": "Prix de l’électricité des 24 dernières heures" },
+        "emissions": { "hourly": "Émissions des 24 dernières heures" }
     },
     "footer": {
         "foundbugs": "Un bug ? Une idée ? Cliquez",
@@ -195,1278 +189,381 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publie à titre informatif des données et des images sur son site <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a>.electricityMap ne répond pas de l’exactitude de ces informations, ne fournit aucune garantie sur ce point et se réserve le droit de changer le contenu de ce site à tout moment, ainsi que d’en retirer, sans avoir à informer son auditoire. electricityMap décline toute responsabilité et ne pourrait être tenu responsable de dommages ou dépenses qui résulteraient de l’inexactitude d’electricityMap, qu’elle soit due à une erreur, un manque de données, la présence d’information obsolète ou dépassée. Cela s’applique à electricityMap ainsi qu’à tout produit dérivé. Il est interdit d’inclure cette page web et n’importe lequel de ces éléments dans une autre page web, sans le consentement écrit préalable de electricityMap.<br><br> Tous les droits de propriété intellectuelle appartiennent aux propriétaires légitimes et légaux de ce site, ainsi qu’à tous les concédants. La copie, la distribution ou tout autre usage de ces documents, en particulier les données énergétiques, sont interdits sans le consentement écrit de electricityMap, sauf contre-indication légale (telle que le droit de mention), à moins que cela ne soit explicitement spécifié par ces documents.<br><br>Cette notice légale pourra être ponctuellement mise à jour."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorre"
-        },
-        "AE": {
-            "zoneName": "Émirats arabes unis"
-        },
-        "AF": {
-            "zoneName": "Afghanistan"
-        },
-        "AG": {
-            "zoneName": "Antigua-et-Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albanie"
-        },
-        "AM": {
-            "zoneName": "Arménie"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarctique"
-        },
-        "AS": {
-            "zoneName": "Samoa américaines"
-        },
-        "AT": {
-            "zoneName": "Autriche"
-        },
-        "AR": {
-            "zoneName": "Argentine"
-        },
-        "AUS-NSW": {
-            "countryName": "Australie",
-            "zoneName": "Nouvelle-Galles du Sud"
-        },
-        "AUS-NT": {
-            "countryName": "Australie",
-            "zoneName": "Territoire du Nord"
-        },
-        "AUS-QLD": {
-            "countryName": "Australie",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australie",
-            "zoneName": "Australie-Méridionale"
-        },
-        "AUS-TAS": {
-            "countryName": "Australie",
-            "zoneName": "Tasmanie"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Australie",
-            "zoneName": "Tasmanie (Île King)"
-        },
-        "AUS-VIC": {
-            "countryName": "Australie",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australie",
-            "zoneName": "Australie-Occidentale"
-        },
-        "AUS-WA-RI": {
-            "countryName": "Australie",
-            "zoneName": "Île Rottnest"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Åland"
-        },
-        "AZ": {
-            "zoneName": "Azerbaïdjan"
-        },
-        "BA": {
-            "zoneName": "Bosnie-Herzégovine"
-        },
-        "BB": {
-            "zoneName": "Barbade"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Belgique"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgarie"
-        },
-        "BH": {
-            "zoneName": "Bahreïn"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Bénin"
-        },
-        "BM": {
-            "zoneName": "Bermudes"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivie"
-        },
-        "BQ": {
-            "zoneName": "Pays-Bas caribéens"
-        },
-        "BR-CS": {
-            "countryName": "Brésil",
-            "zoneName": "Central"
-        },
-        "BR-N": {
-            "countryName": "Brésil",
-            "zoneName": "Nord"
-        },
-        "BR-NE": {
-            "countryName": "Brésil",
-            "zoneName": "Nord-Est"
-        },
-        "BR-S": {
-            "countryName": "Brésil",
-            "zoneName": "Sud"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Bhoutan"
-        },
-        "BV": {
-            "zoneName": "Île Bouvet"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Biélorussie"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Canada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Canada",
-            "zoneName": "Colombie-Britannique"
-        },
-        "CA-MB": {
-            "countryName": "Canada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Canada",
-            "zoneName": "Terre-Neuve-et-Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Canada",
-            "zoneName": "Nouveau-Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Canada",
-            "zoneName": "Territoires du Nord-Ouest"
-        },
-        "CA-NS": {
-            "countryName": "Canada",
-            "zoneName": "Nouvelle-Écosse"
-        },
-        "CA-NU": {
-            "countryName": "Canada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Canada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Canada",
-            "zoneName": "Île-du-Prince-Édouard"
-        },
-        "CA-QC": {
-            "countryName": "Canada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Canada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Canada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Îles Cocos"
-        },
-        "CD": {
-            "zoneName": "République démocratique du Congo"
-        },
-        "CF": {
-            "zoneName": "République centrafricaine"
-        },
-        "CG": {
-            "zoneName": "République du Congo"
-        },
-        "CH": {
-            "zoneName": "Suisse"
-        },
-        "CI": {
-            "zoneName": "Côte d’Ivoire"
-        },
-        "CK": {
-            "zoneName": "Îles Cook"
-        },
-        "CL-SING": {
-            "countryName": "Chili",
-            "zoneName": "SING"
-        },
-        "CL-SING-SIC": {
-            "countryName": "Chili",
-            "zoneName": "SING - SIC"
-        },
-        "CL-SEM": {
-            "countryName": "Chili",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "Chili",
-            "zoneName": "SEA"
-        },
-        "CL-SEN": {
-            "countryName": "Chili",
-            "zoneName": "SEN"
-        },
-        "CL-CHP": {
-            "countryName": "Chili",
-            "zoneName": "Île de Pâques"
-        },
-        "CM": {
-            "zoneName": "Cameroun"
-        },
-        "CN": {
-            "zoneName": "Chine"
-        },
-        "CO": {
-            "zoneName": "Colombie"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Cuba"
-        },
-        "CV": {
-            "zoneName": "Cap-Vert"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Île Christmas"
-        },
-        "CY": {
-            "zoneName": "Chypre"
-        },
-        "CZ": {
-            "zoneName": "Tchéquie"
-        },
-        "DE": {
-            "zoneName": "Allemagne"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Danemark"
-        },
-        "DK-DK1": {
-            "countryName": "Danemark",
-            "zoneName": "Danemark ouest"
-        },
-        "DK-DK2": {
-            "countryName": "Danemark",
-            "zoneName": "Danemark est"
-        },
-        "DK-BHM": {
-            "countryName": "Danemark",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominique"
-        },
-        "DO": {
-            "zoneName": "République Dominicaine"
-        },
-        "DZ": {
-            "zoneName": "Algérie"
-        },
-        "EC": {
-            "zoneName": "Equateur"
-        },
-        "EE": {
-            "zoneName": "Estonie"
-        },
-        "EG": {
-            "zoneName": "Egypte"
-        },
-        "EH": {
-            "zoneName": "Sahara Occidental"
-        },
-        "ER": {
-            "zoneName": "Érythrée"
-        },
-        "ES": {
-            "zoneName": "Espagne"
-        },
-        "ES-IB-FO": {
-            "countryName": "Espagne",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Espagne",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Espagne",
-            "zoneName": "Majorque"
-        },
-        "ES-IB-ME": {
-            "countryName": "Espagne",
-            "zoneName": "Minorque"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Espagne",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Espagne",
-            "zoneName": "Grande Canarie"
-        },
-        "ES-CN-HI": {
-            "countryName": "Espagne",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Espagne",
-            "zoneName": "Ile de la Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Espagne",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Espagne",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Éthiopie"
-        },
-        "FI": {
-            "zoneName": "Finlande"
-        },
-        "FJ": {
-            "zoneName": "Fidji"
-        },
-        "FK": {
-            "zoneName": "Malouines"
-        },
-        "FM": {
-            "zoneName": "Micronésie"
-        },
-        "FO": {
-            "zoneName": "Îles Féroé"
-        },
-        "FR": {
-            "zoneName": "France"
-        },
-        "FR-COR": {
-            "countryName": "France",
-            "zoneName": "Corse"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Grande-Bretagne"
-        },
-        "GB-NIR": {
-            "zoneName": "Irlande du Nord"
-        },
-        "GB-ORK": {
-            "countryName": "Grande Bretagne",
-            "zoneName": "Orcades"
-        },
-        "GB-SHI": {
-            "countryName": "Grande Bretagne",
-            "zoneName": "Shetland"
-        },
-        "GB-ZET": {
-            "countryName": "Grande Bretagne",
-            "zoneName": "Shetland"
-        },
-        "GD": {
-            "zoneName": "Grenade"
-        },
-        "GE": {
-            "zoneName": "Géorgie"
-        },
-        "GF": {
-            "countryName": "France",
-            "zoneName": "Guyane Française"
-        },
-        "GG": {
-            "zoneName": "Guernesey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Groenland"
-        },
-        "GM": {
-            "zoneName": "Gambie"
-        },
-        "GN": {
-            "zoneName": "Guinée"
-        },
-        "GP": {
-            "countryName": "France",
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Guinée équatoriale"
-        },
-        "GR": {
-            "zoneName": "Grèce"
-        },
-        "GR-IS": {
-            "countryName": "Grèce",
-            "zoneName": "Îles Égéennes"
-        },
-        "GS": {
-            "zoneName": "Géorgie du Sud-et-les Îles Sandwich du Sud"
-        },
-        "GT": {
-            "zoneName": "Guatémala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinée-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Îles Heard-et-MacDonald"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Croatie"
-        },
-        "HT": {
-            "zoneName": "Haïti"
-        },
-        "HU": {
-            "zoneName": "Hongrie"
-        },
-        "ID": {
-            "zoneName": "Indonésie"
-        },
-        "IE": {
-            "zoneName": "Irlande"
-        },
-        "IL": {
-            "zoneName": "Israël"
-        },
-        "IM": {
-            "zoneName": "Île de Man"
-        },
-        "IN-AN": {
-            "countryName": "Inde",
-            "zoneName": "Andaman and Nicobar Islands"
-        },
-        "IN-AP": {
-            "countryName": "Inde",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Inde",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Inde",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "Inde",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Inde",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Inde",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "Inde",
-            "zoneName": "Dadra et Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "Inde",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Inde",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "Inde",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Inde",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "Inde",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Inde",
-            "zoneName": "Jammu and Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "Inde",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Inde",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Inde",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "Inde",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Inde",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Inde",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Inde",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Inde",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Inde",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "Inde",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "Inde",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "Inde",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "Inde",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "Inde",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "Inde",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Inde",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Inde",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Inde",
-            "zoneName": "West Bengal"
-        },
-        "IO": {
-            "zoneName": "Territoire britannique de l’océan Indien"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Islande"
-        },
-        "IT": {
-            "zoneName": "Italie"
-        },
-        "IT-CNO": {
-            "countryName": "Italie",
-            "zoneName": "Centre nord"
-        },
-        "IT-CSO": {
-            "countryName": "Italie",
-            "zoneName": "Centre sud"
-        },
-        "IT-NO": {
-            "countryName": "Italie",
-            "zoneName": "Nord"
-        },
-        "IT-SAR": {
-            "countryName": "Italie",
-            "zoneName": "Sardaigne"
-        },
-        "IT-SIC": {
-            "countryName": "Italie",
-            "zoneName": "Sicile"
-        },
-        "IT-SO": {
-            "countryName": "Italie",
-            "zoneName": "Sud"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaïque"
-        },
-        "JO": {
-            "zoneName": "Jordanie"
-        },
-        "JP-CB": {
-            "countryName": "Japon",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japon",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japon",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Japon",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japon",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japon",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Japon",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japon",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japon",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japon",
-            "zoneName": "Tokyo"
-        },
-        "KE": {
-            "zoneName": "Kenya"
-        },
-        "KG": {
-            "zoneName": "Kirghizistan"
-        },
-        "KH": {
-            "zoneName": "Cambodge"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comores"
-        },
-        "KN": {
-            "zoneName": "Saint-Christophe-et-Niévès"
-        },
-        "KP": {
-            "zoneName": "Corée du Nord"
-        },
-        "KR": {
-            "zoneName": "Corée du Sud"
-        },
-        "KW": {
-            "zoneName": "Koweït"
-        },
-        "KY": {
-            "zoneName": "Îles Caïmans"
-        },
-        "KZ": {
-            "zoneName": "Kazakhstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Liban"
-        },
-        "LC": {
-            "zoneName": "Sainte-Lucie"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Lituanie"
-        },
-        "LU": {
-            "zoneName": "Luxembourg"
-        },
-        "LV": {
-            "zoneName": "Lettonie"
-        },
-        "LY": {
-            "zoneName": "Libya"
-        },
-        "MA": {
-            "zoneName": "Maroc"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldavie"
-        },
-        "ME": {
-            "zoneName": "Monténégro"
-        },
-        "MF": {
-            "countryName": "France",
-            "zoneName": "Saint-Martin"
-        },
-        "MG": {
-            "zoneName": "Madagascar"
-        },
-        "MH": {
-            "zoneName": "Îles Marshall"
-        },
-        "MK": {
-            "zoneName": "Macédoine du Nord"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Birmanie"
-        },
-        "MN": {
-            "zoneName": "Mongolia"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Îles Mariannes du Nord"
-        },
-        "MQ": {
-            "countryName": "France",
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritanie"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malte"
-        },
-        "MU": {
-            "zoneName": "Maurice"
-        },
-        "MV": {
-            "zoneName": "Maldives"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mexique"
-        },
-        "MX-BC": {
-            "countryName": "Mexique",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mexique",
-            "zoneName": "Centre"
-        },
-        "MX-NE": {
-            "countryName": "Mexique",
-            "zoneName": "Nord-est"
-        },
-        "MX-NO": {
-            "countryName": "Mexique",
-            "zoneName": "Nord"
-        },
-        "MX-NW": {
-            "countryName": "Mexique",
-            "zoneName": "Nord-ouest"
-        },
-        "MX-OC": {
-            "countryName": "Mexique",
-            "zoneName": "Occidental"
-        },
-        "MX-OR": {
-            "countryName": "Mexique",
-            "zoneName": "Oriental"
-        },
-        "MX-PN": {
-            "countryName": "Mexique",
-            "zoneName": "Péninsule"
-        },
-        "MY-EM": {
-            "countryName": "Malaisie",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malaisie",
-            "zoneName": "Peninsule"
-        },
-        "MZ": {
-            "zoneName": "Mozambique"
-        },
-        "NA": {
-            "zoneName": "Namibie"
-        },
-        "NC": {
-            "zoneName": "Nouvelle-Calédonie"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Île Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Haut-Karabagh"
-        },
-        "NL": {
-            "zoneName": "Pays-Bas"
-        },
-        "NO-NO1": {
-            "countryName": "Norvège",
-            "zoneName": "Norvège du Sud-Est"
-        },
-        "NO-NO2": {
-            "countryName": "Norvège",
-            "zoneName": "Norvège du Sud-Ouest"
-        },
-        "NO-NO3": {
-            "countryName": "Norvège",
-            "zoneName": "Norvège Centre"
-        },
-        "NO-NO4": {
-            "countryName": "Norvège",
-            "zoneName": "Norvège Nord"
-        },
-        "NO-NO5": {
-            "countryName": "Norvège",
-            "zoneName": "Norvège Ouest"
-        },
-        "NP": {
-            "zoneName": "Népal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Nouvelle-Zélande"
-        },
-        "NZ-NZA": {
-            "countryName": "Nouvelle-Zélande",
-            "zoneName": "Îles Auckland"
-        },
-        "NZ-NZC": {
-            "countryName": "Nouvelle-Zélande",
-            "zoneName": "Îles Chatham"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Pérou"
-        },
-        "PF": {
-            "zoneName": "Polynésie française"
-        },
-        "PG": {
-            "zoneName": "Papouasie-Nouvelle-Guinée"
-        },
-        "PH": {
-            "zoneName": "Philippines"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Pologne"
-        },
-        "PM": {
-            "countryName": "France",
-            "zoneName": "Saint-Pierre-et-Miquelon"
-        },
-        "PN": {
-            "zoneName": "Îles Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Porto Rico"
-        },
-        "PS": {
-            "zoneName": "Palestine"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Açores"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madère"
-        },
-        "PW": {
-            "zoneName": "Palaos"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Qatar"
-        },
-        "RE": {
-            "countryName": "France",
-            "zoneName": "La Réunion"
-        },
-        "RO": {
-            "zoneName": "Roumanie"
-        },
-        "RS": {
-            "zoneName": "Serbie"
-        },
-        "RU": {
-            "zoneName": "Russie"
-        },
-        "RU-1": {
-            "countryName": "Russie",
-            "zoneName": "Europe-Oural"
-        },
-        "RU-2": {
-            "countryName": "Russie",
-            "zoneName": "Sibérie"
-        },
-        "RU-EU": {
-            "countryName": "Russie",
-            "zoneName": "Arctique"
-        },
-        "RU-AS": {
-            "countryName": "Russie",
-            "zoneName": "Orient"
-        },
-        "RU-FE": {
-            "countryName": "Russie",
-            "zoneName": "Extrême-Orient"
-        },
-        "RU-KGD": {
-            "countryName": "Russie",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Arabie saoudite"
-        },
-        "SB": {
-            "zoneName": "Salomon"
-        },
-        "SC": {
-            "zoneName": "Seychelles"
-        },
-        "SD": {
-            "zoneName": "Soudan"
-        },
-        "SE": {
-            "zoneName": "Suède"
-        },
-        "SG": {
-            "zoneName": "Singapour"
-        },
-        "SH": {
-            "zoneName": "Sainte-Hélène, Ascension et Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovénie"
-        },
-        "SJ": {
-            "zoneName": "Svalbard et ile Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovaquie"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "Sain Marin"
-        },
-        "SN": {
-            "zoneName": "Sénégal"
-        },
-        "SO": {
-            "zoneName": "Somalie"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Soudan du Sud"
-        },
-        "ST": {
-            "zoneName": "Sao Tomé et Principe"
-        },
-        "SV": {
-            "zoneName": "Salvador"
-        },
-        "SX": {
-            "countryName": "Saint Martin",
-            "zoneName": "Pays-Bas"
-        },
-        "SY": {
-            "zoneName": "Syrie"
-        },
-        "SZ": {
-            "zoneName": "Swaziland"
-        },
-        "TC": {
-            "zoneName": "Îles Turques-et-Caïques"
-        },
-        "TD": {
-            "zoneName": "Tchad"
-        },
-        "TF": {
-            "zoneName": "Terres australes et antarctiques françaises"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thaïlande"
-        },
-        "TJ": {
-            "zoneName": "Tadjikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor oriental"
-        },
-        "TM": {
-            "zoneName": "Turkménistan"
-        },
-        "TN": {
-            "zoneName": "Tunisie"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turquie"
-        },
-        "TT": {
-            "zoneName": "Trinité et Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taïwan"
-        },
-        "TZ": {
-            "zoneName": "Tanzanie"
-        },
-        "UA": {
-            "zoneName": "Ukraine"
-        },
-        "UA-CR": {
-            "zoneName": "Crimée",
-            "countryName": "Ukraine"
-        },
-        "UG": {
-            "zoneName": "Ouganda"
-        },
-        "UM": {
-            "zoneName": "Îles mineures éloignées des États-Unis"
-        },
-        "US-HI": {
-            "countryName": "États-Unis d’Amérique",
-            "zoneName": "Hawaï"
-        },
-        "US-HI-HA": {
-            "countryName": "États Unis d’Amérique",
-            "zoneName": "Hawaï"
-        },
-        "US-HI-KA": {
-            "countryName": "États Unis d’Amérique",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "États Unis d’Amérique",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "États Unis d’Amérique",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "États Unis d’Amérique",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "États Unis d’Amérique",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "États Unis d’Amérique",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "États Unis d’Amérique",
-            "zoneName": "Oahu"
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Ouzbékistan"
-        },
-        "VA": {
-            "zoneName": "Cité du Vatican"
-        },
-        "VC": {
-            "zoneName": "Saint-Vincent-et-les Grenadines"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Îles Vierges",
-            "zoneName": "Îles Vierges britanniques"
-        },
-        "VI": {
-            "countryName": "États-Unis d’Amérique",
-            "zoneName": "Îles Vierges des États-Unis"
-        },
-        "VN": {
-            "zoneName": "Viêt Nam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "countryName": "France",
-            "zoneName": "Wallis-et-Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Chypre du Nord"
-        },
-        "YE": {
-            "zoneName": "Yémen"
-        },
-        "YT": {
-            "countryName": "France",
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Afrique du Sud"
-        },
-        "ZM": {
-            "zoneName": "Zambie"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "AD": { "zoneName": "Andorre" },
+        "AE": { "zoneName": "Émirats arabes unis" },
+        "AF": { "zoneName": "Afghanistan" },
+        "AG": { "zoneName": "Antigua-et-Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albanie" },
+        "AM": { "zoneName": "Arménie" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarctique" },
+        "AS": { "zoneName": "Samoa américaines" },
+        "AT": { "zoneName": "Autriche" },
+        "AR": { "zoneName": "Argentine" },
+        "AUS-NSW": { "countryName": "Australie", "zoneName": "Nouvelle-Galles du Sud" },
+        "AUS-NT": { "countryName": "Australie", "zoneName": "Territoire du Nord" },
+        "AUS-QLD": { "countryName": "Australie", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australie", "zoneName": "Australie-Méridionale" },
+        "AUS-TAS": { "countryName": "Australie", "zoneName": "Tasmanie" },
+        "AUS-TAS-KI": { "countryName": "Australie", "zoneName": "Tasmanie (Île King)" },
+        "AUS-VIC": { "countryName": "Australie", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australie", "zoneName": "Australie-Occidentale" },
+        "AUS-WA-RI": { "countryName": "Australie", "zoneName": "Île Rottnest" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Åland" },
+        "AZ": { "zoneName": "Azerbaïdjan" },
+        "BA": { "zoneName": "Bosnie-Herzégovine" },
+        "BB": { "zoneName": "Barbade" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Belgique" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgarie" },
+        "BH": { "zoneName": "Bahreïn" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Bénin" },
+        "BM": { "zoneName": "Bermudes" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivie" },
+        "BQ": { "zoneName": "Pays-Bas caribéens" },
+        "BR-CS": { "countryName": "Brésil", "zoneName": "Central" },
+        "BR-N": { "countryName": "Brésil", "zoneName": "Nord" },
+        "BR-NE": { "countryName": "Brésil", "zoneName": "Nord-Est" },
+        "BR-S": { "countryName": "Brésil", "zoneName": "Sud" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Bhoutan" },
+        "BV": { "zoneName": "Île Bouvet" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Biélorussie" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Canada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Canada", "zoneName": "Colombie-Britannique" },
+        "CA-MB": { "countryName": "Canada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Canada", "zoneName": "Terre-Neuve-et-Labrador" },
+        "CA-NB": { "countryName": "Canada", "zoneName": "Nouveau-Brunswick" },
+        "CA-NT": { "countryName": "Canada", "zoneName": "Territoires du Nord-Ouest" },
+        "CA-NS": { "countryName": "Canada", "zoneName": "Nouvelle-Écosse" },
+        "CA-NU": { "countryName": "Canada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Canada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Canada", "zoneName": "Île-du-Prince-Édouard" },
+        "CA-QC": { "countryName": "Canada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Canada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Canada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Îles Cocos" },
+        "CD": { "zoneName": "République démocratique du Congo" },
+        "CF": { "zoneName": "République centrafricaine" },
+        "CG": { "zoneName": "République du Congo" },
+        "CH": { "zoneName": "Suisse" },
+        "CI": { "zoneName": "Côte d’Ivoire" },
+        "CK": { "zoneName": "Îles Cook" },
+        "CL-SING": { "countryName": "Chili", "zoneName": "SING" },
+        "CL-SING-SIC": { "countryName": "Chili", "zoneName": "SING - SIC" },
+        "CL-SEM": { "countryName": "Chili", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "Chili", "zoneName": "SEA" },
+        "CL-SEN": { "countryName": "Chili", "zoneName": "SEN" },
+        "CL-CHP": { "countryName": "Chili", "zoneName": "Île de Pâques" },
+        "CM": { "zoneName": "Cameroun" },
+        "CN": { "zoneName": "Chine" },
+        "CO": { "zoneName": "Colombie" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Cuba" },
+        "CV": { "zoneName": "Cap-Vert" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Île Christmas" },
+        "CY": { "zoneName": "Chypre" },
+        "CZ": { "zoneName": "Tchéquie" },
+        "DE": { "zoneName": "Allemagne" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Danemark" },
+        "DK-DK1": { "countryName": "Danemark", "zoneName": "Danemark ouest" },
+        "DK-DK2": { "countryName": "Danemark", "zoneName": "Danemark est" },
+        "DK-BHM": { "countryName": "Danemark", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominique" },
+        "DO": { "zoneName": "République Dominicaine" },
+        "DZ": { "zoneName": "Algérie" },
+        "EC": { "zoneName": "Equateur" },
+        "EE": { "zoneName": "Estonie" },
+        "EG": { "zoneName": "Egypte" },
+        "EH": { "zoneName": "Sahara Occidental" },
+        "ER": { "zoneName": "Érythrée" },
+        "ES": { "zoneName": "Espagne" },
+        "ES-IB-FO": { "countryName": "Espagne", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Espagne", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Espagne", "zoneName": "Majorque" },
+        "ES-IB-ME": { "countryName": "Espagne", "zoneName": "Minorque" },
+        "ES-CN-FVLZ": { "countryName": "Espagne", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Espagne", "zoneName": "Grande Canarie" },
+        "ES-CN-HI": { "countryName": "Espagne", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Espagne", "zoneName": "Ile de la Gomera" },
+        "ES-CN-LP": { "countryName": "Espagne", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Espagne", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Éthiopie" },
+        "FI": { "zoneName": "Finlande" },
+        "FJ": { "zoneName": "Fidji" },
+        "FK": { "zoneName": "Malouines" },
+        "FM": { "zoneName": "Micronésie" },
+        "FO": { "zoneName": "Îles Féroé" },
+        "FR": { "zoneName": "France" },
+        "FR-COR": { "countryName": "France", "zoneName": "Corse" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Grande-Bretagne" },
+        "GB-NIR": { "zoneName": "Irlande du Nord" },
+        "GB-ORK": { "countryName": "Grande Bretagne", "zoneName": "Orcades" },
+        "GB-SHI": { "countryName": "Grande Bretagne", "zoneName": "Shetland" },
+        "GB-ZET": { "countryName": "Grande Bretagne", "zoneName": "Shetland" },
+        "GD": { "zoneName": "Grenade" },
+        "GE": { "zoneName": "Géorgie" },
+        "GF": { "countryName": "France", "zoneName": "Guyane Française" },
+        "GG": { "zoneName": "Guernesey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Groenland" },
+        "GM": { "zoneName": "Gambie" },
+        "GN": { "zoneName": "Guinée" },
+        "GP": { "countryName": "France", "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Guinée équatoriale" },
+        "GR": { "zoneName": "Grèce" },
+        "GR-IS": { "countryName": "Grèce", "zoneName": "Îles Égéennes" },
+        "GS": { "zoneName": "Géorgie du Sud-et-les Îles Sandwich du Sud" },
+        "GT": { "zoneName": "Guatémala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinée-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Îles Heard-et-MacDonald" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Croatie" },
+        "HT": { "zoneName": "Haïti" },
+        "HU": { "zoneName": "Hongrie" },
+        "ID": { "zoneName": "Indonésie" },
+        "IE": { "zoneName": "Irlande" },
+        "IL": { "zoneName": "Israël" },
+        "IM": { "zoneName": "Île de Man" },
+        "IN-AN": { "countryName": "Inde", "zoneName": "Andaman and Nicobar Islands" },
+        "IN-AP": { "countryName": "Inde", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Inde", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Inde", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "Inde", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Inde", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Inde", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "Inde", "zoneName": "Dadra et Nagar Haveli" },
+        "IN-GA": { "countryName": "Inde", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Inde", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "Inde", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Inde", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "Inde", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Inde", "zoneName": "Jammu and Kashmir" },
+        "IN-KA": { "countryName": "Inde", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Inde", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Inde", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "Inde", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Inde", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Inde", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Inde", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Inde", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Inde", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "Inde", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "Inde", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "Inde", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "Inde", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "Inde", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "Inde", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Inde", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Inde", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Inde", "zoneName": "West Bengal" },
+        "IO": { "zoneName": "Territoire britannique de l’océan Indien" },
+        "IQ": { "zoneName": "Irak" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Islande" },
+        "IT": { "zoneName": "Italie" },
+        "IT-CNO": { "countryName": "Italie", "zoneName": "Centre nord" },
+        "IT-CSO": { "countryName": "Italie", "zoneName": "Centre sud" },
+        "IT-NO": { "countryName": "Italie", "zoneName": "Nord" },
+        "IT-SAR": { "countryName": "Italie", "zoneName": "Sardaigne" },
+        "IT-SIC": { "countryName": "Italie", "zoneName": "Sicile" },
+        "IT-SO": { "countryName": "Italie", "zoneName": "Sud" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaïque" },
+        "JO": { "zoneName": "Jordanie" },
+        "JP-CB": { "countryName": "Japon", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Japon", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Japon", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Japon", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japon", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japon", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Japon", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japon", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japon", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Japon", "zoneName": "Tokyo" },
+        "KE": { "zoneName": "Kenya" },
+        "KG": { "zoneName": "Kirghizistan" },
+        "KH": { "zoneName": "Cambodge" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comores" },
+        "KN": { "zoneName": "Saint-Christophe-et-Niévès" },
+        "KP": { "zoneName": "Corée du Nord" },
+        "KR": { "zoneName": "Corée du Sud" },
+        "KW": { "zoneName": "Koweït" },
+        "KY": { "zoneName": "Îles Caïmans" },
+        "KZ": { "zoneName": "Kazakhstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Liban" },
+        "LC": { "zoneName": "Sainte-Lucie" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Lituanie" },
+        "LU": { "zoneName": "Luxembourg" },
+        "LV": { "zoneName": "Lettonie" },
+        "LY": { "zoneName": "Libya" },
+        "MA": { "zoneName": "Maroc" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldavie" },
+        "ME": { "zoneName": "Monténégro" },
+        "MF": { "countryName": "France", "zoneName": "Saint-Martin" },
+        "MG": { "zoneName": "Madagascar" },
+        "MH": { "zoneName": "Îles Marshall" },
+        "MK": { "zoneName": "Macédoine du Nord" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Birmanie" },
+        "MN": { "zoneName": "Mongolia" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Îles Mariannes du Nord" },
+        "MQ": { "countryName": "France", "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritanie" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malte" },
+        "MU": { "zoneName": "Maurice" },
+        "MV": { "zoneName": "Maldives" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mexique" },
+        "MX-BC": { "countryName": "Mexique", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mexique", "zoneName": "Centre" },
+        "MX-NE": { "countryName": "Mexique", "zoneName": "Nord-est" },
+        "MX-NO": { "countryName": "Mexique", "zoneName": "Nord" },
+        "MX-NW": { "countryName": "Mexique", "zoneName": "Nord-ouest" },
+        "MX-OC": { "countryName": "Mexique", "zoneName": "Occidental" },
+        "MX-OR": { "countryName": "Mexique", "zoneName": "Oriental" },
+        "MX-PN": { "countryName": "Mexique", "zoneName": "Péninsule" },
+        "MY-EM": { "countryName": "Malaisie", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malaisie", "zoneName": "Peninsule" },
+        "MZ": { "zoneName": "Mozambique" },
+        "NA": { "zoneName": "Namibie" },
+        "NC": { "zoneName": "Nouvelle-Calédonie" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Île Norfolk" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Haut-Karabagh" },
+        "NL": { "zoneName": "Pays-Bas" },
+        "NO-NO1": { "countryName": "Norvège", "zoneName": "Norvège du Sud-Est" },
+        "NO-NO2": { "countryName": "Norvège", "zoneName": "Norvège du Sud-Ouest" },
+        "NO-NO3": { "countryName": "Norvège", "zoneName": "Norvège Centre" },
+        "NO-NO4": { "countryName": "Norvège", "zoneName": "Norvège Nord" },
+        "NO-NO5": { "countryName": "Norvège", "zoneName": "Norvège Ouest" },
+        "NP": { "zoneName": "Népal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Nouvelle-Zélande" },
+        "NZ-NZA": { "countryName": "Nouvelle-Zélande", "zoneName": "Îles Auckland" },
+        "NZ-NZC": { "countryName": "Nouvelle-Zélande", "zoneName": "Îles Chatham" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Pérou" },
+        "PF": { "zoneName": "Polynésie française" },
+        "PG": { "zoneName": "Papouasie-Nouvelle-Guinée" },
+        "PH": { "zoneName": "Philippines" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Pologne" },
+        "PM": { "countryName": "France", "zoneName": "Saint-Pierre-et-Miquelon" },
+        "PN": { "zoneName": "Îles Pitcairn" },
+        "PR": { "zoneName": "Porto Rico" },
+        "PS": { "zoneName": "Palestine" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Açores" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madère" },
+        "PW": { "zoneName": "Palaos" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Qatar" },
+        "RE": { "countryName": "France", "zoneName": "La Réunion" },
+        "RO": { "zoneName": "Roumanie" },
+        "RS": { "zoneName": "Serbie" },
+        "RU": { "zoneName": "Russie" },
+        "RU-1": { "countryName": "Russie", "zoneName": "Europe-Oural" },
+        "RU-2": { "countryName": "Russie", "zoneName": "Sibérie" },
+        "RU-EU": { "countryName": "Russie", "zoneName": "Arctique" },
+        "RU-AS": { "countryName": "Russie", "zoneName": "Orient" },
+        "RU-FE": { "countryName": "Russie", "zoneName": "Extrême-Orient" },
+        "RU-KGD": { "countryName": "Russie", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Arabie saoudite" },
+        "SB": { "zoneName": "Salomon" },
+        "SC": { "zoneName": "Seychelles" },
+        "SD": { "zoneName": "Soudan" },
+        "SE": { "zoneName": "Suède" },
+        "SG": { "zoneName": "Singapour" },
+        "SH": { "zoneName": "Sainte-Hélène, Ascension et Tristan da Cunha" },
+        "SI": { "zoneName": "Slovénie" },
+        "SJ": { "zoneName": "Svalbard et ile Jan Mayen" },
+        "SK": { "zoneName": "Slovaquie" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "Sain Marin" },
+        "SN": { "zoneName": "Sénégal" },
+        "SO": { "zoneName": "Somalie" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Soudan du Sud" },
+        "ST": { "zoneName": "Sao Tomé et Principe" },
+        "SV": { "zoneName": "Salvador" },
+        "SX": { "countryName": "Saint Martin", "zoneName": "Pays-Bas" },
+        "SY": { "zoneName": "Syrie" },
+        "SZ": { "zoneName": "Swaziland" },
+        "TC": { "zoneName": "Îles Turques-et-Caïques" },
+        "TD": { "zoneName": "Tchad" },
+        "TF": { "zoneName": "Terres australes et antarctiques françaises" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thaïlande" },
+        "TJ": { "zoneName": "Tadjikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor oriental" },
+        "TM": { "zoneName": "Turkménistan" },
+        "TN": { "zoneName": "Tunisie" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turquie" },
+        "TT": { "zoneName": "Trinité et Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taïwan" },
+        "TZ": { "zoneName": "Tanzanie" },
+        "UA": { "zoneName": "Ukraine" },
+        "UA-CR": { "zoneName": "Crimée", "countryName": "Ukraine" },
+        "UG": { "zoneName": "Ouganda" },
+        "UM": { "zoneName": "Îles mineures éloignées des États-Unis" },
+        "US-HI": { "countryName": "États-Unis d’Amérique", "zoneName": "Hawaï" },
+        "US-HI-HA": { "countryName": "États Unis d’Amérique", "zoneName": "Hawaï" },
+        "US-HI-KA": { "countryName": "États Unis d’Amérique", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "États Unis d’Amérique", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "États Unis d’Amérique", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "États Unis d’Amérique", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "États Unis d’Amérique", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "États Unis d’Amérique", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "États Unis d’Amérique", "zoneName": "Oahu" },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Ouzbékistan" },
+        "VA": { "zoneName": "Cité du Vatican" },
+        "VC": { "zoneName": "Saint-Vincent-et-les Grenadines" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Îles Vierges", "zoneName": "Îles Vierges britanniques" },
+        "VI": { "countryName": "États-Unis d’Amérique", "zoneName": "Îles Vierges des États-Unis" },
+        "VN": { "zoneName": "Viêt Nam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "countryName": "France", "zoneName": "Wallis-et-Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Chypre du Nord" },
+        "YE": { "zoneName": "Yémen" },
+        "YT": { "countryName": "France", "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Afrique du Sud" },
+        "ZM": { "zoneName": "Zambie" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/hr.json
+++ b/web/public/locales/hr.json
@@ -6,15 +6,9 @@
         "datasources": "izvore podataka",
         "contribute": "Daj svoj doprinos <a href=\"%s\" target=\"_blank\">dodavanjem vlastitog područja</a>"
     },
-    "mobile-main-menu": {
-        "map": "Mapa",
-        "areas": "Područja",
-        "about": "O nama"
-    },
+    "mobile-main-menu": { "map": "Mapa", "areas": "Područja", "about": "O nama" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Prikaz utjecaja struje na klimu"
-        },
+        "view1": { "subtitle": "Prikaz utjecaja struje na klimu" },
         "view2": {
             "header": "Pogledaj koliko CO₂ se emitira za proizvodnju tvoje struje, u realnom vremenu",
             "text": "Područja u svijetu su pobojana prema faktoru emisije (uključujući sve staklenične plinove) svoje upotrijebljene struje. Zelena boja označava manje ekološkije izvore struje."
@@ -50,13 +44,13 @@
         "search": "Traži"
     },
     "country-history": {
-        "carbonintensity24h": "Faktor emisije u zadnja 24 sata",
-        "emissionsorigin24h": "Izvor emisija u zadnja 24 sata",
-        "emissionsproduction24h": "Emisije proizvedene u zadnja 24 sata",
-        "electricityorigin24h": "Izvor struje u zadnja 24 sata",
-        "electricityproduction24h": "Proizvodnja struje u zadnja 24 sata",
-        "electricityprices24h": "Cijene struje u zadnja 24 sata",
-        "Getdata": "Nađi povijesne podatke i API s prognozom"
+        "Getdata": "Nađi povijesne podatke i API s prognozom",
+        "carbonintensity": { "hourly": "Faktor emisije u zadnja 24 sata" },
+        "emissionsorigin": { "hourly": "Izvor emisija u zadnja 24 sata" },
+        "emissionsproduction": { "hourly": "Emisije proizvedene u zadnja 24 sata" },
+        "electricityorigin": { "hourly": "Izvor struje u zadnja 24 sata" },
+        "electricityproduction": { "hourly": "Proizvodnja struje u zadnja 24 sata" },
+        "electricityprices": { "hourly": "Cijene struje u zadnja 24 sata" }
     },
     "footer": {
         "foundbugs": "Pronašao si grešku ili imaš ideje? Prijavi ih",
@@ -184,1210 +178,366 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> objavljuje podatke i slike na <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> u svrhu informiranja. Ne daje nikakve tvrdnje o ispravnosti podataka, niti daje ikakav oblik garancije i uzima za pravo promijeniti sadržaj u bilo kojem trenutku ili ukloniti dijelove bez prethodnog informiranja. electricityMap ne preuzima odgovornost za nikakvu štetu ili troškove uzrokovane nepouzdanošću, nepotpunošću ili zastarjelosti podaka na mapi ili informaciji izvedenoj iz tih podataka. Nije dopušteno uključiti ovu web stranicu ili bilo koje njene pojedine dijelove u drugu web stranicu bez prijašnjeg formalnog pismenog dopuštenja.<br><br> Sva intelektualna vlasnička prava pripadaju pravim vlasnicima i davateljima licence. Kopiranje, distribucija i bilo kakvo korištenje ovih sadržaja (posebno energetskih podataka) nije dozvoljeno bez pismene dozvole electricityMap-a, osim u slučajima pokrivenim propisima obveznog prava (npr. prava o citiranju), osim iznimnih odredbi za specifične sadržaje.<br><br> Ova odredba je ažurirana s vremena na vrijeme."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andora"
-        },
-        "AE": {
-            "zoneName": "Ujedinjeni Arapski Emirati"
-        },
-        "AF": {
-            "zoneName": "Afganistan"
-        },
-        "AG": {
-            "zoneName": "Antigva i Barbuda"
-        },
-        "AI": {
-            "zoneName": "Angvila"
-        },
-        "AL": {
-            "zoneName": "Albanija"
-        },
-        "AM": {
-            "zoneName": "Armenija"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarktika"
-        },
-        "AS": {
-            "zoneName": "Američka Samoa"
-        },
-        "AT": {
-            "zoneName": "Austrija"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AUS-NSW": {
-            "countryName": "Australija",
-            "zoneName": "Novi Južni Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Australija",
-            "zoneName": "Sjeverni teritorij"
-        },
-        "AUS-QLD": {
-            "countryName": "Australija",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australija",
-            "zoneName": "Južna Australija"
-        },
-        "AUS-TAS": {
-            "countryName": "Australija",
-            "zoneName": "Tasmanija"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmanija",
-            "zoneName": "King Island"
-        },
-        "AUS-VIC": {
-            "countryName": "Australija",
-            "zoneName": "Viktorija"
-        },
-        "AUS-WA": {
-            "countryName": "Australija",
-            "zoneName": "Zapadna Australija"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Ålandski Otoci"
-        },
-        "AZ": {
-            "zoneName": "Azerbejdžan"
-        },
-        "BA": {
-            "zoneName": "Bosna i Hercegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladeš"
-        },
-        "BE": {
-            "zoneName": "Belgija"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bugarska"
-        },
-        "BH": {
-            "zoneName": "Bahrein"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunej"
-        },
-        "BO": {
-            "zoneName": "Bolivija"
-        },
-        "BQ": {
-            "zoneName": "Karipska Nizozemska"
-        },
-        "BR-CS": {
-            "countryName": "Brazil",
-            "zoneName": "Središnji Brazil"
-        },
-        "BR-N": {
-            "countryName": "Brazil",
-            "zoneName": "Sjeverni Brazil"
-        },
-        "BR-NE": {
-            "countryName": "Brazil",
-            "zoneName": "Sjeveroistočni Brazil"
-        },
-        "BR-S": {
-            "countryName": "Brazil",
-            "zoneName": "Južni Brazil"
-        },
-        "BS": {
-            "zoneName": "Bahami"
-        },
-        "BT": {
-            "zoneName": "Butan"
-        },
-        "BV": {
-            "zoneName": "Otok Bouvet"
-        },
-        "BW": {
-            "zoneName": "Botsvana"
-        },
-        "BY": {
-            "zoneName": "Bjelorusija"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "Britanska Kolumbija"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland i Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "Novi Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Sjeveroistočni teritorij"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Otok Princa Edwarda"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Kokosovi otoci"
-        },
-        "CD": {
-            "zoneName": "DR Kongo"
-        },
-        "CF": {
-            "zoneName": "Srednjoafrička Republika"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Švicarska"
-        },
-        "CI": {
-            "zoneName": "Obala Bjelokosti"
-        },
-        "CK": {
-            "zoneName": "Cookovo Otočje"
-        },
-        "CL-SEN": {
-            "countryName": "Čile",
-            "zoneName": "SEN"
-        },
-        "CL-SEM": {
-            "countryName": "Čile",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "Čile",
-            "zoneName": "SEA"
-        },
-        "CL-CHP": {
-            "countryName": "Čile",
-            "zoneName": "Uskršnji otok"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Kina"
-        },
-        "CO": {
-            "zoneName": "Kolumbija"
-        },
-        "CR": {
-            "zoneName": "Kostarika"
-        },
-        "CU": {
-            "zoneName": "Kuba"
-        },
-        "CV": {
-            "zoneName": "Zelenortska Republika"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Božićni Otok"
-        },
-        "CY": {
-            "zoneName": "Cipar"
-        },
-        "CZ": {
-            "zoneName": "Češka"
-        },
-        "DE": {
-            "zoneName": "Njemačka"
-        },
-        "DJ": {
-            "zoneName": "Džibuti"
-        },
-        "DK": {
-            "zoneName": "Danska"
-        },
-        "DK-DK1": {
-            "countryName": "Danska",
-            "zoneName": "Zapadna Danska"
-        },
-        "DK-DK2": {
-            "countryName": "Danska",
-            "zoneName": "Istočna Danska"
-        },
-        "DK-BHM": {
-            "countryName": "Danska",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominika"
-        },
-        "DO": {
-            "zoneName": "Dominikanska Republika"
-        },
-        "DZ": {
-            "zoneName": "Alžir"
-        },
-        "EC": {
-            "zoneName": "Ekvador"
-        },
-        "EE": {
-            "zoneName": "Estonija"
-        },
-        "EG": {
-            "zoneName": "Egipat"
-        },
-        "EH": {
-            "zoneName": "Zapadna Sahara"
-        },
-        "ER": {
-            "zoneName": "Eritreja"
-        },
-        "ES": {
-            "zoneName": "Španjolska"
-        },
-        "ES-IB-FO": {
-            "countryName": "Španjolska",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Španjolska",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Španjolska",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Španjolska",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Španjolska",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Španjolska",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Španjolska",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Španjolska",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Španjolska",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Španjolska",
-            "zoneName": "Tenerifi"
-        },
-        "ET": {
-            "zoneName": "Etiopija"
-        },
-        "FI": {
-            "zoneName": "Finska"
-        },
-        "FJ": {
-            "zoneName": "Fidži"
-        },
-        "FK": {
-            "zoneName": "Falklandsko Otočje"
-        },
-        "FM": {
-            "zoneName": "Mikronezija"
-        },
-        "FO": {
-            "zoneName": "Farojsko Otočje"
-        },
-        "FR": {
-            "zoneName": "Francuska"
-        },
-        "FR-COR": {
-            "countryName": "Francuska",
-            "zoneName": "Korzika"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Velika Britanija"
-        },
-        "GB-NIR": {
-            "zoneName": "Južna Irska"
-        },
-        "GB-ORK": {
-            "countryName": "Velika Britanija",
-            "zoneName": "Otočje Orkney"
-        },
-        "GB-SHI": {
-            "countryName": "Velika Britanija",
-            "zoneName": "Shetland Otoci"
-        },
-        "GB-ZET": {
-            "countryName": "Velika Britanija",
-            "zoneName": "Shetland Otoci"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Gruzija"
-        },
-        "GF": {
-            "zoneName": "Francuska Gvajana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Gana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Grenland"
-        },
-        "GM": {
-            "zoneName": "Gambija"
-        },
-        "GN": {
-            "zoneName": "Gvineja"
-        },
-        "GP": {
-            "zoneName": "Gvadalupa"
-        },
-        "GQ": {
-            "zoneName": "Ekvatorijalna Gvineja"
-        },
-        "GR": {
-            "zoneName": "Grčka"
-        },
-        "GR-IS": {
-            "countryName": "Grčka",
-            "zoneName": "Egejski Otoci"
-        },
-        "GS": {
-            "zoneName": "Južna Georgija i otočje Južni Sandwich"
-        },
-        "GT": {
-            "zoneName": "Gvatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Gvineja Bisau"
-        },
-        "GY": {
-            "zoneName": "Gvajana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Otok Heard i otočje McDonald"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Hrvatska"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Mađarska"
-        },
-        "ID": {
-            "zoneName": "Indonezija"
-        },
-        "IE": {
-            "zoneName": "Irska"
-        },
-        "IL": {
-            "zoneName": "Izrael"
-        },
-        "IM": {
-            "zoneName": "Otok Man"
-        },
-        "IN-AN": {
-            "countryName": "Indija",
-            "zoneName": "Otoci Andaman i Nicobar"
-        },
-        "IN-AP": {
-            "countryName": "Indija",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Indija",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Indija",
-            "zoneName": "Asam"
-        },
-        "IN-BR": {
-            "countryName": "Indija",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Indija",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Indija",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "India",
-            "zoneName": "Dadra i Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "Indija",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Indija",
-            "zoneName": "Gudžarat"
-        },
-        "IN-HP": {
-            "countryName": "Indija",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Indija",
-            "zoneName": "Hariana"
-        },
-        "IN-JH": {
-            "countryName": "Indija",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Indija",
-            "zoneName": "Jammu i Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "Indija",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Indija",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Indija",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "Indija",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Indija",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Indija",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Indija",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Indija",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Indija",
-            "zoneName": "Orisa"
-        },
-        "IN-PB": {
-            "countryName": "Indija",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "Indija",
-            "zoneName": "Puducherry"
-        },
-        "IN-RJ": {
-            "countryName": "Indija",
-            "zoneName": "Radžastan"
-        },
-        "IN-SK": {
-            "countryName": "Indija",
-            "zoneName": "Sikkim"
-        },
-        "IN-TR": {
-            "countryName": "Indija",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Indija",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Indija",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Indija",
-            "zoneName": "Zapadni Bengal"
-        },
-        "IO": {
-            "zoneName": "Britanski Indijskooceanski teritorij"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Island"
-        },
-        "IT": {
-            "zoneName": "Italija"
-        },
-        "IT-CNO": {
-            "countryName": "Italija",
-            "zoneName": "Srednji Sjever"
-        },
-        "IT-CSO": {
-            "countryName": "Italija",
-            "zoneName": "Srednji Jug"
-        },
-        "IT-NO": {
-            "countryName": "Italija",
-            "zoneName": "Sjever"
-        },
-        "IT-SAR": {
-            "countryName": "Italija",
-            "zoneName": "Sardinija"
-        },
-        "IT-SIC": {
-            "countryName": "Italija",
-            "zoneName": "Sicilija"
-        },
-        "IT-SO": {
-            "countryName": "Italija",
-            "zoneName": "Jug"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamajka"
-        },
-        "JO": {
-            "zoneName": "Jordan"
-        },
-        "JP-CB": {
-            "countryName": "Japan",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japan",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japan",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Japan",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japan",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japan",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Japan",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japan",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japan",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japan",
-            "zoneName": "Tokio"
-        },
-        "KE": {
-            "zoneName": "Kenija"
-        },
-        "KG": {
-            "zoneName": "Kirgistan"
-        },
-        "KH": {
-            "zoneName": "Kambodža"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Komori"
-        },
-        "KN": {
-            "zoneName": "Sveti Kristofor i Nevis"
-        },
-        "KP": {
-            "zoneName": "Sjeverna Koreja"
-        },
-        "KR": {
-            "zoneName": "Južna Koreja"
-        },
-        "KW": {
-            "zoneName": "Kuvajt"
-        },
-        "KY": {
-            "zoneName": "Kajmanski otoci"
-        },
-        "KZ": {
-            "zoneName": "Kazahstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Libanon"
-        },
-        "LC": {
-            "zoneName": "Sveta Lucija"
-        },
-        "LI": {
-            "zoneName": "Lihtenštajn"
-        },
-        "LK": {
-            "zoneName": "Šri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberija"
-        },
-        "LS": {
-            "zoneName": "Lesoto"
-        },
-        "LT": {
-            "zoneName": "Litva"
-        },
-        "LU": {
-            "zoneName": "Luksemburg"
-        },
-        "LV": {
-            "zoneName": "Latvija"
-        },
-        "LY": {
-            "zoneName": "Libija"
-        },
-        "MA": {
-            "zoneName": "Maroko"
-        },
-        "MC": {
-            "zoneName": "Monako"
-        },
-        "MD": {
-            "zoneName": "Moldavija"
-        },
-        "ME": {
-            "zoneName": "Crna Gora"
-        },
-        "MF": {
-            "countryName": "Sveti Martin",
-            "zoneName": "Francuska"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Maršalovi Otoci"
-        },
-        "MK": {
-            "zoneName": "Sjeverna Makedonija"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Mjanmar"
-        },
-        "MN": {
-            "zoneName": "Mongolija"
-        },
-        "MO": {
-            "zoneName": "Makao"
-        },
-        "MP": {
-            "zoneName": "Sjevernomarijanski otoci"
-        },
-        "MQ": {
-            "zoneName": "Martinik"
-        },
-        "MR": {
-            "zoneName": "Mauretanija"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauricijus"
-        },
-        "MV": {
-            "zoneName": "Maldivi"
-        },
-        "MW": {
-            "zoneName": "Malavi"
-        },
-        "MX": {
-            "zoneName": "Meksiko"
-        },
-        "MX-BC": {
-            "countryName": "Meksiko",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Meksiko",
-            "zoneName": "Središnji"
-        },
-        "MX-NE": {
-            "countryName": "Meksiko",
-            "zoneName": "Sjeveroistočni"
-        },
-        "MX-NO": {
-            "countryName": "Meksiko",
-            "zoneName": "Sjeverni"
-        },
-        "MX-NW": {
-            "countryName": "Meksiko",
-            "zoneName": "Sjeverozapadni"
-        },
-        "MX-OC": {
-            "countryName": "Meksiko",
-            "zoneName": "Zapadni"
-        },
-        "MX-OR": {
-            "countryName": "Meksiko",
-            "zoneName": "Istočni"
-        },
-        "MX-PN": {
-            "countryName": "Meksiko",
-            "zoneName": "Poluotok"
-        },
-        "MY-EM": {
-            "countryName": "Malezija",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malezija",
-            "zoneName": "Zapadna Malezija"
-        },
-        "MZ": {
-            "zoneName": "Mozambik"
-        },
-        "NA": {
-            "zoneName": "Namibija"
-        },
-        "NC": {
-            "zoneName": "Nova Kaledonija"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Otok Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigerija"
-        },
-        "NI": {
-            "zoneName": "Nikaragva"
-        },
-        "NL": {
-            "zoneName": "Nizozemska"
-        },
-        "NO-NO1": {
-            "countryName": "Norveška",
-            "zoneName": "Jugoistočna Norveška"
-        },
-        "NO-NO2": {
-            "countryName": "Norveška",
-            "zoneName": "Jugozapadna Norveška"
-        },
-        "NO-NO3": {
-            "countryName": "Norveška",
-            "zoneName": "Središnja Norveška"
-        },
-        "NO-NO4": {
-            "countryName": "Norveška",
-            "zoneName": "Sjeverna Norveška"
-        },
-        "NO-NO5": {
-            "countryName": "Norveška",
-            "zoneName": "Zapadna Norveška"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Novi Zeland"
-        },
-        "NZ-NZA": {
-            "countryName": "Novi Zeland",
-            "zoneName": "Aucklandsko Otočje"
-        },
-        "NZ-NZC": {
-            "countryName": "Novi Zeland",
-            "zoneName": "Otočje Chatham"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Francuska Polinezija"
-        },
-        "PG": {
-            "zoneName": "Papua-Nova Gvineja"
-        },
-        "PH": {
-            "zoneName": "Filipini"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Poljska"
-        },
-        "PM": {
-            "zoneName": "Sveti Petar i Mikelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairnovo Otočje"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Palestina"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Azori"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madera"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paragvaj"
-        },
-        "QA": {
-            "zoneName": "Katar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Rumunjska"
-        },
-        "RS": {
-            "zoneName": "Srbija"
-        },
-        "RU": {
-            "zoneName": "Rusija"
-        },
-        "RU-1": {
-            "countryName": "Rusija",
-            "zoneName": "Europska Rusija i Ural"
-        },
-        "RU-2": {
-            "countryName": "Rusija",
-            "zoneName": "Sibir"
-        },
-        "RU-EU": {
-            "zoneName": "Rusija"
-        },
-        "RU-AS": {
-            "zoneName": "Rusija"
-        },
-        "RU-KGD": {
-            "countryName": "Rusija",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Ruanda"
-        },
-        "SA": {
-            "zoneName": "Saudijska Arabija"
-        },
-        "SB": {
-            "zoneName": "Solomonsko Otočje"
-        },
-        "SC": {
-            "zoneName": "Sejšeli"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Švedska"
-        },
-        "SG": {
-            "zoneName": "Singapur"
-        },
-        "SH": {
-            "zoneName": "Sveta Helena"
-        },
-        "SI": {
-            "zoneName": "Slovenija"
-        },
-        "SJ": {
-            "zoneName": "Svalbard i Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovačka"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalija"
-        },
-        "SR": {
-            "zoneName": "Surinam"
-        },
-        "SS": {
-            "zoneName": "Južni Sudan"
-        },
-        "ST": {
-            "zoneName": "Sveti Toma i Princip"
-        },
-        "SV": {
-            "zoneName": "Salvador"
-        },
-        "SX": {
-            "countryName": "Sveti Martin",
-            "zoneName": "Nizozemska"
-        },
-        "SY": {
-            "zoneName": "Sirija"
-        },
-        "SZ": {
-            "zoneName": "Esvatini"
-        },
-        "TC": {
-            "zoneName": "Otoci Turks i Caicos"
-        },
-        "TD": {
-            "zoneName": "Čad"
-        },
-        "TF": {
-            "zoneName": "Francuski južni teritoriji"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Tajland"
-        },
-        "TJ": {
-            "zoneName": "Tadžikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Istočni Timor"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunis"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turska"
-        },
-        "TT": {
-            "zoneName": "Trinidad i Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Tajvan"
-        },
-        "TZ": {
-            "zoneName": "Tanzanija"
-        },
-        "UA": {
-            "zoneName": "Ukrajina"
-        },
-        "UA-CR": {
-            "countryName": "Krimea",
-            "zoneName": "Ukrajina"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Mali udaljeni otoci SAD-a"
-        },
-        "UY": {
-            "zoneName": "Urugvaj"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatikan"
-        },
-        "VC": {
-            "zoneName": "Sveti Vincent i Grenadini"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Djevičanski otoci",
-            "zoneName": "Djevičanski otoci"
-        },
-        "VI": {
-            "countryName": "Sjedinjene Američke Države",
-            "zoneName": "Djevičanski otoci"
-        },
-        "VN": {
-            "zoneName": "Vijetnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis i Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Sjeverni Cipar"
-        },
-        "YE": {
-            "zoneName": "Jemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Južna Afrika"
-        },
-        "ZM": {
-            "zoneName": "Zambija"
-        },
-        "ZW": {
-            "zoneName": "Zimbabve"
-        }
+        "AD": { "zoneName": "Andora" },
+        "AE": { "zoneName": "Ujedinjeni Arapski Emirati" },
+        "AF": { "zoneName": "Afganistan" },
+        "AG": { "zoneName": "Antigva i Barbuda" },
+        "AI": { "zoneName": "Angvila" },
+        "AL": { "zoneName": "Albanija" },
+        "AM": { "zoneName": "Armenija" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarktika" },
+        "AS": { "zoneName": "Američka Samoa" },
+        "AT": { "zoneName": "Austrija" },
+        "AR": { "zoneName": "Argentina" },
+        "AUS-NSW": { "countryName": "Australija", "zoneName": "Novi Južni Wales" },
+        "AUS-NT": { "countryName": "Australija", "zoneName": "Sjeverni teritorij" },
+        "AUS-QLD": { "countryName": "Australija", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australija", "zoneName": "Južna Australija" },
+        "AUS-TAS": { "countryName": "Australija", "zoneName": "Tasmanija" },
+        "AUS-TAS-KI": { "countryName": "Tasmanija", "zoneName": "King Island" },
+        "AUS-VIC": { "countryName": "Australija", "zoneName": "Viktorija" },
+        "AUS-WA": { "countryName": "Australija", "zoneName": "Zapadna Australija" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Ålandski Otoci" },
+        "AZ": { "zoneName": "Azerbejdžan" },
+        "BA": { "zoneName": "Bosna i Hercegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladeš" },
+        "BE": { "zoneName": "Belgija" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bugarska" },
+        "BH": { "zoneName": "Bahrein" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunej" },
+        "BO": { "zoneName": "Bolivija" },
+        "BQ": { "zoneName": "Karipska Nizozemska" },
+        "BR-CS": { "countryName": "Brazil", "zoneName": "Središnji Brazil" },
+        "BR-N": { "countryName": "Brazil", "zoneName": "Sjeverni Brazil" },
+        "BR-NE": { "countryName": "Brazil", "zoneName": "Sjeveroistočni Brazil" },
+        "BR-S": { "countryName": "Brazil", "zoneName": "Južni Brazil" },
+        "BS": { "zoneName": "Bahami" },
+        "BT": { "zoneName": "Butan" },
+        "BV": { "zoneName": "Otok Bouvet" },
+        "BW": { "zoneName": "Botsvana" },
+        "BY": { "zoneName": "Bjelorusija" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "Britanska Kolumbija" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland i Labrador" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "Novi Brunswick" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Sjeveroistočni teritorij" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nova Scotia" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Otok Princa Edwarda" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Kokosovi otoci" },
+        "CD": { "zoneName": "DR Kongo" },
+        "CF": { "zoneName": "Srednjoafrička Republika" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Švicarska" },
+        "CI": { "zoneName": "Obala Bjelokosti" },
+        "CK": { "zoneName": "Cookovo Otočje" },
+        "CL-SEN": { "countryName": "Čile", "zoneName": "SEN" },
+        "CL-SEM": { "countryName": "Čile", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "Čile", "zoneName": "SEA" },
+        "CL-CHP": { "countryName": "Čile", "zoneName": "Uskršnji otok" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Kina" },
+        "CO": { "zoneName": "Kolumbija" },
+        "CR": { "zoneName": "Kostarika" },
+        "CU": { "zoneName": "Kuba" },
+        "CV": { "zoneName": "Zelenortska Republika" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Božićni Otok" },
+        "CY": { "zoneName": "Cipar" },
+        "CZ": { "zoneName": "Češka" },
+        "DE": { "zoneName": "Njemačka" },
+        "DJ": { "zoneName": "Džibuti" },
+        "DK": { "zoneName": "Danska" },
+        "DK-DK1": { "countryName": "Danska", "zoneName": "Zapadna Danska" },
+        "DK-DK2": { "countryName": "Danska", "zoneName": "Istočna Danska" },
+        "DK-BHM": { "countryName": "Danska", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominika" },
+        "DO": { "zoneName": "Dominikanska Republika" },
+        "DZ": { "zoneName": "Alžir" },
+        "EC": { "zoneName": "Ekvador" },
+        "EE": { "zoneName": "Estonija" },
+        "EG": { "zoneName": "Egipat" },
+        "EH": { "zoneName": "Zapadna Sahara" },
+        "ER": { "zoneName": "Eritreja" },
+        "ES": { "zoneName": "Španjolska" },
+        "ES-IB-FO": { "countryName": "Španjolska", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Španjolska", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Španjolska", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Španjolska", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Španjolska", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Španjolska", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Španjolska", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Španjolska", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "Španjolska", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Španjolska", "zoneName": "Tenerifi" },
+        "ET": { "zoneName": "Etiopija" },
+        "FI": { "zoneName": "Finska" },
+        "FJ": { "zoneName": "Fidži" },
+        "FK": { "zoneName": "Falklandsko Otočje" },
+        "FM": { "zoneName": "Mikronezija" },
+        "FO": { "zoneName": "Farojsko Otočje" },
+        "FR": { "zoneName": "Francuska" },
+        "FR-COR": { "countryName": "Francuska", "zoneName": "Korzika" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Velika Britanija" },
+        "GB-NIR": { "zoneName": "Južna Irska" },
+        "GB-ORK": { "countryName": "Velika Britanija", "zoneName": "Otočje Orkney" },
+        "GB-SHI": { "countryName": "Velika Britanija", "zoneName": "Shetland Otoci" },
+        "GB-ZET": { "countryName": "Velika Britanija", "zoneName": "Shetland Otoci" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Gruzija" },
+        "GF": { "zoneName": "Francuska Gvajana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Gana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Grenland" },
+        "GM": { "zoneName": "Gambija" },
+        "GN": { "zoneName": "Gvineja" },
+        "GP": { "zoneName": "Gvadalupa" },
+        "GQ": { "zoneName": "Ekvatorijalna Gvineja" },
+        "GR": { "zoneName": "Grčka" },
+        "GR-IS": { "countryName": "Grčka", "zoneName": "Egejski Otoci" },
+        "GS": { "zoneName": "Južna Georgija i otočje Južni Sandwich" },
+        "GT": { "zoneName": "Gvatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Gvineja Bisau" },
+        "GY": { "zoneName": "Gvajana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Otok Heard i otočje McDonald" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Hrvatska" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Mađarska" },
+        "ID": { "zoneName": "Indonezija" },
+        "IE": { "zoneName": "Irska" },
+        "IL": { "zoneName": "Izrael" },
+        "IM": { "zoneName": "Otok Man" },
+        "IN-AN": { "countryName": "Indija", "zoneName": "Otoci Andaman i Nicobar" },
+        "IN-AP": { "countryName": "Indija", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Indija", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Indija", "zoneName": "Asam" },
+        "IN-BR": { "countryName": "Indija", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Indija", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Indija", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "India", "zoneName": "Dadra i Nagar Haveli" },
+        "IN-GA": { "countryName": "Indija", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Indija", "zoneName": "Gudžarat" },
+        "IN-HP": { "countryName": "Indija", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Indija", "zoneName": "Hariana" },
+        "IN-JH": { "countryName": "Indija", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Indija", "zoneName": "Jammu i Kashmir" },
+        "IN-KA": { "countryName": "Indija", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Indija", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Indija", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "Indija", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Indija", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Indija", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Indija", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Indija", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Indija", "zoneName": "Orisa" },
+        "IN-PB": { "countryName": "Indija", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "Indija", "zoneName": "Puducherry" },
+        "IN-RJ": { "countryName": "Indija", "zoneName": "Radžastan" },
+        "IN-SK": { "countryName": "Indija", "zoneName": "Sikkim" },
+        "IN-TR": { "countryName": "Indija", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Indija", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Indija", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Indija", "zoneName": "Zapadni Bengal" },
+        "IO": { "zoneName": "Britanski Indijskooceanski teritorij" },
+        "IQ": { "zoneName": "Irak" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Island" },
+        "IT": { "zoneName": "Italija" },
+        "IT-CNO": { "countryName": "Italija", "zoneName": "Srednji Sjever" },
+        "IT-CSO": { "countryName": "Italija", "zoneName": "Srednji Jug" },
+        "IT-NO": { "countryName": "Italija", "zoneName": "Sjever" },
+        "IT-SAR": { "countryName": "Italija", "zoneName": "Sardinija" },
+        "IT-SIC": { "countryName": "Italija", "zoneName": "Sicilija" },
+        "IT-SO": { "countryName": "Italija", "zoneName": "Jug" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamajka" },
+        "JO": { "zoneName": "Jordan" },
+        "JP-CB": { "countryName": "Japan", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Japan", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Japan", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Japan", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japan", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japan", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Japan", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japan", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japan", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Japan", "zoneName": "Tokio" },
+        "KE": { "zoneName": "Kenija" },
+        "KG": { "zoneName": "Kirgistan" },
+        "KH": { "zoneName": "Kambodža" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Komori" },
+        "KN": { "zoneName": "Sveti Kristofor i Nevis" },
+        "KP": { "zoneName": "Sjeverna Koreja" },
+        "KR": { "zoneName": "Južna Koreja" },
+        "KW": { "zoneName": "Kuvajt" },
+        "KY": { "zoneName": "Kajmanski otoci" },
+        "KZ": { "zoneName": "Kazahstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Libanon" },
+        "LC": { "zoneName": "Sveta Lucija" },
+        "LI": { "zoneName": "Lihtenštajn" },
+        "LK": { "zoneName": "Šri Lanka" },
+        "LR": { "zoneName": "Liberija" },
+        "LS": { "zoneName": "Lesoto" },
+        "LT": { "zoneName": "Litva" },
+        "LU": { "zoneName": "Luksemburg" },
+        "LV": { "zoneName": "Latvija" },
+        "LY": { "zoneName": "Libija" },
+        "MA": { "zoneName": "Maroko" },
+        "MC": { "zoneName": "Monako" },
+        "MD": { "zoneName": "Moldavija" },
+        "ME": { "zoneName": "Crna Gora" },
+        "MF": { "countryName": "Sveti Martin", "zoneName": "Francuska" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Maršalovi Otoci" },
+        "MK": { "zoneName": "Sjeverna Makedonija" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Mjanmar" },
+        "MN": { "zoneName": "Mongolija" },
+        "MO": { "zoneName": "Makao" },
+        "MP": { "zoneName": "Sjevernomarijanski otoci" },
+        "MQ": { "zoneName": "Martinik" },
+        "MR": { "zoneName": "Mauretanija" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauricijus" },
+        "MV": { "zoneName": "Maldivi" },
+        "MW": { "zoneName": "Malavi" },
+        "MX": { "zoneName": "Meksiko" },
+        "MX-BC": { "countryName": "Meksiko", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Meksiko", "zoneName": "Središnji" },
+        "MX-NE": { "countryName": "Meksiko", "zoneName": "Sjeveroistočni" },
+        "MX-NO": { "countryName": "Meksiko", "zoneName": "Sjeverni" },
+        "MX-NW": { "countryName": "Meksiko", "zoneName": "Sjeverozapadni" },
+        "MX-OC": { "countryName": "Meksiko", "zoneName": "Zapadni" },
+        "MX-OR": { "countryName": "Meksiko", "zoneName": "Istočni" },
+        "MX-PN": { "countryName": "Meksiko", "zoneName": "Poluotok" },
+        "MY-EM": { "countryName": "Malezija", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malezija", "zoneName": "Zapadna Malezija" },
+        "MZ": { "zoneName": "Mozambik" },
+        "NA": { "zoneName": "Namibija" },
+        "NC": { "zoneName": "Nova Kaledonija" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Otok Norfolk" },
+        "NG": { "zoneName": "Nigerija" },
+        "NI": { "zoneName": "Nikaragva" },
+        "NL": { "zoneName": "Nizozemska" },
+        "NO-NO1": { "countryName": "Norveška", "zoneName": "Jugoistočna Norveška" },
+        "NO-NO2": { "countryName": "Norveška", "zoneName": "Jugozapadna Norveška" },
+        "NO-NO3": { "countryName": "Norveška", "zoneName": "Središnja Norveška" },
+        "NO-NO4": { "countryName": "Norveška", "zoneName": "Sjeverna Norveška" },
+        "NO-NO5": { "countryName": "Norveška", "zoneName": "Zapadna Norveška" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Novi Zeland" },
+        "NZ-NZA": { "countryName": "Novi Zeland", "zoneName": "Aucklandsko Otočje" },
+        "NZ-NZC": { "countryName": "Novi Zeland", "zoneName": "Otočje Chatham" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Francuska Polinezija" },
+        "PG": { "zoneName": "Papua-Nova Gvineja" },
+        "PH": { "zoneName": "Filipini" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Poljska" },
+        "PM": { "zoneName": "Sveti Petar i Mikelon" },
+        "PN": { "zoneName": "Pitcairnovo Otočje" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Palestina" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Azori" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madera" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paragvaj" },
+        "QA": { "zoneName": "Katar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Rumunjska" },
+        "RS": { "zoneName": "Srbija" },
+        "RU": { "zoneName": "Rusija" },
+        "RU-1": { "countryName": "Rusija", "zoneName": "Europska Rusija i Ural" },
+        "RU-2": { "countryName": "Rusija", "zoneName": "Sibir" },
+        "RU-EU": { "zoneName": "Rusija" },
+        "RU-AS": { "zoneName": "Rusija" },
+        "RU-KGD": { "countryName": "Rusija", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Ruanda" },
+        "SA": { "zoneName": "Saudijska Arabija" },
+        "SB": { "zoneName": "Solomonsko Otočje" },
+        "SC": { "zoneName": "Sejšeli" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Švedska" },
+        "SG": { "zoneName": "Singapur" },
+        "SH": { "zoneName": "Sveta Helena" },
+        "SI": { "zoneName": "Slovenija" },
+        "SJ": { "zoneName": "Svalbard i Jan Mayen" },
+        "SK": { "zoneName": "Slovačka" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalija" },
+        "SR": { "zoneName": "Surinam" },
+        "SS": { "zoneName": "Južni Sudan" },
+        "ST": { "zoneName": "Sveti Toma i Princip" },
+        "SV": { "zoneName": "Salvador" },
+        "SX": { "countryName": "Sveti Martin", "zoneName": "Nizozemska" },
+        "SY": { "zoneName": "Sirija" },
+        "SZ": { "zoneName": "Esvatini" },
+        "TC": { "zoneName": "Otoci Turks i Caicos" },
+        "TD": { "zoneName": "Čad" },
+        "TF": { "zoneName": "Francuski južni teritoriji" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Tajland" },
+        "TJ": { "zoneName": "Tadžikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Istočni Timor" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunis" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turska" },
+        "TT": { "zoneName": "Trinidad i Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Tajvan" },
+        "TZ": { "zoneName": "Tanzanija" },
+        "UA": { "zoneName": "Ukrajina" },
+        "UA-CR": { "countryName": "Krimea", "zoneName": "Ukrajina" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Mali udaljeni otoci SAD-a" },
+        "UY": { "zoneName": "Urugvaj" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Vatikan" },
+        "VC": { "zoneName": "Sveti Vincent i Grenadini" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Djevičanski otoci", "zoneName": "Djevičanski otoci" },
+        "VI": { "countryName": "Sjedinjene Američke Države", "zoneName": "Djevičanski otoci" },
+        "VN": { "zoneName": "Vijetnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis i Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Sjeverni Cipar" },
+        "YE": { "zoneName": "Jemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Južna Afrika" },
+        "ZM": { "zoneName": "Zambija" },
+        "ZW": { "zoneName": "Zimbabve" }
     }
 }

--- a/web/public/locales/id.json
+++ b/web/public/locales/id.json
@@ -6,15 +6,9 @@
         "datasources": "sumber data",
         "contribute": "Kontribusi oleh <a href=\"%s\" target=\"_blank\">tambahkan teritori Kamu</a>"
     },
-    "mobile-main-menu": {
-        "map": "Peta Kelistrikan",
-        "areas": "Area",
-        "about": "Tentang"
-    },
+    "mobile-main-menu": { "map": "Peta Kelistrikan", "areas": "Area", "about": "Tentang" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Pemetaan klimatologi yang berdampak pada daya listrik"
-        },
+        "view1": { "subtitle": "Pemetaan klimatologi yang berdampak pada daya listrik" },
         "view2": {
             "header": "Lihat seberapa banyak CO₂ yang dipancarkan untuk memproduksi listrik, secara langsung.",
             "text": "Kami memberikan warna pada area di seluruh dunia berdasarkan intensitas karbon (termasuk gas rumah kaca) yang digunakan dalam listrik di sana. Warna hijau menunjukkan bahwa area di sana sangat bersih dan ramah dalam penggunaan listrik."
@@ -50,13 +44,13 @@
         "search": "Cari area"
     },
     "country-history": {
-        "carbonintensity24h": "Intensitas Karbon dalam kurun waktu 24 jam terakhir",
-        "emissionsorigin24h": "Originalitas emisi dalam kurun waktu 24 jam terakhir",
-        "emissionsproduction24h": "Emisi yang dihasilkan dalam kurun waktu 24 jam terakhir",
-        "electricityorigin24h": "Originalitas listrik dalam kurun waktu 24 jam terakhir",
-        "electricityproduction24h": "Produksi listrik dalam kurun waktu 24 jam terakhir",
-        "electricityprices24h": "Harga listrik dalam kurun waktu 24 jam terakhir",
-        "Getdata": "Dapatkan data original, marjinal dan API cuaca."
+        "Getdata": "Dapatkan data original, marjinal dan API cuaca.",
+        "carbonintensity": { "hourly": "Intensitas Karbon dalam kurun waktu 24 jam terakhir" },
+        "emissionsorigin": { "hourly": "Originalitas emisi dalam kurun waktu 24 jam terakhir" },
+        "emissionsproduction": { "hourly": "Emisi yang dihasilkan dalam kurun waktu 24 jam terakhir" },
+        "electricityorigin": { "hourly": "Originalitas listrik dalam kurun waktu 24 jam terakhir" },
+        "electricityproduction": { "hourly": "Produksi listrik dalam kurun waktu 24 jam terakhir" },
+        "electricityprices": { "hourly": "Harga listrik dalam kurun waktu 24 jam terakhir" }
     },
     "footer": {
         "foundbugs": "Menemukan kesalahan dan ide baru? Laporkan pada Kami",
@@ -190,1245 +184,375 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publishes data and images on the <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> for information purposes. It makes no claims of correctness nor provides any form of warranties, and reserves the right to change the content at any time or to remove parts without having to inform you of this. electricityMap assumes no responsibility for, and shall not be liable for, any damages or expenses you may incur as a result of any inaccuracy, incompleteness, untimeliness or obsolescence of the electricityMap, or the information derived from them.  It is not allowed to include this webpage, or any of its individual elements, in another webpage, without formal prior written consent.<br><br> All intellectual property rights belong to the rightful owners and its licensors. Copying, distribution and any other use of these materials, in particular the energy data, is not permitted without the written permission of electricityMap, except and only to the extent otherwise provided in regulations of mandatory law (such as the right to quote), unless specified otherwise for specific materials. <br><br>This disclaimer may be updated from time to time."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Uni Emirat Arab"
-        },
-        "AF": {
-            "zoneName": "Afghanistan"
-        },
-        "AG": {
-            "zoneName": "Antigua dan Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albania"
-        },
-        "AM": {
-            "zoneName": "Armenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antartika"
-        },
-        "AS": {
-            "zoneName": "American Samoa"
-        },
-        "AT": {
-            "zoneName": "Austria"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AUS-NSW": {
-            "countryName": "Australia",
-            "zoneName": "New South Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Australia",
-            "zoneName": "Northern Territory"
-        },
-        "AUS-QLD": {
-            "countryName": "Australia",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australia",
-            "zoneName": "Australia Selatan"
-        },
-        "AUS-TAS": {
-            "countryName": "Australia",
-            "zoneName": "Tasmania"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmania",
-            "zoneName": "Pulau King"
-        },
-        "AUS-VIC": {
-            "countryName": "Australia",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australia",
-            "zoneName": "Australia Barat"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Pulau Åland"
-        },
-        "AZ": {
-            "zoneName": "Azerbaijan"
-        },
-        "BA": {
-            "zoneName": "Bosnia dan Herzegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Belgia"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgaria"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei Darussalam"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius dan Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brazil",
-            "zoneName": "Brazil Tengah"
-        },
-        "BR-N": {
-            "countryName": "Brazil",
-            "zoneName": "Brazil Utara"
-        },
-        "BR-NE": {
-            "countryName": "Brazil",
-            "zoneName": "Brazil Timur-laut"
-        },
-        "BR-S": {
-            "countryName": "Brazil",
-            "zoneName": "Brazil Selatan"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Pulau Bouvet"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Belarusia"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "British Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland dan Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Teritori Barat-laut"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Pulau Prince Edward"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Pulau Cocos"
-        },
-        "CD": {
-            "zoneName": "Republik Kongo"
-        },
-        "CF": {
-            "zoneName": "Republik Afrika Tengah"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Switzerland"
-        },
-        "CI": {
-            "zoneName": "Pantai Gading"
-        },
-        "CK": {
-            "zoneName": "Pulau Cook"
-        },
-        "CL-SING-SIC": {
-            "countryName": "Chili",
-            "zoneName": "SING/SIC"
-        },
-        "CL-SEM": {
-            "countryName": "Chili",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "Chili",
-            "zoneName": "SEA"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Cina"
-        },
-        "CO": {
-            "zoneName": "Kolombia"
-        },
-        "CR": {
-            "zoneName": "Kosta Rika"
-        },
-        "CU": {
-            "zoneName": "Kuba"
-        },
-        "CV": {
-            "zoneName": "Cabo Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Pulau Christmas"
-        },
-        "CY": {
-            "zoneName": "Cyprus"
-        },
-        "CZ": {
-            "zoneName": "Ceko"
-        },
-        "DE": {
-            "zoneName": "Jerman"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Denmark"
-        },
-        "DK-DK1": {
-            "countryName": "Denmark",
-            "zoneName": "Denmark Barat"
-        },
-        "DK-DK2": {
-            "countryName": "Denmark",
-            "zoneName": "Denmark Timur"
-        },
-        "DK-BHM": {
-            "countryName": "Denmark",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominika"
-        },
-        "DO": {
-            "zoneName": "Republik Dominika"
-        },
-        "DZ": {
-            "zoneName": "Algeria"
-        },
-        "EC": {
-            "zoneName": "Ekuador"
-        },
-        "EE": {
-            "zoneName": "Estonia"
-        },
-        "EG": {
-            "zoneName": "Mesir"
-        },
-        "EH": {
-            "zoneName": "Sahara Barat"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Spanyol"
-        },
-        "ES-IB-FO": {
-            "countryName": "Spanyol",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Spanyol",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Spanyol",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Spanyol",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Spanyol",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Spanyol",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Spanyol",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Spanyol",
-            "zoneName": "Isla de la Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Spanyol",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Spanyol",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Etiopia"
-        },
-        "FI": {
-            "zoneName": "Finlandia"
-        },
-        "FJ": {
-            "zoneName": "Fiji"
-        },
-        "FK": {
-            "zoneName": "Pulau Falkland"
-        },
-        "FM": {
-            "zoneName": "Micronesia"
-        },
-        "FO": {
-            "zoneName": "Pulau Faroe"
-        },
-        "FR": {
-            "zoneName": "Perancis"
-        },
-        "FR-COR": {
-            "countryName": "Perancis",
-            "zoneName": "Corsica"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Britania Raya"
-        },
-        "GB-NIR": {
-            "zoneName": "Irlandia Utara"
-        },
-        "GB-ORK": {
-            "countryName": "Britania Raya",
-            "zoneName": "Pulau Orkney"
-        },
-        "GB-SHI": {
-            "countryName": "Britania Raya",
-            "zoneName": "Pulau Shetland"
-        },
-        "GB-ZET": {
-            "countryName": "Britania Raya",
-            "zoneName": "Pulau Shetland"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgia"
-        },
-        "GF": {
-            "zoneName": "Guyana Perancis"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Greenland"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Guinea Khatulistiwa"
-        },
-        "GR": {
-            "zoneName": "Yunani"
-        },
-        "GR-IS": {
-            "countryName": "Yunani",
-            "zoneName": "Pulau Aegean"
-        },
-        "GS": {
-            "zoneName": "Georgia Selatan dan Pulau Sandwich Selatan"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Pulau Heard dan Pulau McDonald"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Kroasia"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Hongaria"
-        },
-        "ID": {
-            "zoneName": "Indonesia"
-        },
-        "IE": {
-            "zoneName": "Irlandia"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Isle of Man"
-        },
-        "IN-AN": {
-            "countryName": "India",
-            "zoneName": "Andaman dan Pulau Nicobar"
-        },
-        "IN-AP": {
-            "countryName": "India",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "India",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "India",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "India",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "India",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "India",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "India",
-            "zoneName": "Dadra dan Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "India",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "India",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "India",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "India",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "India",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "India",
-            "zoneName": "Jammu dan Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "India",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "India",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "India",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "India",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "India",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "India",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "India",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "India",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "India",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "India",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "India",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "India",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "India",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "India",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "India",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "India",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "India",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "India",
-            "zoneName": "West Bengal"
-        },
-        "IO": {
-            "zoneName": "British Indian Ocean Territory"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Islandia"
-        },
-        "IT": {
-            "zoneName": "Italia"
-        },
-        "IT-CNO": {
-            "countryName": "Italia",
-            "zoneName": "Utara Tengah"
-        },
-        "IT-CSO": {
-            "countryName": "Italia",
-            "zoneName": "Selatan Tengah"
-        },
-        "IT-NO": {
-            "countryName": "Italia",
-            "zoneName": "Utara"
-        },
-        "IT-SAR": {
-            "countryName": "Italia",
-            "zoneName": "Sardinia"
-        },
-        "IT-SIC": {
-            "countryName": "Italia",
-            "zoneName": "Sicily"
-        },
-        "IT-SO": {
-            "countryName": "Italia",
-            "zoneName": "Selatan"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaica"
-        },
-        "JO": {
-            "zoneName": "Jordania"
-        },
-        "JP-CB": {
-            "countryName": "Jepang",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Jepang",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Jepang",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Jepang",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Jepang",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Jepang",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Jepang",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Jepang",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Jepang",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Jepang",
-            "zoneName": "Tōkyō"
-        },
-        "KE": {
-            "zoneName": "Kenya"
-        },
-        "KG": {
-            "zoneName": "Kyrgyzstan"
-        },
-        "KH": {
-            "zoneName": "Kamboja"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comoros"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts and Nevis"
-        },
-        "KP": {
-            "zoneName": "Korea Utara"
-        },
-        "KR": {
-            "zoneName": "Korea Selatan"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Pulau Cayman"
-        },
-        "KZ": {
-            "zoneName": "Kazakhstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Libanon"
-        },
-        "LC": {
-            "zoneName": "Saint Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Lithuania"
-        },
-        "LU": {
-            "zoneName": "Luksemburg"
-        },
-        "LV": {
-            "zoneName": "Latvia"
-        },
-        "LY": {
-            "zoneName": "Libya"
-        },
-        "MA": {
-            "zoneName": "Maroko"
-        },
-        "MC": {
-            "zoneName": "Monako"
-        },
-        "MD": {
-            "zoneName": "Moldova"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Saint Martin",
-            "zoneName": "French"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Pulau Marshall"
-        },
-        "MK": {
-            "zoneName": "Makedonia Utara"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Mongolia"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Pulau Mariana Utara"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Maladewa"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Meksiko"
-        },
-        "MX-BC": {
-            "countryName": "Meksiko",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Meksiko",
-            "zoneName": "Central"
-        },
-        "MX-NE": {
-            "countryName": "Meksiko",
-            "zoneName": "North East"
-        },
-        "MX-NO": {
-            "countryName": "Meksiko",
-            "zoneName": "North"
-        },
-        "MX-NW": {
-            "countryName": "Meksiko",
-            "zoneName": "North West"
-        },
-        "MX-OC": {
-            "countryName": "Meksiko",
-            "zoneName": "Occidental"
-        },
-        "MX-OR": {
-            "countryName": "Meksiko",
-            "zoneName": "Oriental"
-        },
-        "MX-PN": {
-            "countryName": "Meksiko",
-            "zoneName": "Peninsula"
-        },
-        "MY-EM": {
-            "countryName": "Malaysia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malaysia",
-            "zoneName": "Peninsula"
-        },
-        "MZ": {
-            "zoneName": "Mozambik"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "New Caledonia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Pulau Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nikaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabakh"
-        },
-        "NL": {
-            "zoneName": "Belanda"
-        },
-        "NO-NO1": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia Selatan"
-        },
-        "NO-NO2": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia Selatan"
-        },
-        "NO-NO3": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia Tengah"
-        },
-        "NO-NO4": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia Utara"
-        },
-        "NO-NO5": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia Barat"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Selandia Baru"
-        },
-        "NZ-NZA": {
-            "countryName": "Selandia Baru",
-            "zoneName": "Pulau Auckland"
-        },
-        "NZ-NZC": {
-            "countryName": "Selandia Baru",
-            "zoneName": "Pulau Chatham"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "French Polynesia"
-        },
-        "PG": {
-            "zoneName": "Papua New Guinea"
-        },
-        "PH": {
-            "zoneName": "Filipina"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Polandia"
-        },
-        "PM": {
-            "zoneName": "Saint Pierre dan Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Puerto Riko"
-        },
-        "PS": {
-            "zoneName": "Palestina"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Azores"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Qatar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Rumania"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Rusia"
-        },
-        "RU-1": {
-            "countryName": "Rusia",
-            "zoneName": "European Russia dan Ural"
-        },
-        "RU-2": {
-            "countryName": "Rusia",
-            "zoneName": "Siberia"
-        },
-        "RU-EU": {
-            "zoneName": "Rusia"
-        },
-        "RU-AS": {
-            "zoneName": "Rusia"
-        },
-        "RU-KGD": {
-            "countryName": "Rusia",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Arab Saudi"
-        },
-        "SB": {
-            "zoneName": "Pulau Solomon"
-        },
-        "SC": {
-            "zoneName": "Seychelles"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Swedia"
-        },
-        "SG": {
-            "zoneName": "Singapura"
-        },
-        "SH": {
-            "zoneName": "Saint Helena, Ascension dan Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard dan Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovakia"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "South Sudan"
-        },
-        "ST": {
-            "zoneName": "Sao Tome dan Principe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Dutch"
-        },
-        "SY": {
-            "zoneName": "Syria"
-        },
-        "SZ": {
-            "zoneName": "Swaziland"
-        },
-        "TC": {
-            "zoneName": "Turks dan Pulau Caicos"
-        },
-        "TD": {
-            "zoneName": "Chad"
-        },
-        "TF": {
-            "zoneName": "French Southern Territories"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thailand"
-        },
-        "TJ": {
-            "zoneName": "Tajikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunisia"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turki"
-        },
-        "TT": {
-            "zoneName": "Trinidad dan Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tanzania"
-        },
-        "UA": {
-            "zoneName": "Ukraina"
-        },
-        "UA-CR": {
-            "countryName": "Crimea",
-            "zoneName": "Ukraina"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Pulau Outlying Amerika Serikat"
-        },
-        "US-HI-HA": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Oahu"
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatican City"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent dan the Grenadines"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Pulau Virgin",
-            "zoneName": "Pulau Virgin"
-        },
-        "VI": {
-            "countryName": "Amerika Serikat",
-            "zoneName": "Pulau Virgin"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis dan Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Cyprus Utara"
-        },
-        "YE": {
-            "zoneName": "Yaman"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Afrika Selatan"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Uni Emirat Arab" },
+        "AF": { "zoneName": "Afghanistan" },
+        "AG": { "zoneName": "Antigua dan Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albania" },
+        "AM": { "zoneName": "Armenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antartika" },
+        "AS": { "zoneName": "American Samoa" },
+        "AT": { "zoneName": "Austria" },
+        "AR": { "zoneName": "Argentina" },
+        "AUS-NSW": { "countryName": "Australia", "zoneName": "New South Wales" },
+        "AUS-NT": { "countryName": "Australia", "zoneName": "Northern Territory" },
+        "AUS-QLD": { "countryName": "Australia", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australia", "zoneName": "Australia Selatan" },
+        "AUS-TAS": { "countryName": "Australia", "zoneName": "Tasmania" },
+        "AUS-TAS-KI": { "countryName": "Tasmania", "zoneName": "Pulau King" },
+        "AUS-VIC": { "countryName": "Australia", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australia", "zoneName": "Australia Barat" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Pulau Åland" },
+        "AZ": { "zoneName": "Azerbaijan" },
+        "BA": { "zoneName": "Bosnia dan Herzegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Belgia" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgaria" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei Darussalam" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius dan Saba" },
+        "BR-CS": { "countryName": "Brazil", "zoneName": "Brazil Tengah" },
+        "BR-N": { "countryName": "Brazil", "zoneName": "Brazil Utara" },
+        "BR-NE": { "countryName": "Brazil", "zoneName": "Brazil Timur-laut" },
+        "BR-S": { "countryName": "Brazil", "zoneName": "Brazil Selatan" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Pulau Bouvet" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Belarusia" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "British Columbia" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland dan Labrador" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "New Brunswick" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Teritori Barat-laut" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nova Scotia" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Pulau Prince Edward" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Pulau Cocos" },
+        "CD": { "zoneName": "Republik Kongo" },
+        "CF": { "zoneName": "Republik Afrika Tengah" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Switzerland" },
+        "CI": { "zoneName": "Pantai Gading" },
+        "CK": { "zoneName": "Pulau Cook" },
+        "CL-SING-SIC": { "countryName": "Chili", "zoneName": "SING/SIC" },
+        "CL-SEM": { "countryName": "Chili", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "Chili", "zoneName": "SEA" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Cina" },
+        "CO": { "zoneName": "Kolombia" },
+        "CR": { "zoneName": "Kosta Rika" },
+        "CU": { "zoneName": "Kuba" },
+        "CV": { "zoneName": "Cabo Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Pulau Christmas" },
+        "CY": { "zoneName": "Cyprus" },
+        "CZ": { "zoneName": "Ceko" },
+        "DE": { "zoneName": "Jerman" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Denmark" },
+        "DK-DK1": { "countryName": "Denmark", "zoneName": "Denmark Barat" },
+        "DK-DK2": { "countryName": "Denmark", "zoneName": "Denmark Timur" },
+        "DK-BHM": { "countryName": "Denmark", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominika" },
+        "DO": { "zoneName": "Republik Dominika" },
+        "DZ": { "zoneName": "Algeria" },
+        "EC": { "zoneName": "Ekuador" },
+        "EE": { "zoneName": "Estonia" },
+        "EG": { "zoneName": "Mesir" },
+        "EH": { "zoneName": "Sahara Barat" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Spanyol" },
+        "ES-IB-FO": { "countryName": "Spanyol", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Spanyol", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Spanyol", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Spanyol", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Spanyol", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Spanyol", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Spanyol", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Spanyol", "zoneName": "Isla de la Gomera" },
+        "ES-CN-LP": { "countryName": "Spanyol", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Spanyol", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Etiopia" },
+        "FI": { "zoneName": "Finlandia" },
+        "FJ": { "zoneName": "Fiji" },
+        "FK": { "zoneName": "Pulau Falkland" },
+        "FM": { "zoneName": "Micronesia" },
+        "FO": { "zoneName": "Pulau Faroe" },
+        "FR": { "zoneName": "Perancis" },
+        "FR-COR": { "countryName": "Perancis", "zoneName": "Corsica" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Britania Raya" },
+        "GB-NIR": { "zoneName": "Irlandia Utara" },
+        "GB-ORK": { "countryName": "Britania Raya", "zoneName": "Pulau Orkney" },
+        "GB-SHI": { "countryName": "Britania Raya", "zoneName": "Pulau Shetland" },
+        "GB-ZET": { "countryName": "Britania Raya", "zoneName": "Pulau Shetland" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgia" },
+        "GF": { "zoneName": "Guyana Perancis" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Greenland" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Guinea Khatulistiwa" },
+        "GR": { "zoneName": "Yunani" },
+        "GR-IS": { "countryName": "Yunani", "zoneName": "Pulau Aegean" },
+        "GS": { "zoneName": "Georgia Selatan dan Pulau Sandwich Selatan" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Pulau Heard dan Pulau McDonald" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Kroasia" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Hongaria" },
+        "ID": { "zoneName": "Indonesia" },
+        "IE": { "zoneName": "Irlandia" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Isle of Man" },
+        "IN-AN": { "countryName": "India", "zoneName": "Andaman dan Pulau Nicobar" },
+        "IN-AP": { "countryName": "India", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "India", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "India", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "India", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "India", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "India", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "India", "zoneName": "Dadra dan Nagar Haveli" },
+        "IN-GA": { "countryName": "India", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "India", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "India", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "India", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "India", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "India", "zoneName": "Jammu dan Kashmir" },
+        "IN-KA": { "countryName": "India", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "India", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "India", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "India", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "India", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "India", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "India", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "India", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "India", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "India", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "India", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "India", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "India", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "India", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "India", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "India", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "India", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "India", "zoneName": "West Bengal" },
+        "IO": { "zoneName": "British Indian Ocean Territory" },
+        "IQ": { "zoneName": "Irak" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Islandia" },
+        "IT": { "zoneName": "Italia" },
+        "IT-CNO": { "countryName": "Italia", "zoneName": "Utara Tengah" },
+        "IT-CSO": { "countryName": "Italia", "zoneName": "Selatan Tengah" },
+        "IT-NO": { "countryName": "Italia", "zoneName": "Utara" },
+        "IT-SAR": { "countryName": "Italia", "zoneName": "Sardinia" },
+        "IT-SIC": { "countryName": "Italia", "zoneName": "Sicily" },
+        "IT-SO": { "countryName": "Italia", "zoneName": "Selatan" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaica" },
+        "JO": { "zoneName": "Jordania" },
+        "JP-CB": { "countryName": "Jepang", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Jepang", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Jepang", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Jepang", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Jepang", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Jepang", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Jepang", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Jepang", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Jepang", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Jepang", "zoneName": "Tōkyō" },
+        "KE": { "zoneName": "Kenya" },
+        "KG": { "zoneName": "Kyrgyzstan" },
+        "KH": { "zoneName": "Kamboja" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comoros" },
+        "KN": { "zoneName": "Saint Kitts and Nevis" },
+        "KP": { "zoneName": "Korea Utara" },
+        "KR": { "zoneName": "Korea Selatan" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Pulau Cayman" },
+        "KZ": { "zoneName": "Kazakhstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Libanon" },
+        "LC": { "zoneName": "Saint Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Lithuania" },
+        "LU": { "zoneName": "Luksemburg" },
+        "LV": { "zoneName": "Latvia" },
+        "LY": { "zoneName": "Libya" },
+        "MA": { "zoneName": "Maroko" },
+        "MC": { "zoneName": "Monako" },
+        "MD": { "zoneName": "Moldova" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Saint Martin", "zoneName": "French" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Pulau Marshall" },
+        "MK": { "zoneName": "Makedonia Utara" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Mongolia" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Pulau Mariana Utara" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Maladewa" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Meksiko" },
+        "MX-BC": { "countryName": "Meksiko", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Meksiko", "zoneName": "Central" },
+        "MX-NE": { "countryName": "Meksiko", "zoneName": "North East" },
+        "MX-NO": { "countryName": "Meksiko", "zoneName": "North" },
+        "MX-NW": { "countryName": "Meksiko", "zoneName": "North West" },
+        "MX-OC": { "countryName": "Meksiko", "zoneName": "Occidental" },
+        "MX-OR": { "countryName": "Meksiko", "zoneName": "Oriental" },
+        "MX-PN": { "countryName": "Meksiko", "zoneName": "Peninsula" },
+        "MY-EM": { "countryName": "Malaysia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malaysia", "zoneName": "Peninsula" },
+        "MZ": { "zoneName": "Mozambik" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "New Caledonia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Pulau Norfolk" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nikaragua" },
+        "NKR": { "zoneName": "Nagorno-Karabakh" },
+        "NL": { "zoneName": "Belanda" },
+        "NO-NO1": { "countryName": "Norwegia", "zoneName": "Norwegia Selatan" },
+        "NO-NO2": { "countryName": "Norwegia", "zoneName": "Norwegia Selatan" },
+        "NO-NO3": { "countryName": "Norwegia", "zoneName": "Norwegia Tengah" },
+        "NO-NO4": { "countryName": "Norwegia", "zoneName": "Norwegia Utara" },
+        "NO-NO5": { "countryName": "Norwegia", "zoneName": "Norwegia Barat" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Selandia Baru" },
+        "NZ-NZA": { "countryName": "Selandia Baru", "zoneName": "Pulau Auckland" },
+        "NZ-NZC": { "countryName": "Selandia Baru", "zoneName": "Pulau Chatham" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "French Polynesia" },
+        "PG": { "zoneName": "Papua New Guinea" },
+        "PH": { "zoneName": "Filipina" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Polandia" },
+        "PM": { "zoneName": "Saint Pierre dan Miquelon" },
+        "PN": { "zoneName": "Pitcairn" },
+        "PR": { "zoneName": "Puerto Riko" },
+        "PS": { "zoneName": "Palestina" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Azores" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Qatar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Rumania" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Rusia" },
+        "RU-1": { "countryName": "Rusia", "zoneName": "European Russia dan Ural" },
+        "RU-2": { "countryName": "Rusia", "zoneName": "Siberia" },
+        "RU-EU": { "zoneName": "Rusia" },
+        "RU-AS": { "zoneName": "Rusia" },
+        "RU-KGD": { "countryName": "Rusia", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Arab Saudi" },
+        "SB": { "zoneName": "Pulau Solomon" },
+        "SC": { "zoneName": "Seychelles" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Swedia" },
+        "SG": { "zoneName": "Singapura" },
+        "SH": { "zoneName": "Saint Helena, Ascension dan Tristan da Cunha" },
+        "SI": { "zoneName": "Slovenia" },
+        "SJ": { "zoneName": "Svalbard dan Jan Mayen" },
+        "SK": { "zoneName": "Slovakia" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "South Sudan" },
+        "ST": { "zoneName": "Sao Tome dan Principe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Dutch" },
+        "SY": { "zoneName": "Syria" },
+        "SZ": { "zoneName": "Swaziland" },
+        "TC": { "zoneName": "Turks dan Pulau Caicos" },
+        "TD": { "zoneName": "Chad" },
+        "TF": { "zoneName": "French Southern Territories" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thailand" },
+        "TJ": { "zoneName": "Tajikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunisia" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turki" },
+        "TT": { "zoneName": "Trinidad dan Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tanzania" },
+        "UA": { "zoneName": "Ukraina" },
+        "UA-CR": { "countryName": "Crimea", "zoneName": "Ukraina" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Pulau Outlying Amerika Serikat" },
+        "US-HI-HA": { "countryName": "Amerika Serikat", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "Amerika Serikat", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Amerika Serikat", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Amerika Serikat", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Amerika Serikat", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Amerika Serikat", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Amerika Serikat", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Amerika Serikat", "zoneName": "Oahu" },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Vatican City" },
+        "VC": { "zoneName": "Saint Vincent dan the Grenadines" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Pulau Virgin", "zoneName": "Pulau Virgin" },
+        "VI": { "countryName": "Amerika Serikat", "zoneName": "Pulau Virgin" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis dan Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Cyprus Utara" },
+        "YE": { "zoneName": "Yaman" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Afrika Selatan" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/it.json
+++ b/web/public/locales/it.json
@@ -6,15 +6,9 @@
         "datasources": "le fonti dei dati",
         "contribute": "Contribuisci <a href=\"%s\" target=\"_blank\">aggiungendo il tuo territorio</a>"
     },
-    "mobile-main-menu": {
-        "map": "Mappa",
-        "areas": "Aree",
-        "about": "Info"
-    },
+    "mobile-main-menu": { "map": "Mappa", "areas": "Aree", "about": "Info" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Mappatura dell'impatto climatico dell'elettricità"
-        },
+        "view1": { "subtitle": "Mappatura dell'impatto climatico dell'elettricità" },
         "view2": {
             "header": "Guarda quanta CO₂ è emessa nel produrre la tua elettricità, in tempo reale.",
             "text": "Coloriamo le aree nel mondo tramite la loro intensità di carbonio (include tutti i gas serra) dell'elettricità che consumano. Più l'area è verde più produce elettricità in maniera ecologica."
@@ -51,14 +45,14 @@
         "search": "Cerca un'area..."
     },
     "country-history": {
-        "carbonintensity24h": "Intensità di carbonio nelle ultime 24 ore",
-        "emissions24h": "Emissioni nelle ultime 24 ore",
-        "emissionsorigin24h": "Origine delle emissioni nelle ultime 24 ore",
-        "emissionsproduction24h": "Emissioni prodotte nelle ultime 24 ore",
-        "electricityorigin24h": "Origine dell'elettricità nelle ultime 24 ore",
-        "electricityproduction24h": "Produzione elettrica nelle ultime 24 ore",
-        "electricityprices24h": "Prezzi dell'elettricità nelle ultime 24 ore",
-        "Getdata": "Ottieni API di dati storici e previsioni"
+        "Getdata": "Ottieni API di dati storici e previsioni",
+        "carbonintensity": { "hourly": "Intensità di carbonio nelle ultime 24 ore" },
+        "emissionsorigin": { "hourly": "Origine delle emissioni nelle ultime 24 ore" },
+        "emissionsproduction": { "hourly": "Emissioni prodotte nelle ultime 24 ore" },
+        "electricityorigin": { "hourly": "Origine dell'elettricità nelle ultime 24 ore" },
+        "electricityproduction": { "hourly": "Produzione elettrica nelle ultime 24 ore" },
+        "electricityprices": { "hourly": "Prezzi dell'elettricità nelle ultime 24 ore" },
+        "emissions": { "hourly": "Emissioni nelle ultime 24 ore" }
     },
     "footer": {
         "foundbugs": "Hai delle idee o hai trovato dei problemi? Scrivici",
@@ -201,1331 +195,405 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> pubblica dati ed immagini per <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> solo a scopo informativo. Non fa affermazioni di correttezza né fornisce alcuna forma di garanzia, e si riserva il diritto di modificare il contenuto in qualsiasi momento o di rimuovere parti senza previo avviso. electricityMap non si assume nessuna responsabilità, e non sarà responsabile per alcun danno o spesa che potresti subire a causa dell'inesattezza, intempestività o obsolescenza di electricityMap, o le informazioni derivanti da essa. Non è consentito includere questa pagina web, o uno dei suoi singoli elementi senza un previo consenso formale scritto.<br><br>Tutti i diritti di proprietà intellettuale appartengono ai legittimi proprietari ed ai suoi licenziatari. La copia e qualsiasi altro uso di questi materiali, in particolare i dati sull'energia, non sono consentiti senza il permesso scritto di electricityMap, ad eccezione solo dei modi previsti dalla legge (come il diritto di citazione), a meno che non sia specificato diversamente per materiali specifici. <br><br>Questa esclusione di responsabilità può essere modificata in qualsiasi momento."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Emirati Arabi Uniti"
-        },
-        "AF": {
-            "zoneName": "Afghanistan"
-        },
-        "AG": {
-            "zoneName": "Antigua e Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albania"
-        },
-        "AM": {
-            "zoneName": "Armenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antartide"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AS": {
-            "zoneName": "Samoa americane"
-        },
-        "AT": {
-            "zoneName": "Austria"
-        },
-        "AUS-NSW": {
-            "countryName": "Australia",
-            "zoneName": "Nuovo Galles del Sud"
-        },
-        "AUS-NT": {
-            "countryName": "Australia",
-            "zoneName": "Territorio del Nord"
-        },
-        "AUS-QLD": {
-            "countryName": "Australia",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australia",
-            "zoneName": "Australia meridionale"
-        },
-        "AUS-TAS": {
-            "countryName": "Australia",
-            "zoneName": "Tasmania"
-        },
-        "AUS-TAS-CBI": {
-            "countryName": "Australia",
-            "zoneName": "Cape Barren Island"
-        },
-        "AUS-TAS-FI": {
-            "countryName": "Australia",
-            "zoneName": "Flinders Island"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Australia",
-            "zoneName": "King"
-        },
-        "AUS-VIC": {
-            "countryName": "Australia",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australia",
-            "zoneName": "Australia occidentale"
-        },
-        "AUS-WA-RI": {
-            "countryName": "Australia",
-            "zoneName": "Isola Rottnest"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Isole Åland"
-        },
-        "AZ": {
-            "zoneName": "Azerbaigian"
-        },
-        "BA": {
-            "zoneName": "Bosnia ed Erzegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Belgio"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgaria"
-        },
-        "BH": {
-            "zoneName": "Bahrein"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Paesi Bassi caraibici"
-        },
-        "BR-CS": {
-            "countryName": "Brasile",
-            "zoneName": "Centro"
-        },
-        "BR-N": {
-            "countryName": "Brasile",
-            "zoneName": "Nord"
-        },
-        "BR-NE": {
-            "countryName": "Brasile",
-            "zoneName": "Nordest"
-        },
-        "BR-S": {
-            "countryName": "Brasile",
-            "zoneName": "Sud"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Butan"
-        },
-        "BV": {
-            "zoneName": "Isola Bouvet"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Bielorussia"
-        },
-        "BZ": {
-            "zoneName": "Belise"
-        },
-        "CA-AB": {
-            "countryName": "Canada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Canada",
-            "zoneName": "Columbia Britannica"
-        },
-        "CA-MB": {
-            "countryName": "Canada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NB": {
-            "countryName": "Canada",
-            "zoneName": "Nuovo Brunswick"
-        },
-        "CA-NL": {
-            "countryName": "Canada",
-            "zoneName": "Terranova e Labrador"
-        },
-        "CA-NL-LB": {
-            "countryName": "Canada",
-            "zoneName": "Labrador"
-        },
-        "CA-NL-NF": {
-            "countryName": "Canada",
-            "zoneName": "Terranova"
-        },
-        "CA-NS": {
-            "countryName": "Canada",
-            "zoneName": "Nuova Scozia"
-        },
-        "CA-NT": {
-            "countryName": "Canada",
-            "zoneName": "Territori del Nordovest"
-        },
-        "CA-NU": {
-            "countryName": "Canada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Canada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Canada",
-            "zoneName": "Isola del Principe Edoardo"
-        },
-        "CA-QC": {
-            "countryName": "Canada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Canada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Canada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Isole Cocos"
-        },
-        "CD": {
-            "zoneName": "Repubblica Democratica del Congo"
-        },
-        "CF": {
-            "zoneName": "Repubblica Centrafricana"
-        },
-        "CG": {
-            "zoneName": "Congo"
-        },
-        "CH": {
-            "zoneName": "Svizzera"
-        },
-        "CI": {
-            "zoneName": "Costa d'Avorio"
-        },
-        "CK": {
-            "zoneName": "Isole Cook"
-        },
-        "CL-CHP": {
-            "countryName": "Cile",
-            "zoneName": "Isola di Pasqua"
-        },
-        "CL-SEA": {
-            "countryName": "Cile",
-            "zoneName": "Sistema Eléctrico de Aysén"
-        },
-        "CL-SEM": {
-            "countryName": "Cile",
-            "zoneName": "Sistema Eléctrico de Magallanes"
-        },
-        "CL-SEN": {
-            "countryName": "Cile",
-            "zoneName": "Sistema Eléctrico Nacional"
-        },
-        "CM": {
-            "zoneName": "Camerun"
-        },
-        "CN": {
-            "zoneName": "Cina"
-        },
-        "CO": {
-            "zoneName": "Colombia"
-        },
-        "CR": {
-            "zoneName": "Costarica"
-        },
-        "CU": {
-            "zoneName": "Cuba"
-        },
-        "CV": {
-            "zoneName": "Capo Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Isola di Natale"
-        },
-        "CY": {
-            "zoneName": "Cipro"
-        },
-        "CZ": {
-            "zoneName": "Cechia"
-        },
-        "DE": {
-            "zoneName": "Germania"
-        },
-        "DJ": {
-            "zoneName": "Gibuti"
-        },
-        "DK": {
-            "zoneName": "Danimarca"
-        },
-        "DK-DK1": {
-            "countryName": "Danimarca",
-            "zoneName": "Danimarca occidentale"
-        },
-        "DK-DK2": {
-            "countryName": "Danimarca",
-            "zoneName": "Danimarca orientale"
-        },
-        "DK-BHM": {
-            "countryName": "Danimarca",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "Repubblica Dominicana"
-        },
-        "DZ": {
-            "zoneName": "Algeria"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Estonia"
-        },
-        "EG": {
-            "zoneName": "Egitto"
-        },
-        "EH": {
-            "zoneName": "Sahara occidentale"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Spagna"
-        },
-        "ES-IB-FO": {
-            "countryName": "Spagna",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Spagna",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Spagna",
-            "zoneName": "Maiorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Spagna",
-            "zoneName": "Minorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Spagna",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Spagna",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Spagna",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Spagna",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Spagna",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Spagna",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Etiopia"
-        },
-        "FI": {
-            "zoneName": "Finlandia"
-        },
-        "FJ": {
-            "zoneName": "Figi"
-        },
-        "FK": {
-            "zoneName": "Isole Falkland"
-        },
-        "FM": {
-            "zoneName": "Micronesia"
-        },
-        "FO": {
-            "zoneName": "Isole Faroe"
-        },
-        "FR": {
-            "zoneName": "Francia"
-        },
-        "FR-COR": {
-            "countryName": "Francia",
-            "zoneName": "Corsica"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Gran Bretagna"
-        },
-        "GB-NIR": {
-            "zoneName": "Irlanda del Nord"
-        },
-        "GB-ORK": {
-            "countryName": "Gran Bretagna",
-            "zoneName": "Isole Orcadi"
-        },
-        "GB-SHI": {
-            "countryName": "Gran Bretagna",
-            "zoneName": "Isole Shetland"
-        },
-        "GB-ZET": {
-            "countryName": "Gran Bretagna",
-            "zoneName": "Isole Shetland"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgia"
-        },
-        "GF": {
-            "zoneName": "Guiana francese"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibilterra"
-        },
-        "GL": {
-            "zoneName": "Groenlandia"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadalupa"
-        },
-        "GQ": {
-            "zoneName": "Guinea equatoriale"
-        },
-        "GR": {
-            "zoneName": "Grecia"
-        },
-        "GR-IS": {
-            "countryName": "Grecia",
-            "zoneName": "Isole egee"
-        },
-        "GS": {
-            "zoneName": "Georgia del Sud e Isole Sandwich Australi"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Isola Heard e Isole McDonald"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Croazia"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Ungheria"
-        },
-        "ID": {
-            "zoneName": "Indonesia"
-        },
-        "IE": {
-            "zoneName": "Irlanda"
-        },
-        "IL": {
-            "zoneName": "Israele"
-        },
-        "IM": {
-            "zoneName": "Isola di Man"
-        },
-        "IN-AN": {
-            "countryName": "India",
-            "zoneName": "Andamane e Nicobare"
-        },
-        "IN-AP": {
-            "countryName": "India",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "India",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "India",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "India",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "India",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "India",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "India",
-            "zoneName": "Dadra e Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "India",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "India",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "India",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "India",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "India",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "India",
-            "zoneName": "Jammu e Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "India",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "India",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "India",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "India",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "India",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "India",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "India",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "India",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "India",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "India",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "India",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "India",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "India",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "India",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "India",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "India",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "India",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "India",
-            "zoneName": "Bengala occidentale"
-        },
-        "IO": {
-            "zoneName": "Territorio britannico dell'Oceano Indiano"
-        },
-        "IQ": {
-            "zoneName": "Iraq"
-        },
-        "IQ-KUR": {
-            "countryName": "Iraq",
-            "zoneName": "Curdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Islanda"
-        },
-        "IT": {
-            "zoneName": "Italia"
-        },
-        "IT-CNO": {
-            "countryName": "Italia",
-            "zoneName": "Centronord"
-        },
-        "IT-CSO": {
-            "countryName": "Italia",
-            "zoneName": "Centrosud"
-        },
-        "IT-NO": {
-            "countryName": "Italia",
-            "zoneName": "Settentrione"
-        },
-        "IT-SAR": {
-            "countryName": "Italia",
-            "zoneName": "Sardegna"
-        },
-        "IT-SIC": {
-            "countryName": "Italia",
-            "zoneName": "Sicilia"
-        },
-        "IT-SO": {
-            "countryName": "Italia",
-            "zoneName": "Meridione"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Giamaica"
-        },
-        "JO": {
-            "zoneName": "Giordania"
-        },
-        "JP-CB": {
-            "countryName": "Giappone",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Giappone",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Giappone",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Giappone",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Giappone",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Giappone",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Giappone",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Giappone",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Giappone",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Giappone",
-            "zoneName": "Tōkyō"
-        },
-        "KE": {
-            "zoneName": "Kenya"
-        },
-        "KG": {
-            "zoneName": "Chirghisia"
-        },
-        "KH": {
-            "zoneName": "Cambogia"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comore"
-        },
-        "KN": {
-            "zoneName": "San Cristoforo e Nevis"
-        },
-        "KP": {
-            "zoneName": "Corea del Nord"
-        },
-        "KR": {
-            "zoneName": "Corea del Sud"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Isole Cayman"
-        },
-        "KZ": {
-            "zoneName": "Kazakistan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Libano"
-        },
-        "LC": {
-            "zoneName": "Santa Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Lituania"
-        },
-        "LU": {
-            "zoneName": "Lussemburgo"
-        },
-        "LV": {
-            "zoneName": "Lettonia"
-        },
-        "LY": {
-            "zoneName": "Libia"
-        },
-        "MA": {
-            "zoneName": "Marocco"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldavia"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "San Martino",
-            "zoneName": "Francese"
-        },
-        "MG": {
-            "zoneName": "Madagascar"
-        },
-        "MH": {
-            "zoneName": "Isole Marshall"
-        },
-        "MK": {
-            "zoneName": "Macedonia del Nord"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Birmania"
-        },
-        "MN": {
-            "zoneName": "Mongolia"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Isole Marianne settentrionali"
-        },
-        "MQ": {
-            "zoneName": "Martinica"
-        },
-        "MR": {
-            "zoneName": "Mauritania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Maurizio"
-        },
-        "MV": {
-            "zoneName": "Maldive"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Messico"
-        },
-        "MX-BC": {
-            "countryName": "Messico",
-            "zoneName": "Bassa California"
-        },
-        "MX-CE": {
-            "countryName": "Messico",
-            "zoneName": "Centro"
-        },
-        "MX-NE": {
-            "countryName": "Messico",
-            "zoneName": "Nordest"
-        },
-        "MX-NO": {
-            "countryName": "Messico",
-            "zoneName": "Nord"
-        },
-        "MX-NW": {
-            "countryName": "Messico",
-            "zoneName": "Nordovest"
-        },
-        "MX-OC": {
-            "countryName": "Messico",
-            "zoneName": "Occidente"
-        },
-        "MX-OR": {
-            "countryName": "Messico",
-            "zoneName": "Oriente"
-        },
-        "MX-PN": {
-            "countryName": "Messico",
-            "zoneName": "Penisola"
-        },
-        "MY-EM": {
-            "countryName": "Malesia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malesia",
-            "zoneName": "Penisola"
-        },
-        "MZ": {
-            "zoneName": "Mozambico"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "Nuova Caledonia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Isola Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno Karabakh"
-        },
-        "NL": {
-            "zoneName": "Paesi Bassi"
-        },
-        "NO-NO1": {
-            "countryName": "Norvegia",
-            "zoneName": "Sudest"
-        },
-        "NO-NO2": {
-            "countryName": "Norvegia",
-            "zoneName": "Sudovest"
-        },
-        "NO-NO3": {
-            "countryName": "Norvegia",
-            "zoneName": "Centro"
-        },
-        "NO-NO4": {
-            "countryName": "Norvegia",
-            "zoneName": "Nord"
-        },
-        "NO-NO5": {
-            "countryName": "Norvegia",
-            "zoneName": "Ovest"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Nuova Zelanda"
-        },
-        "NZ-NZA": {
-            "countryName": "Nuova Zelanda",
-            "zoneName": "Isole Auckland"
-        },
-        "NZ-NZC": {
-            "countryName": "Nuova Zelanda",
-            "zoneName": "Isole Chatham"
-        },
-        "NZ-NZST": {
-            "countryName": "Nuova Zelanda",
-            "zoneName": "Stewart"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Perù"
-        },
-        "PF": {
-            "zoneName": "Polinesia francese"
-        },
-        "PG": {
-            "zoneName": "Papua Nuova Guinea"
-        },
-        "PH": {
-            "zoneName": "Filippine"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Polonia"
-        },
-        "PM": {
-            "zoneName": "Saint-Pierre e Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Portorico"
-        },
-        "PS": {
-            "zoneName": "Palestina"
-        },
-        "PT": {
-            "zoneName": "Portogallo"
-        },
-        "PT-AC": {
-            "countryName": "Portogallo",
-            "zoneName": "Azzorre"
-        },
-        "PT-MA": {
-            "countryName": "Portogallo",
-            "zoneName": "Madera"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Qatar"
-        },
-        "RE": {
-            "zoneName": "Riunione"
-        },
-        "RO": {
-            "zoneName": "Romania"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Russia"
-        },
-        "RU-1": {
-            "countryName": "Russia",
-            "zoneName": "Russia europea e Ural"
-        },
-        "RU-2": {
-            "countryName": "Russia",
-            "zoneName": "Siberia"
-        },
-        "RU-AS": {
-            "countryName": "Russia",
-            "zoneName": "Est"
-        },
-        "RU-EU": {
-            "countryName": "Russia",
-            "zoneName": "Artide"
-        },
-        "RU-FE": {
-            "countryName": "Russia",
-            "zoneName": "Estremo Oriente"
-        },
-        "RU-KGD": {
-            "countryName": "Russia",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Ruanda"
-        },
-        "SA": {
-            "zoneName": "Arabia Saudita"
-        },
-        "SB": {
-            "zoneName": "Isole Salomone"
-        },
-        "SC": {
-            "zoneName": "Seychelles"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Svezia"
-        },
-        "SG": {
-            "zoneName": "Singapore"
-        },
-        "SH": {
-            "zoneName": "Sant'Elena, Ascensione e Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard e Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovacchia"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Sud Sudan"
-        },
-        "ST": {
-            "zoneName": "São Tomé e Príncipe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "San Martino",
-            "zoneName": "Neerlandese"
-        },
-        "SY": {
-            "zoneName": "Siria"
-        },
-        "SZ": {
-            "zoneName": "Regno di eSwatini"
-        },
-        "TC": {
-            "zoneName": "Turks e Caicos"
-        },
-        "TD": {
-            "zoneName": "Ciad"
-        },
-        "TF": {
-            "zoneName": "Terre australi e antartiche francesi"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Tailandia"
-        },
-        "TJ": {
-            "zoneName": "Tagikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor Est"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunisia"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turchia"
-        },
-        "TT": {
-            "zoneName": "Trinidad e Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tanzania"
-        },
-        "UA": {
-            "zoneName": "Ucraina"
-        },
-        "UA-CR": {
-            "countryName": "Ucraina",
-            "zoneName": "Crimea"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Isole minori esterne degli Stati Uniti d'America"
-        },
-        "US-HI-HA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Oahu"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Emirati Arabi Uniti" },
+        "AF": { "zoneName": "Afghanistan" },
+        "AG": { "zoneName": "Antigua e Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albania" },
+        "AM": { "zoneName": "Armenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antartide" },
+        "AR": { "zoneName": "Argentina" },
+        "AS": { "zoneName": "Samoa americane" },
+        "AT": { "zoneName": "Austria" },
+        "AUS-NSW": { "countryName": "Australia", "zoneName": "Nuovo Galles del Sud" },
+        "AUS-NT": { "countryName": "Australia", "zoneName": "Territorio del Nord" },
+        "AUS-QLD": { "countryName": "Australia", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australia", "zoneName": "Australia meridionale" },
+        "AUS-TAS": { "countryName": "Australia", "zoneName": "Tasmania" },
+        "AUS-TAS-CBI": { "countryName": "Australia", "zoneName": "Cape Barren Island" },
+        "AUS-TAS-FI": { "countryName": "Australia", "zoneName": "Flinders Island" },
+        "AUS-TAS-KI": { "countryName": "Australia", "zoneName": "King" },
+        "AUS-VIC": { "countryName": "Australia", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australia", "zoneName": "Australia occidentale" },
+        "AUS-WA-RI": { "countryName": "Australia", "zoneName": "Isola Rottnest" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Isole Åland" },
+        "AZ": { "zoneName": "Azerbaigian" },
+        "BA": { "zoneName": "Bosnia ed Erzegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Belgio" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgaria" },
+        "BH": { "zoneName": "Bahrein" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Paesi Bassi caraibici" },
+        "BR-CS": { "countryName": "Brasile", "zoneName": "Centro" },
+        "BR-N": { "countryName": "Brasile", "zoneName": "Nord" },
+        "BR-NE": { "countryName": "Brasile", "zoneName": "Nordest" },
+        "BR-S": { "countryName": "Brasile", "zoneName": "Sud" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Butan" },
+        "BV": { "zoneName": "Isola Bouvet" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Bielorussia" },
+        "BZ": { "zoneName": "Belise" },
+        "CA-AB": { "countryName": "Canada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Canada", "zoneName": "Columbia Britannica" },
+        "CA-MB": { "countryName": "Canada", "zoneName": "Manitoba" },
+        "CA-NB": { "countryName": "Canada", "zoneName": "Nuovo Brunswick" },
+        "CA-NL": { "countryName": "Canada", "zoneName": "Terranova e Labrador" },
+        "CA-NL-LB": { "countryName": "Canada", "zoneName": "Labrador" },
+        "CA-NL-NF": { "countryName": "Canada", "zoneName": "Terranova" },
+        "CA-NS": { "countryName": "Canada", "zoneName": "Nuova Scozia" },
+        "CA-NT": { "countryName": "Canada", "zoneName": "Territori del Nordovest" },
+        "CA-NU": { "countryName": "Canada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Canada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Canada", "zoneName": "Isola del Principe Edoardo" },
+        "CA-QC": { "countryName": "Canada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Canada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Canada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Isole Cocos" },
+        "CD": { "zoneName": "Repubblica Democratica del Congo" },
+        "CF": { "zoneName": "Repubblica Centrafricana" },
+        "CG": { "zoneName": "Congo" },
+        "CH": { "zoneName": "Svizzera" },
+        "CI": { "zoneName": "Costa d'Avorio" },
+        "CK": { "zoneName": "Isole Cook" },
+        "CL-CHP": { "countryName": "Cile", "zoneName": "Isola di Pasqua" },
+        "CL-SEA": { "countryName": "Cile", "zoneName": "Sistema Eléctrico de Aysén" },
+        "CL-SEM": { "countryName": "Cile", "zoneName": "Sistema Eléctrico de Magallanes" },
+        "CL-SEN": { "countryName": "Cile", "zoneName": "Sistema Eléctrico Nacional" },
+        "CM": { "zoneName": "Camerun" },
+        "CN": { "zoneName": "Cina" },
+        "CO": { "zoneName": "Colombia" },
+        "CR": { "zoneName": "Costarica" },
+        "CU": { "zoneName": "Cuba" },
+        "CV": { "zoneName": "Capo Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Isola di Natale" },
+        "CY": { "zoneName": "Cipro" },
+        "CZ": { "zoneName": "Cechia" },
+        "DE": { "zoneName": "Germania" },
+        "DJ": { "zoneName": "Gibuti" },
+        "DK": { "zoneName": "Danimarca" },
+        "DK-DK1": { "countryName": "Danimarca", "zoneName": "Danimarca occidentale" },
+        "DK-DK2": { "countryName": "Danimarca", "zoneName": "Danimarca orientale" },
+        "DK-BHM": { "countryName": "Danimarca", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "Repubblica Dominicana" },
+        "DZ": { "zoneName": "Algeria" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Estonia" },
+        "EG": { "zoneName": "Egitto" },
+        "EH": { "zoneName": "Sahara occidentale" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Spagna" },
+        "ES-IB-FO": { "countryName": "Spagna", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Spagna", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Spagna", "zoneName": "Maiorca" },
+        "ES-IB-ME": { "countryName": "Spagna", "zoneName": "Minorca" },
+        "ES-CN-FVLZ": { "countryName": "Spagna", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Spagna", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Spagna", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Spagna", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "Spagna", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Spagna", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Etiopia" },
+        "FI": { "zoneName": "Finlandia" },
+        "FJ": { "zoneName": "Figi" },
+        "FK": { "zoneName": "Isole Falkland" },
+        "FM": { "zoneName": "Micronesia" },
+        "FO": { "zoneName": "Isole Faroe" },
+        "FR": { "zoneName": "Francia" },
+        "FR-COR": { "countryName": "Francia", "zoneName": "Corsica" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Gran Bretagna" },
+        "GB-NIR": { "zoneName": "Irlanda del Nord" },
+        "GB-ORK": { "countryName": "Gran Bretagna", "zoneName": "Isole Orcadi" },
+        "GB-SHI": { "countryName": "Gran Bretagna", "zoneName": "Isole Shetland" },
+        "GB-ZET": { "countryName": "Gran Bretagna", "zoneName": "Isole Shetland" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgia" },
+        "GF": { "zoneName": "Guiana francese" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibilterra" },
+        "GL": { "zoneName": "Groenlandia" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadalupa" },
+        "GQ": { "zoneName": "Guinea equatoriale" },
+        "GR": { "zoneName": "Grecia" },
+        "GR-IS": { "countryName": "Grecia", "zoneName": "Isole egee" },
+        "GS": { "zoneName": "Georgia del Sud e Isole Sandwich Australi" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Isola Heard e Isole McDonald" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Croazia" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Ungheria" },
+        "ID": { "zoneName": "Indonesia" },
+        "IE": { "zoneName": "Irlanda" },
+        "IL": { "zoneName": "Israele" },
+        "IM": { "zoneName": "Isola di Man" },
+        "IN-AN": { "countryName": "India", "zoneName": "Andamane e Nicobare" },
+        "IN-AP": { "countryName": "India", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "India", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "India", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "India", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "India", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "India", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "India", "zoneName": "Dadra e Nagar Haveli" },
+        "IN-GA": { "countryName": "India", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "India", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "India", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "India", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "India", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "India", "zoneName": "Jammu e Kashmir" },
+        "IN-KA": { "countryName": "India", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "India", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "India", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "India", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "India", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "India", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "India", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "India", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "India", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "India", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "India", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "India", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "India", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "India", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "India", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "India", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "India", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "India", "zoneName": "Bengala occidentale" },
+        "IO": { "zoneName": "Territorio britannico dell'Oceano Indiano" },
+        "IQ": { "zoneName": "Iraq" },
+        "IQ-KUR": { "countryName": "Iraq", "zoneName": "Curdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Islanda" },
+        "IT": { "zoneName": "Italia" },
+        "IT-CNO": { "countryName": "Italia", "zoneName": "Centronord" },
+        "IT-CSO": { "countryName": "Italia", "zoneName": "Centrosud" },
+        "IT-NO": { "countryName": "Italia", "zoneName": "Settentrione" },
+        "IT-SAR": { "countryName": "Italia", "zoneName": "Sardegna" },
+        "IT-SIC": { "countryName": "Italia", "zoneName": "Sicilia" },
+        "IT-SO": { "countryName": "Italia", "zoneName": "Meridione" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Giamaica" },
+        "JO": { "zoneName": "Giordania" },
+        "JP-CB": { "countryName": "Giappone", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Giappone", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Giappone", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Giappone", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Giappone", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Giappone", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Giappone", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Giappone", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Giappone", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Giappone", "zoneName": "Tōkyō" },
+        "KE": { "zoneName": "Kenya" },
+        "KG": { "zoneName": "Chirghisia" },
+        "KH": { "zoneName": "Cambogia" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comore" },
+        "KN": { "zoneName": "San Cristoforo e Nevis" },
+        "KP": { "zoneName": "Corea del Nord" },
+        "KR": { "zoneName": "Corea del Sud" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Isole Cayman" },
+        "KZ": { "zoneName": "Kazakistan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Libano" },
+        "LC": { "zoneName": "Santa Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Lituania" },
+        "LU": { "zoneName": "Lussemburgo" },
+        "LV": { "zoneName": "Lettonia" },
+        "LY": { "zoneName": "Libia" },
+        "MA": { "zoneName": "Marocco" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldavia" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "San Martino", "zoneName": "Francese" },
+        "MG": { "zoneName": "Madagascar" },
+        "MH": { "zoneName": "Isole Marshall" },
+        "MK": { "zoneName": "Macedonia del Nord" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Birmania" },
+        "MN": { "zoneName": "Mongolia" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Isole Marianne settentrionali" },
+        "MQ": { "zoneName": "Martinica" },
+        "MR": { "zoneName": "Mauritania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Maurizio" },
+        "MV": { "zoneName": "Maldive" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Messico" },
+        "MX-BC": { "countryName": "Messico", "zoneName": "Bassa California" },
+        "MX-CE": { "countryName": "Messico", "zoneName": "Centro" },
+        "MX-NE": { "countryName": "Messico", "zoneName": "Nordest" },
+        "MX-NO": { "countryName": "Messico", "zoneName": "Nord" },
+        "MX-NW": { "countryName": "Messico", "zoneName": "Nordovest" },
+        "MX-OC": { "countryName": "Messico", "zoneName": "Occidente" },
+        "MX-OR": { "countryName": "Messico", "zoneName": "Oriente" },
+        "MX-PN": { "countryName": "Messico", "zoneName": "Penisola" },
+        "MY-EM": { "countryName": "Malesia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malesia", "zoneName": "Penisola" },
+        "MZ": { "zoneName": "Mozambico" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "Nuova Caledonia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Isola Norfolk" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Nagorno Karabakh" },
+        "NL": { "zoneName": "Paesi Bassi" },
+        "NO-NO1": { "countryName": "Norvegia", "zoneName": "Sudest" },
+        "NO-NO2": { "countryName": "Norvegia", "zoneName": "Sudovest" },
+        "NO-NO3": { "countryName": "Norvegia", "zoneName": "Centro" },
+        "NO-NO4": { "countryName": "Norvegia", "zoneName": "Nord" },
+        "NO-NO5": { "countryName": "Norvegia", "zoneName": "Ovest" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Nuova Zelanda" },
+        "NZ-NZA": { "countryName": "Nuova Zelanda", "zoneName": "Isole Auckland" },
+        "NZ-NZC": { "countryName": "Nuova Zelanda", "zoneName": "Isole Chatham" },
+        "NZ-NZST": { "countryName": "Nuova Zelanda", "zoneName": "Stewart" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Perù" },
+        "PF": { "zoneName": "Polinesia francese" },
+        "PG": { "zoneName": "Papua Nuova Guinea" },
+        "PH": { "zoneName": "Filippine" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Polonia" },
+        "PM": { "zoneName": "Saint-Pierre e Miquelon" },
+        "PN": { "zoneName": "Pitcairn" },
+        "PR": { "zoneName": "Portorico" },
+        "PS": { "zoneName": "Palestina" },
+        "PT": { "zoneName": "Portogallo" },
+        "PT-AC": { "countryName": "Portogallo", "zoneName": "Azzorre" },
+        "PT-MA": { "countryName": "Portogallo", "zoneName": "Madera" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Qatar" },
+        "RE": { "zoneName": "Riunione" },
+        "RO": { "zoneName": "Romania" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Russia" },
+        "RU-1": { "countryName": "Russia", "zoneName": "Russia europea e Ural" },
+        "RU-2": { "countryName": "Russia", "zoneName": "Siberia" },
+        "RU-AS": { "countryName": "Russia", "zoneName": "Est" },
+        "RU-EU": { "countryName": "Russia", "zoneName": "Artide" },
+        "RU-FE": { "countryName": "Russia", "zoneName": "Estremo Oriente" },
+        "RU-KGD": { "countryName": "Russia", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Ruanda" },
+        "SA": { "zoneName": "Arabia Saudita" },
+        "SB": { "zoneName": "Isole Salomone" },
+        "SC": { "zoneName": "Seychelles" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Svezia" },
+        "SG": { "zoneName": "Singapore" },
+        "SH": { "zoneName": "Sant'Elena, Ascensione e Tristan da Cunha" },
+        "SI": { "zoneName": "Slovenia" },
+        "SJ": { "zoneName": "Svalbard e Jan Mayen" },
+        "SK": { "zoneName": "Slovacchia" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Sud Sudan" },
+        "ST": { "zoneName": "São Tomé e Príncipe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "San Martino", "zoneName": "Neerlandese" },
+        "SY": { "zoneName": "Siria" },
+        "SZ": { "zoneName": "Regno di eSwatini" },
+        "TC": { "zoneName": "Turks e Caicos" },
+        "TD": { "zoneName": "Ciad" },
+        "TF": { "zoneName": "Terre australi e antartiche francesi" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Tailandia" },
+        "TJ": { "zoneName": "Tagikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor Est" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunisia" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turchia" },
+        "TT": { "zoneName": "Trinidad e Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tanzania" },
+        "UA": { "zoneName": "Ucraina" },
+        "UA-CR": { "countryName": "Ucraina", "zoneName": "Crimea" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Isole minori esterne degli Stati Uniti d'America" },
+        "US-HI-HA": { "countryName": "Stati Uniti d'America", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "Stati Uniti d'America", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Stati Uniti d'America", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Stati Uniti d'America", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Stati Uniti d'America", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Stati Uniti d'America", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Stati Uniti d'America", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Stati Uniti d'America", "zoneName": "Oahu" },
         "US-CAL-BANC": {
             "countryName": "Stati Uniti d'America",
             "zoneName": "Balancing Authority Of Northern California"
         },
-        "US-CAL-CISO": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "California Independent System Operator"
-        },
-        "US-CAL-IID": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Imperial Irrigation District"
-        },
+        "US-CAL-CISO": { "countryName": "Stati Uniti d'America", "zoneName": "California Independent System Operator" },
+        "US-CAL-IID": { "countryName": "Stati Uniti d'America", "zoneName": "Imperial Irrigation District" },
         "US-CAL-LDWP": {
             "countryName": "Stati Uniti d'America",
             "zoneName": "Los Angeles Department Of Water And Power"
         },
-        "US-CAL-TIDC": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Duke Energy Carolinas"
-        },
-        "US-CAR-SC": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "South Carolina Public Service Authority"
-        },
-        "US-CAR-SCEG": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "South Carolina Electric & Gas Company"
-        },
+        "US-CAL-TIDC": { "countryName": "Stati Uniti d'America", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "Stati Uniti d'America", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "Stati Uniti d'America", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "Stati Uniti d'America", "zoneName": "Duke Energy Carolinas" },
+        "US-CAR-SC": { "countryName": "Stati Uniti d'America", "zoneName": "South Carolina Public Service Authority" },
+        "US-CAR-SCEG": { "countryName": "Stati Uniti d'America", "zoneName": "South Carolina Electric & Gas Company" },
         "US-CAR-YAD": {
             "countryName": "Stati Uniti d'America",
             "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
         },
-        "US-CENT-SPA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Southwestern Power Administration"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Città di Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Jacksonville Electric Authority"
-        },
+        "US-CENT-SPA": { "countryName": "Stati Uniti d'America", "zoneName": "Southwestern Power Administration" },
+        "US-CENT-SWPP": { "countryName": "Stati Uniti d'America", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "Stati Uniti d'America", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "Stati Uniti d'America", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "Stati Uniti d'America", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "Stati Uniti d'America", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "Stati Uniti d'America", "zoneName": "Città di Homestead" },
+        "US-FLA-JEA": { "countryName": "Stati Uniti d'America", "zoneName": "Jacksonville Electric Authority" },
         "US-FLA-NSB": {
             "countryName": "Stati Uniti d'America",
             "zoneName": "Utilities Commission Of New Smyrna Beach"
         },
-        "US-FLA-SEC": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Città di Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "PJM Interconnection, Llc"
-        },
-        "US-MIDW-AECI": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Associated Electric Cooperative, Inc."
-        },
-        "US-MIDW-GLHB": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "GridLiance"
-        },
+        "US-FLA-SEC": { "countryName": "Stati Uniti d'America", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "Stati Uniti d'America", "zoneName": "Città di Tallahassee" },
+        "US-FLA-TEC": { "countryName": "Stati Uniti d'America", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "Stati Uniti d'America", "zoneName": "PJM Interconnection, Llc" },
+        "US-MIDW-AECI": { "countryName": "Stati Uniti d'America", "zoneName": "Associated Electric Cooperative, Inc." },
+        "US-MIDW-GLHB": { "countryName": "Stati Uniti d'America", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "Stati Uniti d'America",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1534,78 +602,24 @@
             "countryName": "Stati Uniti d'America",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc.."
         },
-        "US-NE-ISNE": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
-        "US-NW-GCPD": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "PUD No. 2 Of Grant County, Washington"
-        },
-        "US-NW-GRID": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Portland General Electric Company"
-        },
-        "US-NW-PSCO": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Public Service Company Of Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NE-ISNE": { "countryName": "Stati Uniti d'America", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "Stati Uniti d'America", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "Stati Uniti d'America", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "Stati Uniti d'America", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "Stati Uniti d'America", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "Stati Uniti d'America", "zoneName": "PUD No. 1 Of Douglas County" },
+        "US-NW-GCPD": { "countryName": "Stati Uniti d'America", "zoneName": "PUD No. 2 Of Grant County, Washington" },
+        "US-NW-GRID": { "countryName": "Stati Uniti d'America", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "Stati Uniti d'America", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "Stati Uniti d'America", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "Stati Uniti d'America", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "Stati Uniti d'America", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "Stati Uniti d'America", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "Stati Uniti d'America", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "Stati Uniti d'America", "zoneName": "Portland General Electric Company" },
+        "US-NW-PSCO": { "countryName": "Stati Uniti d'America", "zoneName": "Public Service Company Of Colorado" },
+        "US-NW-PSEI": { "countryName": "Stati Uniti d'America", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "Stati Uniti d'America", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "Stati Uniti d'America",
             "zoneName": "Città di Tacoma, Department Of Public Utilities, Light Division"
@@ -1618,129 +632,46 @@
             "countryName": "Stati Uniti d'America",
             "zoneName": "Western Area Power Administration UGP West"
         },
-        "US-NW-WWA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "New York Independent System Operator"
-        },
-        "US-SE-AEC": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Southeastern Power Administration"
-        },
-        "US-SE-SOCO": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Southern Company Services, Inc. - Trans"
-        },
-        "US-SW-AZPS": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Gila River Power, LLC"
-        },
-        "US-SW-HGMA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "New Harquahala Generating Company, LLC"
-        },
-        "US-SW-PNM": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Public Service Company Of New Mexico"
-        },
-        "US-SW-SRP": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-NW-WWA": { "countryName": "Stati Uniti d'America", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "Stati Uniti d'America", "zoneName": "New York Independent System Operator" },
+        "US-SE-AEC": { "countryName": "Stati Uniti d'America", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "Stati Uniti d'America", "zoneName": "Southeastern Power Administration" },
+        "US-SE-SOCO": { "countryName": "Stati Uniti d'America", "zoneName": "Southern Company Services, Inc. - Trans" },
+        "US-SW-AZPS": { "countryName": "Stati Uniti d'America", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "Stati Uniti d'America", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "Stati Uniti d'America", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "Stati Uniti d'America", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "Stati Uniti d'America", "zoneName": "Gila River Power, LLC" },
+        "US-SW-HGMA": { "countryName": "Stati Uniti d'America", "zoneName": "New Harquahala Generating Company, LLC" },
+        "US-SW-PNM": { "countryName": "Stati Uniti d'America", "zoneName": "Public Service Company Of New Mexico" },
+        "US-SW-SRP": { "countryName": "Stati Uniti d'America", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "Stati Uniti d'America", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "Stati Uniti d'America",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Tennessee Valley Authority"
-        },
+        "US-TEN-TVA": { "countryName": "Stati Uniti d'America", "zoneName": "Tennessee Valley Authority" },
         "US-TEX-ERCO": {
             "countryName": "Stati Uniti d'America",
             "zoneName": "Electric Reliability Council Of Texas, Inc."
         },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Città del Vaticano"
-        },
-        "VC": {
-            "zoneName": "San Vincenzo e Grenadine"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Isole Vergini",
-            "zoneName": "Isole Vergini"
-        },
-        "VI": {
-            "countryName": "Stati Uniti d'America",
-            "zoneName": "Isole Vergini statunitensi"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis e Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XK": {
-            "zoneName": "Kosovo"
-        },
-        "XX": {
-            "zoneName": "Cipro del Nord"
-        },
-        "YE": {
-            "zoneName": "Yemen"
-        },
-        "YT": {
-            "zoneName": "Maiotta"
-        },
-        "ZA": {
-            "zoneName": "Sudafrica"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Città del Vaticano" },
+        "VC": { "zoneName": "San Vincenzo e Grenadine" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Isole Vergini", "zoneName": "Isole Vergini" },
+        "VI": { "countryName": "Stati Uniti d'America", "zoneName": "Isole Vergini statunitensi" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis e Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XK": { "zoneName": "Kosovo" },
+        "XX": { "zoneName": "Cipro del Nord" },
+        "YE": { "zoneName": "Yemen" },
+        "YT": { "zoneName": "Maiotta" },
+        "ZA": { "zoneName": "Sudafrica" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/ja.json
+++ b/web/public/locales/ja.json
@@ -6,15 +6,9 @@
         "datasources": "データソースを見る",
         "contribute": "貢献するには <a href=\"%s\" target=\"_blank\">自分の国のデータを追加してください</a>"
     },
-    "mobile-main-menu": {
-        "map": "電力マップ",
-        "areas": "エリア",
-        "about": "このサイトについて"
-    },
+    "mobile-main-menu": { "map": "電力マップ", "areas": "エリア", "about": "このサイトについて" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "電力による環境負荷のマッピング"
-        },
+        "view1": { "subtitle": "電力による環境負荷のマッピング" },
         "view2": {
             "header": "あなたの電気を消費するのにどれほどのCO₂が生み出されるかをリアルタイムで見る",
             "text": "わたしたちは電力消費による炭素集約度(すべての温室効果ガスを含む)を世界中に色で表します。緑色に近づくほど、その電力が環境に優しくなります。"
@@ -51,14 +45,14 @@
         "search": "エリアを検索"
     },
     "country-history": {
-        "carbonintensity24h": "最近の24時間の炭素強度",
-        "emissions24h": "過去24時間の排出",
-        "emissionsorigin24h": "過去24時間の排出源",
-        "emissionsproduction24h": "過去24時間に生成された排出ガス",
-        "electricityorigin24h": "最近の24時間の電力源",
-        "electricityproduction24h": "最近の24時間の発電",
-        "electricityprices24h": "最近の24時間の電力価格",
-        "Getdata": "過去と予想のデータを取得する"
+        "Getdata": "過去と予想のデータを取得する",
+        "carbonintensity": { "hourly": "最近の24時間の炭素強度" },
+        "emissionsorigin": { "hourly": "過去24時間の排出源" },
+        "emissionsproduction": { "hourly": "過去24時間に生成された排出ガス" },
+        "electricityorigin": { "hourly": "最近の24時間の電力源" },
+        "electricityproduction": { "hourly": "最近の24時間の発電" },
+        "electricityprices": { "hourly": "最近の24時間の電力価格" },
+        "emissions": { "hourly": "過去24時間の排出" }
     },
     "footer": {
         "foundbugs": "バグの発見? ご報告ください",
@@ -195,1297 +189,385 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publishes data and images on the <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> for information purposes. It makes no claims of correctness nor provides any form of warranties, and reserves the right to change the content at any time or to remove parts without having to inform you of this. electricityMap assumes no responsibility for, and shall not be liable for, any damages or expenses you may incur as a result of any inaccuracy, incompleteness, untimeliness or obsolescence of the electricityMap, or the information derived from them.  It is not allowed to include this webpage, or any of its individual elements, in another webpage, without formal prior written consent.<br><br> All intellectual property rights belong to the rightful owners and its licensors. Copying, distribution and any other use of these materials, in particular the energy data, is not permitted without the written permission of electricityMap, except and only to the extent otherwise provided in regulations of mandatory law (such as the right to quote), unless specified otherwise for specific materials. <br><br>This disclaimer may be updated from time to time."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "アンドラ"
-        },
-        "AE": {
-            "zoneName": "アラブ首長国連邦"
-        },
-        "AF": {
-            "zoneName": "アフガニスタン"
-        },
-        "AG": {
-            "zoneName": "アンティグア・バーブーダ"
-        },
-        "AI": {
-            "zoneName": "アンギラ"
-        },
-        "AL": {
-            "zoneName": "アルバニア"
-        },
-        "AM": {
-            "zoneName": "アルメニア"
-        },
-        "AO": {
-            "zoneName": "アンゴラ"
-        },
-        "AQ": {
-            "zoneName": "南極大陸"
-        },
-        "AS": {
-            "zoneName": "アメリカ領サモア"
-        },
-        "AT": {
-            "zoneName": "オーストリア"
-        },
-        "AR": {
-            "zoneName": "アルゼンチン"
-        },
-        "AUS-NSW": {
-            "countryName": "オーストラリア",
-            "zoneName": "ニューサウスウェールズ州"
-        },
-        "AUS-NT": {
-            "countryName": "オーストラリア",
-            "zoneName": "ノーザンテリトリー"
-        },
-        "AUS-QLD": {
-            "countryName": "オーストラリア",
-            "zoneName": "クイーンズランド州"
-        },
-        "AUS-SA": {
-            "countryName": "オーストラリア",
-            "zoneName": "南 オーストラリア"
-        },
-        "AUS-TAS": {
-            "countryName": "オーストラリア",
-            "zoneName": "タスマニア"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "オーストラリア",
-            "zoneName": "キング島"
-        },
-        "AUS-VIC": {
-            "countryName": "オーストラリア",
-            "zoneName": "ビクトリア州"
-        },
-        "AUS-WA": {
-            "countryName": "オーストラリア",
-            "zoneName": "西 オーストラリア"
-        },
-        "AW": {
-            "zoneName": "アルバ"
-        },
-        "AX": {
-            "zoneName": "オーランド諸島"
-        },
-        "AZ": {
-            "zoneName": "アゼルバイジャン"
-        },
-        "BA": {
-            "zoneName": "ボスニア・ヘルツェゴビナ"
-        },
-        "BB": {
-            "zoneName": "バルバドス"
-        },
-        "BD": {
-            "zoneName": "バングラデシュ"
-        },
-        "BE": {
-            "zoneName": "ベルギー"
-        },
-        "BF": {
-            "zoneName": "ブルキナファソ"
-        },
-        "BG": {
-            "zoneName": "ブルガリア"
-        },
-        "BH": {
-            "zoneName": "バーレーン"
-        },
-        "BI": {
-            "zoneName": "ブルンジ"
-        },
-        "BJ": {
-            "zoneName": "ベナン"
-        },
-        "BM": {
-            "zoneName": "バミューダ"
-        },
-        "BN": {
-            "zoneName": "ブルネイ"
-        },
-        "BO": {
-            "zoneName": "ボリビア"
-        },
-        "BQ": {
-            "zoneName": "ボネール、シント・ユースタティウスおよびサバ"
-        },
-        "BR-CS": {
-            "countryName": "ブラジル",
-            "zoneName": "中央ブラジル"
-        },
-        "BR-N": {
-            "countryName": "ブラジル",
-            "zoneName": "北ブラジル"
-        },
-        "BR-NE": {
-            "countryName": "ブラジル",
-            "zoneName": "東北ブラジル"
-        },
-        "BR-S": {
-            "countryName": "ブラジル",
-            "zoneName": "南ブラジル"
-        },
-        "BS": {
-            "zoneName": "バハマ"
-        },
-        "BT": {
-            "zoneName": "ブータン"
-        },
-        "BV": {
-            "zoneName": "ブーベ島"
-        },
-        "BW": {
-            "zoneName": "ボツワナ"
-        },
-        "BY": {
-            "zoneName": "ベラルーシ"
-        },
-        "BZ": {
-            "zoneName": "ベリーズ"
-        },
-        "CA-AB": {
-            "countryName": "カナダ",
-            "zoneName": "アルバータ州"
-        },
-        "CA-BC": {
-            "countryName": "カナダ",
-            "zoneName": "ブリティッシュコロンビア"
-        },
-        "CA-MB": {
-            "countryName": "カナダ",
-            "zoneName": "マニトバ州"
-        },
-        "CA-NL": {
-            "countryName": "カナダ",
-            "zoneName": "ニューファンドランドアンドラブラドール州"
-        },
-        "CA-NB": {
-            "countryName": "カナダ",
-            "zoneName": "ニューブランズウィック"
-        },
-        "CA-NT": {
-            "countryName": "カナダ",
-            "zoneName": "ノースウェスト準州"
-        },
-        "CA-NS": {
-            "countryName": "カナダ",
-            "zoneName": "ノバスコシア州"
-        },
-        "CA-NU": {
-            "countryName": "カナダ",
-            "zoneName": "ヌナブト"
-        },
-        "CA-ON": {
-            "countryName": "カナダ",
-            "zoneName": "オンタリオ"
-        },
-        "CA-PE": {
-            "countryName": "カナダ",
-            "zoneName": "プリンス・エドワード島"
-        },
-        "CA-QC": {
-            "countryName": "カナダ",
-            "zoneName": "ケベック州"
-        },
-        "CA-SK": {
-            "countryName": "カナダ",
-            "zoneName": "サスカチュワン州"
-        },
-        "CA-YT": {
-            "countryName": "カナダ",
-            "zoneName": "ユーコン"
-        },
-        "CC": {
-            "zoneName": "ココス諸島"
-        },
-        "CD": {
-            "zoneName": "コンゴ民主共和国"
-        },
-        "CF": {
-            "zoneName": "中央アフリカ共和国"
-        },
-        "CG": {
-            "zoneName": "コンゴ"
-        },
-        "CH": {
-            "zoneName": "スイス"
-        },
-        "CI": {
-            "zoneName": "コートジボワール"
-        },
-        "CK": {
-            "zoneName": "クック諸島"
-        },
-        "CL-SEA": {
-            "countryName": "チリ",
-            "zoneName": "Sistema Eléctrico de Aysén"
-        },
-        "CL-SEM": {
-            "countryName": "チリ",
-            "zoneName": "Sistema Eléctrico de Magallanes"
-        },
-        "CL-SEN": {
-            "countryName": "チリ",
-            "zoneName": "Sistema Eléctrico Nacional"
-        },
-        "CM": {
-            "zoneName": "カメルーン"
-        },
-        "CN": {
-            "zoneName": "中国"
-        },
-        "CO": {
-            "zoneName": "コロンビア"
-        },
-        "CR": {
-            "zoneName": "コスタリカ"
-        },
-        "CU": {
-            "zoneName": "キューバ"
-        },
-        "CV": {
-            "zoneName": "カーボベルデ"
-        },
-        "CW": {
-            "zoneName": "キュラソー"
-        },
-        "CX": {
-            "zoneName": "クリスマス島"
-        },
-        "CY": {
-            "zoneName": "キプロス"
-        },
-        "CZ": {
-            "zoneName": "チェコ"
-        },
-        "DE": {
-            "zoneName": "ドイツ"
-        },
-        "DJ": {
-            "zoneName": "ジブチ"
-        },
-        "DK": {
-            "zoneName": "デンマーク"
-        },
-        "DK-DK1": {
-            "countryName": "デンマーク",
-            "zoneName": "西デンマーク"
-        },
-        "DK-DK2": {
-            "countryName": "デンマーク",
-            "zoneName": "西デンマーク"
-        },
-        "DK-BHM": {
-            "countryName": "デンマーク",
-            "zoneName": "東デンマーク"
-        },
-        "DM": {
-            "zoneName": "ドミニカ"
-        },
-        "DO": {
-            "zoneName": "ドミニカ共和国"
-        },
-        "DZ": {
-            "zoneName": "アルジェリア"
-        },
-        "EC": {
-            "zoneName": "エクアドル"
-        },
-        "EE": {
-            "zoneName": "エストニア"
-        },
-        "EG": {
-            "zoneName": "エジプト"
-        },
-        "EH": {
-            "zoneName": "西サハラ"
-        },
-        "ER": {
-            "zoneName": "エリトリア"
-        },
-        "ES": {
-            "zoneName": "スペイン"
-        },
-        "ES-IB-FO": {
-            "countryName": "スペイン",
-            "zoneName": "フォルメンテラ島"
-        },
-        "ES-IB-IZ": {
-            "countryName": "スペイン",
-            "zoneName": "イビサ島"
-        },
-        "ES-IB-MA": {
-            "countryName": "スペイン",
-            "zoneName": "マヨルカ島"
-        },
-        "ES-IB-ME": {
-            "countryName": "スペイン",
-            "zoneName": "メノルカ島"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "スペイン",
-            "zoneName": "フエルテベントゥラ島/ランサローテ島"
-        },
-        "ES-CN-GC": {
-            "countryName": "スペイン",
-            "zoneName": "グラン・カナリア島"
-        },
-        "ES-CN-HI": {
-            "countryName": "スペイン",
-            "zoneName": "エル・イエロ島 "
-        },
-        "ES-CN-IG": {
-            "countryName": "スペイン",
-            "zoneName": "ラ・ゴメラ島"
-        },
-        "ES-CN-LP": {
-            "countryName": "スペイン",
-            "zoneName": "ラ・パルマ島"
-        },
-        "ES-CN-TE": {
-            "countryName": "スペイン",
-            "zoneName": "テネリフェ島"
-        },
-        "ET": {
-            "zoneName": "エチオピア"
-        },
-        "FI": {
-            "zoneName": "フィンランド"
-        },
-        "FJ": {
-            "zoneName": "フィジー"
-        },
-        "FK": {
-            "zoneName": "フォークランド諸島"
-        },
-        "FM": {
-            "zoneName": "ミクロネシア"
-        },
-        "FO": {
-            "zoneName": "フェロー諸島"
-        },
-        "FR": {
-            "zoneName": "フランス"
-        },
-        "FR-COR": {
-            "countryName": "フランス",
-            "zoneName": "コルシカ島"
-        },
-        "GA": {
-            "zoneName": "ガボン"
-        },
-        "GB": {
-            "zoneName": "イギリス"
-        },
-        "GB-NIR": {
-            "zoneName": "北アイルランド"
-        },
-        "GB-ORK": {
-            "countryName": "イギリス",
-            "zoneName": "オークニー諸島"
-        },
-        "GB-SHI": {
-            "countryName": "イギリス",
-            "zoneName": "シェットランド諸島"
-        },
-        "GB-ZET": {
-            "countryName": "イギリス",
-            "zoneName": "シェットランド諸島"
-        },
-        "GD": {
-            "zoneName": "グレナダ"
-        },
-        "GE": {
-            "zoneName": "ジョージア州"
-        },
-        "GF": {
-            "zoneName": "フランス領ギアナ"
-        },
-        "GG": {
-            "zoneName": "ガーンジー"
-        },
-        "GH": {
-            "zoneName": "ガーナ"
-        },
-        "GI": {
-            "zoneName": "ジブラルタル"
-        },
-        "GL": {
-            "zoneName": "グリーンランド"
-        },
-        "GM": {
-            "zoneName": "ガンビア"
-        },
-        "GN": {
-            "zoneName": "ギニア"
-        },
-        "GP": {
-            "zoneName": "グアドループ"
-        },
-        "GQ": {
-            "zoneName": "赤道ギニア"
-        },
-        "GR": {
-            "zoneName": "ギリシャ"
-        },
-        "GR-IS": {
-            "countryName": "ギリシャ",
-            "zoneName": "エーゲ海諸島"
-        },
-        "GS": {
-            "zoneName": "サウスジョージア・サウスサンドウィッチ諸島"
-        },
-        "GT": {
-            "zoneName": "グアテマラ"
-        },
-        "GU": {
-            "zoneName": "グアム"
-        },
-        "GW": {
-            "zoneName": "ギニアビサウ"
-        },
-        "GY": {
-            "zoneName": "ガイアナ"
-        },
-        "HK": {
-            "zoneName": "香港"
-        },
-        "HM": {
-            "zoneName": "ハード島とマクドナルド諸島"
-        },
-        "HN": {
-            "zoneName": "ホンジュラス"
-        },
-        "HR": {
-            "zoneName": "クロアチア"
-        },
-        "HT": {
-            "zoneName": "ハイチ"
-        },
-        "HU": {
-            "zoneName": "ハンガリー"
-        },
-        "ID": {
-            "zoneName": "インドネシア"
-        },
-        "IE": {
-            "zoneName": "アイルランド"
-        },
-        "IL": {
-            "zoneName": "イスラエル"
-        },
-        "IM": {
-            "zoneName": "マン島"
-        },
-        "IN-AN": {
-            "countryName": "インド",
-            "zoneName": "アンダマンとニコバル諸島"
-        },
-        "IN-AP": {
-            "countryName": "インド",
-            "zoneName": "アンドラ・プラデシュ"
-        },
-        "IN-AR": {
-            "countryName": "インド",
-            "zoneName": "アルナチャルプラデーシュ州"
-        },
-        "IN-AS": {
-            "countryName": "インド",
-            "zoneName": "アッサム"
-        },
-        "IN-BR": {
-            "countryName": "インド",
-            "zoneName": "ビハール"
-        },
-        "IN-CT": {
-            "countryName": "インド",
-            "zoneName": "チャッティースガル"
-        },
-        "IN-DL": {
-            "countryName": "インド",
-            "zoneName": "デリー"
-        },
-        "IN-DN": {
-            "countryName": "インド",
-            "zoneName": "ダードラーおよびナガル・ハヴェーリー"
-        },
-        "IN-GA": {
-            "countryName": "インド",
-            "zoneName": "ゴア"
-        },
-        "IN-GJ": {
-            "countryName": "インド",
-            "zoneName": "グジャラート州"
-        },
-        "IN-HP": {
-            "countryName": "インド",
-            "zoneName": "ヒマーチャルプラデーシュ州"
-        },
-        "IN-HR": {
-            "countryName": "インド",
-            "zoneName": "ハリヤーナ"
-        },
-        "IN-JH": {
-            "countryName": "インド",
-            "zoneName": "ジャールカンド州"
-        },
-        "IN-JK": {
-            "countryName": "インド",
-            "zoneName": "ジャムとカシミール"
-        },
-        "IN-KA": {
-            "countryName": "インド",
-            "zoneName": "カルナタカ"
-        },
-        "IN-KL": {
-            "countryName": "インド",
-            "zoneName": "ケララ州"
-        },
-        "IN-MH": {
-            "countryName": "インド",
-            "zoneName": "マハラシュトラ"
-        },
-        "IN-ML": {
-            "countryName": "インド",
-            "zoneName": "メガラヤ"
-        },
-        "IN-MN": {
-            "countryName": "インド",
-            "zoneName": "マニプール"
-        },
-        "IN-MP": {
-            "countryName": "インド",
-            "zoneName": "マディヤ・プラデシュ"
-        },
-        "IN-MZ": {
-            "countryName": "インド",
-            "zoneName": "ミゾラム"
-        },
-        "IN-NL": {
-            "countryName": "インド",
-            "zoneName": "ナガランド"
-        },
-        "IN-OR": {
-            "countryName": "インド",
-            "zoneName": "オリッサ州"
-        },
-        "IN-PB": {
-            "countryName": "インド",
-            "zoneName": "パンジャーブ"
-        },
-        "IN-PY": {
-            "countryName": "インド",
-            "zoneName": "ポンディシェリ"
-        },
-        "IN-RJ": {
-            "countryName": "インド",
-            "zoneName": "ラージャスターン"
-        },
-        "IN-SK": {
-            "countryName": "インド",
-            "zoneName": "シッキム"
-        },
-        "IN-TL": {
-            "countryName": "インド",
-            "zoneName": "タミルナードゥ州"
-        },
-        "IN-TR": {
-            "countryName": "インド",
-            "zoneName": "トリプラ"
-        },
-        "IN-UP": {
-            "countryName": "インド",
-            "zoneName": "ウッタル・プラデーシュ州"
-        },
-        "IN-UT": {
-            "countryName": "インド",
-            "zoneName": "ウッタラーカンド州"
-        },
-        "IN-WB": {
-            "countryName": "インド",
-            "zoneName": "西ベンガル州"
-        },
-        "IO": {
-            "zoneName": "イギリス領インド洋地域"
-        },
-        "IQ": {
-            "zoneName": "イラク"
-        },
-        "IQ-KUR": {
-            "countryName": "イラク",
-            "zoneName": "クルディスタン"
-        },
-        "IR": {
-            "zoneName": "イラン"
-        },
-        "IS": {
-            "zoneName": "アイスランド"
-        },
-        "IT": {
-            "zoneName": "イタリア"
-        },
-        "IT-CNO": {
-            "countryName": "イタリア",
-            "zoneName": "中央北部"
-        },
-        "IT-CSO": {
-            "countryName": "イタリア",
-            "zoneName": "中央南部"
-        },
-        "IT-NO": {
-            "countryName": "イタリア",
-            "zoneName": "北部"
-        },
-        "IT-SAR": {
-            "countryName": "イタリア",
-            "zoneName": "サルデーニャ"
-        },
-        "IT-SIC": {
-            "countryName": "イタリア",
-            "zoneName": "シチリア"
-        },
-        "IT-SO": {
-            "countryName": "イタリア",
-            "zoneName": "南部"
-        },
-        "JE": {
-            "zoneName": "ジャージー"
-        },
-        "JM": {
-            "zoneName": "ジャマイカ"
-        },
-        "JO": {
-            "zoneName": "ヨルダン"
-        },
-        "JP-CB": {
-            "countryName": "日本",
-            "zoneName": "中部"
-        },
-        "JP-CG": {
-            "countryName": "日本",
-            "zoneName": "中国"
-        },
-        "JP-HKD": {
-            "countryName": "日本",
-            "zoneName": "北海道"
-        },
-        "JP-HR": {
-            "countryName": "日本",
-            "zoneName": "北陸"
-        },
-        "JP-KN": {
-            "countryName": "日本",
-            "zoneName": "関西"
-        },
-        "JP-KY": {
-            "countryName": "日本",
-            "zoneName": "九州"
-        },
-        "JP-ON": {
-            "countryName": "日本",
-            "zoneName": "沖縄"
-        },
-        "JP-SK": {
-            "countryName": "日本",
-            "zoneName": "四国"
-        },
-        "JP-TH": {
-            "countryName": "日本",
-            "zoneName": "東北"
-        },
-        "JP-TK": {
-            "countryName": "日本",
-            "zoneName": "東京"
-        },
-        "KE": {
-            "zoneName": "ケニア"
-        },
-        "KG": {
-            "zoneName": "キルギス"
-        },
-        "KH": {
-            "zoneName": "カンボジア"
-        },
-        "KI": {
-            "zoneName": "キリバス"
-        },
-        "KM": {
-            "zoneName": "コモロ"
-        },
-        "KN": {
-            "zoneName": "セントクリストファー・ネービス"
-        },
-        "KP": {
-            "zoneName": "北朝鮮"
-        },
-        "KR": {
-            "zoneName": "韓国"
-        },
-        "KW": {
-            "zoneName": "クウェート"
-        },
-        "KY": {
-            "zoneName": "ケイマン諸島"
-        },
-        "KZ": {
-            "zoneName": "カザフスタン"
-        },
-        "LA": {
-            "zoneName": "ラオス"
-        },
-        "LB": {
-            "zoneName": "レバノン"
-        },
-        "LC": {
-            "zoneName": "セントルシア"
-        },
-        "LI": {
-            "zoneName": "リヒテンシュタイン"
-        },
-        "LK": {
-            "zoneName": "スリランカ"
-        },
-        "LR": {
-            "zoneName": "リベリア"
-        },
-        "LS": {
-            "zoneName": "レソト"
-        },
-        "LT": {
-            "zoneName": "リトアニア"
-        },
-        "LU": {
-            "zoneName": "ルクセンブルク"
-        },
-        "LV": {
-            "zoneName": "ラトビア"
-        },
-        "LY": {
-            "zoneName": "リビア"
-        },
-        "MA": {
-            "zoneName": "モロッコ"
-        },
-        "MC": {
-            "zoneName": "モナコ"
-        },
-        "MD": {
-            "zoneName": "モルドバ"
-        },
-        "ME": {
-            "zoneName": "モンテネグロ"
-        },
-        "MF": {
-            "countryName": "セント・マーチン",
-            "zoneName": "フランス"
-        },
-        "MG": {
-            "zoneName": "マダガスカル"
-        },
-        "MH": {
-            "zoneName": "マーシャル諸島"
-        },
-        "MK": {
-            "zoneName": "北マケドニア"
-        },
-        "ML": {
-            "zoneName": "マリ"
-        },
-        "MM": {
-            "zoneName": "ミャンマー"
-        },
-        "MN": {
-            "zoneName": "モンゴル"
-        },
-        "MO": {
-            "zoneName": "マカオ"
-        },
-        "MP": {
-            "zoneName": "北マリアナ諸島"
-        },
-        "MQ": {
-            "zoneName": "マルティニーク"
-        },
-        "MR": {
-            "zoneName": "モーリタニア"
-        },
-        "MS": {
-            "zoneName": "モントセラト"
-        },
-        "MT": {
-            "zoneName": "マルタ"
-        },
-        "MU": {
-            "zoneName": "モーリシャス"
-        },
-        "MV": {
-            "zoneName": "モルディブ"
-        },
-        "MW": {
-            "zoneName": "マラウイ"
-        },
-        "MX": {
-            "zoneName": "メキシコ"
-        },
-        "MX-BC": {
-            "countryName": "メキシコ",
-            "zoneName": "バハ・カリフォルニア"
-        },
-        "MX-CE": {
-            "countryName": "メキシコ",
-            "zoneName": "中央部"
-        },
-        "MX-NE": {
-            "countryName": "メキシコ",
-            "zoneName": "北東部"
-        },
-        "MX-NO": {
-            "countryName": "メキシコ",
-            "zoneName": "北部"
-        },
-        "MX-NW": {
-            "countryName": "メキシコ",
-            "zoneName": "北西部"
-        },
-        "MX-OC": {
-            "countryName": "メキシコ",
-            "zoneName": "西洋部"
-        },
-        "MX-OR": {
-            "countryName": "メキシコ",
-            "zoneName": "東洋部"
-        },
-        "MX-PN": {
-            "countryName": "メキシコ",
-            "zoneName": "半島部"
-        },
-        "MY-EM": {
-            "countryName": "マレーシア",
-            "zoneName": "ボルネオ"
-        },
-        "MY-WM": {
-            "countryName": "マレーシア",
-            "zoneName": "マレー半島"
-        },
-        "MZ": {
-            "zoneName": "モザンビーク"
-        },
-        "NA": {
-            "zoneName": "ナミビア"
-        },
-        "NC": {
-            "zoneName": "ニューカレドニア"
-        },
-        "NE": {
-            "zoneName": "ニジェール"
-        },
-        "NF": {
-            "zoneName": "ノーフォーク島"
-        },
-        "NG": {
-            "zoneName": "ナイジェリア"
-        },
-        "NI": {
-            "zoneName": "ニカラグア"
-        },
-        "NKR": {
-            "zoneName": "ナゴルノ・カラバフ"
-        },
-        "NL": {
-            "zoneName": "オランダ"
-        },
-        "NO-NO1": {
-            "countryName": "ノルウェー",
-            "zoneName": "ノルウェー南東部"
-        },
-        "NO-NO2": {
-            "countryName": "ノルウェー",
-            "zoneName": "ノルウェー南西部"
-        },
-        "NO-NO3": {
-            "countryName": "ノルウェー",
-            "zoneName": "ノルウェー中部"
-        },
-        "NO-NO4": {
-            "countryName": "ノルウェー",
-            "zoneName": "ノルウェー北部"
-        },
-        "NO-NO5": {
-            "countryName": "ノルウェー",
-            "zoneName": "ノルウェー西部"
-        },
-        "NP": {
-            "zoneName": "ネパール"
-        },
-        "NR": {
-            "zoneName": "ナウル"
-        },
-        "NU": {
-            "zoneName": "ニウエ"
-        },
-        "NZ": {
-            "zoneName": "ニュージーランド"
-        },
-        "NZ-NZA": {
-            "countryName": "ニュージーランド",
-            "zoneName": "オークランド諸島"
-        },
-        "NZ-NZC": {
-            "countryName": "ニュージーランド",
-            "zoneName": "チャタム諸島"
-        },
-        "OM": {
-            "zoneName": "オマーン"
-        },
-        "PA": {
-            "zoneName": "パナマ"
-        },
-        "PE": {
-            "zoneName": "ペルー"
-        },
-        "PF": {
-            "zoneName": "フランス領ポリネシア"
-        },
-        "PG": {
-            "zoneName": "パプアニューギニア"
-        },
-        "PH": {
-            "zoneName": "フィリピン"
-        },
-        "PK": {
-            "zoneName": "パキスタン"
-        },
-        "PL": {
-            "zoneName": "ポーランド"
-        },
-        "PM": {
-            "zoneName": "サン・ピエール及びミクロン"
-        },
-        "PN": {
-            "zoneName": "ピトケアン"
-        },
-        "PR": {
-            "zoneName": "プエルトリコ"
-        },
-        "PS": {
-            "zoneName": "パレスチナ"
-        },
-        "PT": {
-            "zoneName": "ポルトガル"
-        },
-        "PT-AC": {
-            "countryName": "ポルトガル",
-            "zoneName": "アゾレス諸島"
-        },
-        "PT-MA": {
-            "countryName": "ポルトガル",
-            "zoneName": "マデイラ"
-        },
-        "PW": {
-            "zoneName": "パラオ"
-        },
-        "PY": {
-            "zoneName": "パラグアイ"
-        },
-        "QA": {
-            "zoneName": "カタール"
-        },
-        "RE": {
-            "zoneName": "レユニオン"
-        },
-        "RO": {
-            "zoneName": "ルーマニア"
-        },
-        "RS": {
-            "zoneName": "セルビア"
-        },
-        "RU": {
-            "zoneName": "ロシア"
-        },
-        "RU-1": {
-            "countryName": "ロシア",
-            "zoneName": "ヨーロッパロシアとウラル"
-        },
-        "RU-2": {
-            "countryName": "ロシア",
-            "zoneName": "シベリア"
-        },
-        "RU-EU": {
-            "zoneName": "ロシア"
-        },
-        "RU-AS": {
-            "zoneName": "ロシア"
-        },
-        "RU-KGD": {
-            "countryName": "ロシア",
-            "zoneName": "カリーニングラード"
-        },
-        "RW": {
-            "zoneName": "ルワンダ"
-        },
-        "SA": {
-            "zoneName": "サウジアラビア"
-        },
-        "SB": {
-            "zoneName": "ソロモン諸島"
-        },
-        "SC": {
-            "zoneName": "セーシェル"
-        },
-        "SD": {
-            "zoneName": "スーダン"
-        },
-        "SE": {
-            "zoneName": "スウェーデン"
-        },
-        "SG": {
-            "zoneName": "シンガポール"
-        },
-        "SH": {
-            "zoneName": "セントヘレナ・アセンションおよびトリスタンダクーニャ"
-        },
-        "SI": {
-            "zoneName": "スロベニア"
-        },
-        "SJ": {
-            "zoneName": "スヴァールバル諸島およびヤンマイエン島"
-        },
-        "SK": {
-            "zoneName": "スロバキア"
-        },
-        "SL": {
-            "zoneName": "シエラレオネ"
-        },
-        "SM": {
-            "zoneName": "サンマリノ"
-        },
-        "SN": {
-            "zoneName": "セネガル"
-        },
-        "SO": {
-            "zoneName": "ソマリア"
-        },
-        "SR": {
-            "zoneName": "スリナム"
-        },
-        "SS": {
-            "zoneName": "南スーダン"
-        },
-        "ST": {
-            "zoneName": "サントメ・プリンシペ"
-        },
-        "SV": {
-            "zoneName": "エルサルバドル"
-        },
-        "SX": {
-            "countryName": "シント・マールテン",
-            "zoneName": "オランダ領"
-        },
-        "SY": {
-            "zoneName": "シリア"
-        },
-        "SZ": {
-            "zoneName": "エスワティニ"
-        },
-        "TC": {
-            "zoneName": "タークス・カイコス諸島"
-        },
-        "TD": {
-            "zoneName": "チャド"
-        },
-        "TF": {
-            "zoneName": "フランス領南方・南極地域"
-        },
-        "TG": {
-            "zoneName": "トーゴ"
-        },
-        "TH": {
-            "zoneName": "タイ"
-        },
-        "TJ": {
-            "zoneName": "タジキスタン"
-        },
-        "TK": {
-            "zoneName": "トケラウ"
-        },
-        "TL": {
-            "zoneName": "東ティモール"
-        },
-        "TM": {
-            "zoneName": "トルクメニスタン"
-        },
-        "TN": {
-            "zoneName": "チュニジア"
-        },
-        "TO": {
-            "zoneName": "トンガ"
-        },
-        "TR": {
-            "zoneName": "トルコ"
-        },
-        "TT": {
-            "zoneName": "トリニダード・ドバゴ"
-        },
-        "TV": {
-            "zoneName": "ツバル"
-        },
-        "TW": {
-            "zoneName": "台湾"
-        },
-        "TZ": {
-            "zoneName": "タンザニア"
-        },
-        "UA": {
-            "zoneName": "ウクライナ"
-        },
-        "UA-CR": {
-            "countryName": "クリミア",
-            "zoneName": "ウクライナ"
-        },
-        "UG": {
-            "zoneName": "ウガンダ"
-        },
-        "UM": {
-            "zoneName": "アメリカ合衆国領有小離島"
-        },
-        "US-HI-HA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "ハワイ"
-        },
-        "US-HI-KA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "カウアイ"
-        },
-        "US-HI-KH": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "カホオラウェ"
-        },
-        "US-HI-LA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "ラナイ"
-        },
-        "US-HI-MA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "マウイ"
-        },
-        "US-HI-MO": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "モロカイ"
-        },
-        "US-HI-NI": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "ニイハウ"
-        },
-        "US-HI-OA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "オアフ"
-        },
-        "US-CAL-BANC": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Balancing Authority Of Northern California"
-        },
-        "US-CAL-CISO": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "California Independent System Operator"
-        },
-        "US-CAL-IID": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Imperial Irrigation District"
-        },
-        "US-CAL-LDWP": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Los Angeles Department Of Water And Power"
-        },
-        "US-CAL-TIDC": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Duke Energy Carolinas"
-        },
-        "US-CAR-SC": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "South Carolina Public Service Authority"
-        },
-        "US-CAR-SCEG": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "South Carolina Electric & Gas Company"
-        },
-        "US-CAR-YAD": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
-        },
-        "US-CENT-SPA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Southwestern Power Administration"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "City Of Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "JEA"
-        },
-        "US-FLA-NSB": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Utilities Commission Of New Smyrna Beach"
-        },
-        "US-FLA-SEC": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "City Of Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "PJM Interconnection, Llc"
-        },
-        "US-MIDW-AECI": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Associated Electric Cooperative, Inc."
-        },
-        "US-MIDW-GLHB": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "GridLiance"
-        },
+        "AD": { "zoneName": "アンドラ" },
+        "AE": { "zoneName": "アラブ首長国連邦" },
+        "AF": { "zoneName": "アフガニスタン" },
+        "AG": { "zoneName": "アンティグア・バーブーダ" },
+        "AI": { "zoneName": "アンギラ" },
+        "AL": { "zoneName": "アルバニア" },
+        "AM": { "zoneName": "アルメニア" },
+        "AO": { "zoneName": "アンゴラ" },
+        "AQ": { "zoneName": "南極大陸" },
+        "AS": { "zoneName": "アメリカ領サモア" },
+        "AT": { "zoneName": "オーストリア" },
+        "AR": { "zoneName": "アルゼンチン" },
+        "AUS-NSW": { "countryName": "オーストラリア", "zoneName": "ニューサウスウェールズ州" },
+        "AUS-NT": { "countryName": "オーストラリア", "zoneName": "ノーザンテリトリー" },
+        "AUS-QLD": { "countryName": "オーストラリア", "zoneName": "クイーンズランド州" },
+        "AUS-SA": { "countryName": "オーストラリア", "zoneName": "南 オーストラリア" },
+        "AUS-TAS": { "countryName": "オーストラリア", "zoneName": "タスマニア" },
+        "AUS-TAS-KI": { "countryName": "オーストラリア", "zoneName": "キング島" },
+        "AUS-VIC": { "countryName": "オーストラリア", "zoneName": "ビクトリア州" },
+        "AUS-WA": { "countryName": "オーストラリア", "zoneName": "西 オーストラリア" },
+        "AW": { "zoneName": "アルバ" },
+        "AX": { "zoneName": "オーランド諸島" },
+        "AZ": { "zoneName": "アゼルバイジャン" },
+        "BA": { "zoneName": "ボスニア・ヘルツェゴビナ" },
+        "BB": { "zoneName": "バルバドス" },
+        "BD": { "zoneName": "バングラデシュ" },
+        "BE": { "zoneName": "ベルギー" },
+        "BF": { "zoneName": "ブルキナファソ" },
+        "BG": { "zoneName": "ブルガリア" },
+        "BH": { "zoneName": "バーレーン" },
+        "BI": { "zoneName": "ブルンジ" },
+        "BJ": { "zoneName": "ベナン" },
+        "BM": { "zoneName": "バミューダ" },
+        "BN": { "zoneName": "ブルネイ" },
+        "BO": { "zoneName": "ボリビア" },
+        "BQ": { "zoneName": "ボネール、シント・ユースタティウスおよびサバ" },
+        "BR-CS": { "countryName": "ブラジル", "zoneName": "中央ブラジル" },
+        "BR-N": { "countryName": "ブラジル", "zoneName": "北ブラジル" },
+        "BR-NE": { "countryName": "ブラジル", "zoneName": "東北ブラジル" },
+        "BR-S": { "countryName": "ブラジル", "zoneName": "南ブラジル" },
+        "BS": { "zoneName": "バハマ" },
+        "BT": { "zoneName": "ブータン" },
+        "BV": { "zoneName": "ブーベ島" },
+        "BW": { "zoneName": "ボツワナ" },
+        "BY": { "zoneName": "ベラルーシ" },
+        "BZ": { "zoneName": "ベリーズ" },
+        "CA-AB": { "countryName": "カナダ", "zoneName": "アルバータ州" },
+        "CA-BC": { "countryName": "カナダ", "zoneName": "ブリティッシュコロンビア" },
+        "CA-MB": { "countryName": "カナダ", "zoneName": "マニトバ州" },
+        "CA-NL": { "countryName": "カナダ", "zoneName": "ニューファンドランドアンドラブラドール州" },
+        "CA-NB": { "countryName": "カナダ", "zoneName": "ニューブランズウィック" },
+        "CA-NT": { "countryName": "カナダ", "zoneName": "ノースウェスト準州" },
+        "CA-NS": { "countryName": "カナダ", "zoneName": "ノバスコシア州" },
+        "CA-NU": { "countryName": "カナダ", "zoneName": "ヌナブト" },
+        "CA-ON": { "countryName": "カナダ", "zoneName": "オンタリオ" },
+        "CA-PE": { "countryName": "カナダ", "zoneName": "プリンス・エドワード島" },
+        "CA-QC": { "countryName": "カナダ", "zoneName": "ケベック州" },
+        "CA-SK": { "countryName": "カナダ", "zoneName": "サスカチュワン州" },
+        "CA-YT": { "countryName": "カナダ", "zoneName": "ユーコン" },
+        "CC": { "zoneName": "ココス諸島" },
+        "CD": { "zoneName": "コンゴ民主共和国" },
+        "CF": { "zoneName": "中央アフリカ共和国" },
+        "CG": { "zoneName": "コンゴ" },
+        "CH": { "zoneName": "スイス" },
+        "CI": { "zoneName": "コートジボワール" },
+        "CK": { "zoneName": "クック諸島" },
+        "CL-SEA": { "countryName": "チリ", "zoneName": "Sistema Eléctrico de Aysén" },
+        "CL-SEM": { "countryName": "チリ", "zoneName": "Sistema Eléctrico de Magallanes" },
+        "CL-SEN": { "countryName": "チリ", "zoneName": "Sistema Eléctrico Nacional" },
+        "CM": { "zoneName": "カメルーン" },
+        "CN": { "zoneName": "中国" },
+        "CO": { "zoneName": "コロンビア" },
+        "CR": { "zoneName": "コスタリカ" },
+        "CU": { "zoneName": "キューバ" },
+        "CV": { "zoneName": "カーボベルデ" },
+        "CW": { "zoneName": "キュラソー" },
+        "CX": { "zoneName": "クリスマス島" },
+        "CY": { "zoneName": "キプロス" },
+        "CZ": { "zoneName": "チェコ" },
+        "DE": { "zoneName": "ドイツ" },
+        "DJ": { "zoneName": "ジブチ" },
+        "DK": { "zoneName": "デンマーク" },
+        "DK-DK1": { "countryName": "デンマーク", "zoneName": "西デンマーク" },
+        "DK-DK2": { "countryName": "デンマーク", "zoneName": "西デンマーク" },
+        "DK-BHM": { "countryName": "デンマーク", "zoneName": "東デンマーク" },
+        "DM": { "zoneName": "ドミニカ" },
+        "DO": { "zoneName": "ドミニカ共和国" },
+        "DZ": { "zoneName": "アルジェリア" },
+        "EC": { "zoneName": "エクアドル" },
+        "EE": { "zoneName": "エストニア" },
+        "EG": { "zoneName": "エジプト" },
+        "EH": { "zoneName": "西サハラ" },
+        "ER": { "zoneName": "エリトリア" },
+        "ES": { "zoneName": "スペイン" },
+        "ES-IB-FO": { "countryName": "スペイン", "zoneName": "フォルメンテラ島" },
+        "ES-IB-IZ": { "countryName": "スペイン", "zoneName": "イビサ島" },
+        "ES-IB-MA": { "countryName": "スペイン", "zoneName": "マヨルカ島" },
+        "ES-IB-ME": { "countryName": "スペイン", "zoneName": "メノルカ島" },
+        "ES-CN-FVLZ": { "countryName": "スペイン", "zoneName": "フエルテベントゥラ島/ランサローテ島" },
+        "ES-CN-GC": { "countryName": "スペイン", "zoneName": "グラン・カナリア島" },
+        "ES-CN-HI": { "countryName": "スペイン", "zoneName": "エル・イエロ島 " },
+        "ES-CN-IG": { "countryName": "スペイン", "zoneName": "ラ・ゴメラ島" },
+        "ES-CN-LP": { "countryName": "スペイン", "zoneName": "ラ・パルマ島" },
+        "ES-CN-TE": { "countryName": "スペイン", "zoneName": "テネリフェ島" },
+        "ET": { "zoneName": "エチオピア" },
+        "FI": { "zoneName": "フィンランド" },
+        "FJ": { "zoneName": "フィジー" },
+        "FK": { "zoneName": "フォークランド諸島" },
+        "FM": { "zoneName": "ミクロネシア" },
+        "FO": { "zoneName": "フェロー諸島" },
+        "FR": { "zoneName": "フランス" },
+        "FR-COR": { "countryName": "フランス", "zoneName": "コルシカ島" },
+        "GA": { "zoneName": "ガボン" },
+        "GB": { "zoneName": "イギリス" },
+        "GB-NIR": { "zoneName": "北アイルランド" },
+        "GB-ORK": { "countryName": "イギリス", "zoneName": "オークニー諸島" },
+        "GB-SHI": { "countryName": "イギリス", "zoneName": "シェットランド諸島" },
+        "GB-ZET": { "countryName": "イギリス", "zoneName": "シェットランド諸島" },
+        "GD": { "zoneName": "グレナダ" },
+        "GE": { "zoneName": "ジョージア州" },
+        "GF": { "zoneName": "フランス領ギアナ" },
+        "GG": { "zoneName": "ガーンジー" },
+        "GH": { "zoneName": "ガーナ" },
+        "GI": { "zoneName": "ジブラルタル" },
+        "GL": { "zoneName": "グリーンランド" },
+        "GM": { "zoneName": "ガンビア" },
+        "GN": { "zoneName": "ギニア" },
+        "GP": { "zoneName": "グアドループ" },
+        "GQ": { "zoneName": "赤道ギニア" },
+        "GR": { "zoneName": "ギリシャ" },
+        "GR-IS": { "countryName": "ギリシャ", "zoneName": "エーゲ海諸島" },
+        "GS": { "zoneName": "サウスジョージア・サウスサンドウィッチ諸島" },
+        "GT": { "zoneName": "グアテマラ" },
+        "GU": { "zoneName": "グアム" },
+        "GW": { "zoneName": "ギニアビサウ" },
+        "GY": { "zoneName": "ガイアナ" },
+        "HK": { "zoneName": "香港" },
+        "HM": { "zoneName": "ハード島とマクドナルド諸島" },
+        "HN": { "zoneName": "ホンジュラス" },
+        "HR": { "zoneName": "クロアチア" },
+        "HT": { "zoneName": "ハイチ" },
+        "HU": { "zoneName": "ハンガリー" },
+        "ID": { "zoneName": "インドネシア" },
+        "IE": { "zoneName": "アイルランド" },
+        "IL": { "zoneName": "イスラエル" },
+        "IM": { "zoneName": "マン島" },
+        "IN-AN": { "countryName": "インド", "zoneName": "アンダマンとニコバル諸島" },
+        "IN-AP": { "countryName": "インド", "zoneName": "アンドラ・プラデシュ" },
+        "IN-AR": { "countryName": "インド", "zoneName": "アルナチャルプラデーシュ州" },
+        "IN-AS": { "countryName": "インド", "zoneName": "アッサム" },
+        "IN-BR": { "countryName": "インド", "zoneName": "ビハール" },
+        "IN-CT": { "countryName": "インド", "zoneName": "チャッティースガル" },
+        "IN-DL": { "countryName": "インド", "zoneName": "デリー" },
+        "IN-DN": { "countryName": "インド", "zoneName": "ダードラーおよびナガル・ハヴェーリー" },
+        "IN-GA": { "countryName": "インド", "zoneName": "ゴア" },
+        "IN-GJ": { "countryName": "インド", "zoneName": "グジャラート州" },
+        "IN-HP": { "countryName": "インド", "zoneName": "ヒマーチャルプラデーシュ州" },
+        "IN-HR": { "countryName": "インド", "zoneName": "ハリヤーナ" },
+        "IN-JH": { "countryName": "インド", "zoneName": "ジャールカンド州" },
+        "IN-JK": { "countryName": "インド", "zoneName": "ジャムとカシミール" },
+        "IN-KA": { "countryName": "インド", "zoneName": "カルナタカ" },
+        "IN-KL": { "countryName": "インド", "zoneName": "ケララ州" },
+        "IN-MH": { "countryName": "インド", "zoneName": "マハラシュトラ" },
+        "IN-ML": { "countryName": "インド", "zoneName": "メガラヤ" },
+        "IN-MN": { "countryName": "インド", "zoneName": "マニプール" },
+        "IN-MP": { "countryName": "インド", "zoneName": "マディヤ・プラデシュ" },
+        "IN-MZ": { "countryName": "インド", "zoneName": "ミゾラム" },
+        "IN-NL": { "countryName": "インド", "zoneName": "ナガランド" },
+        "IN-OR": { "countryName": "インド", "zoneName": "オリッサ州" },
+        "IN-PB": { "countryName": "インド", "zoneName": "パンジャーブ" },
+        "IN-PY": { "countryName": "インド", "zoneName": "ポンディシェリ" },
+        "IN-RJ": { "countryName": "インド", "zoneName": "ラージャスターン" },
+        "IN-SK": { "countryName": "インド", "zoneName": "シッキム" },
+        "IN-TL": { "countryName": "インド", "zoneName": "タミルナードゥ州" },
+        "IN-TR": { "countryName": "インド", "zoneName": "トリプラ" },
+        "IN-UP": { "countryName": "インド", "zoneName": "ウッタル・プラデーシュ州" },
+        "IN-UT": { "countryName": "インド", "zoneName": "ウッタラーカンド州" },
+        "IN-WB": { "countryName": "インド", "zoneName": "西ベンガル州" },
+        "IO": { "zoneName": "イギリス領インド洋地域" },
+        "IQ": { "zoneName": "イラク" },
+        "IQ-KUR": { "countryName": "イラク", "zoneName": "クルディスタン" },
+        "IR": { "zoneName": "イラン" },
+        "IS": { "zoneName": "アイスランド" },
+        "IT": { "zoneName": "イタリア" },
+        "IT-CNO": { "countryName": "イタリア", "zoneName": "中央北部" },
+        "IT-CSO": { "countryName": "イタリア", "zoneName": "中央南部" },
+        "IT-NO": { "countryName": "イタリア", "zoneName": "北部" },
+        "IT-SAR": { "countryName": "イタリア", "zoneName": "サルデーニャ" },
+        "IT-SIC": { "countryName": "イタリア", "zoneName": "シチリア" },
+        "IT-SO": { "countryName": "イタリア", "zoneName": "南部" },
+        "JE": { "zoneName": "ジャージー" },
+        "JM": { "zoneName": "ジャマイカ" },
+        "JO": { "zoneName": "ヨルダン" },
+        "JP-CB": { "countryName": "日本", "zoneName": "中部" },
+        "JP-CG": { "countryName": "日本", "zoneName": "中国" },
+        "JP-HKD": { "countryName": "日本", "zoneName": "北海道" },
+        "JP-HR": { "countryName": "日本", "zoneName": "北陸" },
+        "JP-KN": { "countryName": "日本", "zoneName": "関西" },
+        "JP-KY": { "countryName": "日本", "zoneName": "九州" },
+        "JP-ON": { "countryName": "日本", "zoneName": "沖縄" },
+        "JP-SK": { "countryName": "日本", "zoneName": "四国" },
+        "JP-TH": { "countryName": "日本", "zoneName": "東北" },
+        "JP-TK": { "countryName": "日本", "zoneName": "東京" },
+        "KE": { "zoneName": "ケニア" },
+        "KG": { "zoneName": "キルギス" },
+        "KH": { "zoneName": "カンボジア" },
+        "KI": { "zoneName": "キリバス" },
+        "KM": { "zoneName": "コモロ" },
+        "KN": { "zoneName": "セントクリストファー・ネービス" },
+        "KP": { "zoneName": "北朝鮮" },
+        "KR": { "zoneName": "韓国" },
+        "KW": { "zoneName": "クウェート" },
+        "KY": { "zoneName": "ケイマン諸島" },
+        "KZ": { "zoneName": "カザフスタン" },
+        "LA": { "zoneName": "ラオス" },
+        "LB": { "zoneName": "レバノン" },
+        "LC": { "zoneName": "セントルシア" },
+        "LI": { "zoneName": "リヒテンシュタイン" },
+        "LK": { "zoneName": "スリランカ" },
+        "LR": { "zoneName": "リベリア" },
+        "LS": { "zoneName": "レソト" },
+        "LT": { "zoneName": "リトアニア" },
+        "LU": { "zoneName": "ルクセンブルク" },
+        "LV": { "zoneName": "ラトビア" },
+        "LY": { "zoneName": "リビア" },
+        "MA": { "zoneName": "モロッコ" },
+        "MC": { "zoneName": "モナコ" },
+        "MD": { "zoneName": "モルドバ" },
+        "ME": { "zoneName": "モンテネグロ" },
+        "MF": { "countryName": "セント・マーチン", "zoneName": "フランス" },
+        "MG": { "zoneName": "マダガスカル" },
+        "MH": { "zoneName": "マーシャル諸島" },
+        "MK": { "zoneName": "北マケドニア" },
+        "ML": { "zoneName": "マリ" },
+        "MM": { "zoneName": "ミャンマー" },
+        "MN": { "zoneName": "モンゴル" },
+        "MO": { "zoneName": "マカオ" },
+        "MP": { "zoneName": "北マリアナ諸島" },
+        "MQ": { "zoneName": "マルティニーク" },
+        "MR": { "zoneName": "モーリタニア" },
+        "MS": { "zoneName": "モントセラト" },
+        "MT": { "zoneName": "マルタ" },
+        "MU": { "zoneName": "モーリシャス" },
+        "MV": { "zoneName": "モルディブ" },
+        "MW": { "zoneName": "マラウイ" },
+        "MX": { "zoneName": "メキシコ" },
+        "MX-BC": { "countryName": "メキシコ", "zoneName": "バハ・カリフォルニア" },
+        "MX-CE": { "countryName": "メキシコ", "zoneName": "中央部" },
+        "MX-NE": { "countryName": "メキシコ", "zoneName": "北東部" },
+        "MX-NO": { "countryName": "メキシコ", "zoneName": "北部" },
+        "MX-NW": { "countryName": "メキシコ", "zoneName": "北西部" },
+        "MX-OC": { "countryName": "メキシコ", "zoneName": "西洋部" },
+        "MX-OR": { "countryName": "メキシコ", "zoneName": "東洋部" },
+        "MX-PN": { "countryName": "メキシコ", "zoneName": "半島部" },
+        "MY-EM": { "countryName": "マレーシア", "zoneName": "ボルネオ" },
+        "MY-WM": { "countryName": "マレーシア", "zoneName": "マレー半島" },
+        "MZ": { "zoneName": "モザンビーク" },
+        "NA": { "zoneName": "ナミビア" },
+        "NC": { "zoneName": "ニューカレドニア" },
+        "NE": { "zoneName": "ニジェール" },
+        "NF": { "zoneName": "ノーフォーク島" },
+        "NG": { "zoneName": "ナイジェリア" },
+        "NI": { "zoneName": "ニカラグア" },
+        "NKR": { "zoneName": "ナゴルノ・カラバフ" },
+        "NL": { "zoneName": "オランダ" },
+        "NO-NO1": { "countryName": "ノルウェー", "zoneName": "ノルウェー南東部" },
+        "NO-NO2": { "countryName": "ノルウェー", "zoneName": "ノルウェー南西部" },
+        "NO-NO3": { "countryName": "ノルウェー", "zoneName": "ノルウェー中部" },
+        "NO-NO4": { "countryName": "ノルウェー", "zoneName": "ノルウェー北部" },
+        "NO-NO5": { "countryName": "ノルウェー", "zoneName": "ノルウェー西部" },
+        "NP": { "zoneName": "ネパール" },
+        "NR": { "zoneName": "ナウル" },
+        "NU": { "zoneName": "ニウエ" },
+        "NZ": { "zoneName": "ニュージーランド" },
+        "NZ-NZA": { "countryName": "ニュージーランド", "zoneName": "オークランド諸島" },
+        "NZ-NZC": { "countryName": "ニュージーランド", "zoneName": "チャタム諸島" },
+        "OM": { "zoneName": "オマーン" },
+        "PA": { "zoneName": "パナマ" },
+        "PE": { "zoneName": "ペルー" },
+        "PF": { "zoneName": "フランス領ポリネシア" },
+        "PG": { "zoneName": "パプアニューギニア" },
+        "PH": { "zoneName": "フィリピン" },
+        "PK": { "zoneName": "パキスタン" },
+        "PL": { "zoneName": "ポーランド" },
+        "PM": { "zoneName": "サン・ピエール及びミクロン" },
+        "PN": { "zoneName": "ピトケアン" },
+        "PR": { "zoneName": "プエルトリコ" },
+        "PS": { "zoneName": "パレスチナ" },
+        "PT": { "zoneName": "ポルトガル" },
+        "PT-AC": { "countryName": "ポルトガル", "zoneName": "アゾレス諸島" },
+        "PT-MA": { "countryName": "ポルトガル", "zoneName": "マデイラ" },
+        "PW": { "zoneName": "パラオ" },
+        "PY": { "zoneName": "パラグアイ" },
+        "QA": { "zoneName": "カタール" },
+        "RE": { "zoneName": "レユニオン" },
+        "RO": { "zoneName": "ルーマニア" },
+        "RS": { "zoneName": "セルビア" },
+        "RU": { "zoneName": "ロシア" },
+        "RU-1": { "countryName": "ロシア", "zoneName": "ヨーロッパロシアとウラル" },
+        "RU-2": { "countryName": "ロシア", "zoneName": "シベリア" },
+        "RU-EU": { "zoneName": "ロシア" },
+        "RU-AS": { "zoneName": "ロシア" },
+        "RU-KGD": { "countryName": "ロシア", "zoneName": "カリーニングラード" },
+        "RW": { "zoneName": "ルワンダ" },
+        "SA": { "zoneName": "サウジアラビア" },
+        "SB": { "zoneName": "ソロモン諸島" },
+        "SC": { "zoneName": "セーシェル" },
+        "SD": { "zoneName": "スーダン" },
+        "SE": { "zoneName": "スウェーデン" },
+        "SG": { "zoneName": "シンガポール" },
+        "SH": { "zoneName": "セントヘレナ・アセンションおよびトリスタンダクーニャ" },
+        "SI": { "zoneName": "スロベニア" },
+        "SJ": { "zoneName": "スヴァールバル諸島およびヤンマイエン島" },
+        "SK": { "zoneName": "スロバキア" },
+        "SL": { "zoneName": "シエラレオネ" },
+        "SM": { "zoneName": "サンマリノ" },
+        "SN": { "zoneName": "セネガル" },
+        "SO": { "zoneName": "ソマリア" },
+        "SR": { "zoneName": "スリナム" },
+        "SS": { "zoneName": "南スーダン" },
+        "ST": { "zoneName": "サントメ・プリンシペ" },
+        "SV": { "zoneName": "エルサルバドル" },
+        "SX": { "countryName": "シント・マールテン", "zoneName": "オランダ領" },
+        "SY": { "zoneName": "シリア" },
+        "SZ": { "zoneName": "エスワティニ" },
+        "TC": { "zoneName": "タークス・カイコス諸島" },
+        "TD": { "zoneName": "チャド" },
+        "TF": { "zoneName": "フランス領南方・南極地域" },
+        "TG": { "zoneName": "トーゴ" },
+        "TH": { "zoneName": "タイ" },
+        "TJ": { "zoneName": "タジキスタン" },
+        "TK": { "zoneName": "トケラウ" },
+        "TL": { "zoneName": "東ティモール" },
+        "TM": { "zoneName": "トルクメニスタン" },
+        "TN": { "zoneName": "チュニジア" },
+        "TO": { "zoneName": "トンガ" },
+        "TR": { "zoneName": "トルコ" },
+        "TT": { "zoneName": "トリニダード・ドバゴ" },
+        "TV": { "zoneName": "ツバル" },
+        "TW": { "zoneName": "台湾" },
+        "TZ": { "zoneName": "タンザニア" },
+        "UA": { "zoneName": "ウクライナ" },
+        "UA-CR": { "countryName": "クリミア", "zoneName": "ウクライナ" },
+        "UG": { "zoneName": "ウガンダ" },
+        "UM": { "zoneName": "アメリカ合衆国領有小離島" },
+        "US-HI-HA": { "countryName": "アメリカ合衆国", "zoneName": "ハワイ" },
+        "US-HI-KA": { "countryName": "アメリカ合衆国", "zoneName": "カウアイ" },
+        "US-HI-KH": { "countryName": "アメリカ合衆国", "zoneName": "カホオラウェ" },
+        "US-HI-LA": { "countryName": "アメリカ合衆国", "zoneName": "ラナイ" },
+        "US-HI-MA": { "countryName": "アメリカ合衆国", "zoneName": "マウイ" },
+        "US-HI-MO": { "countryName": "アメリカ合衆国", "zoneName": "モロカイ" },
+        "US-HI-NI": { "countryName": "アメリカ合衆国", "zoneName": "ニイハウ" },
+        "US-HI-OA": { "countryName": "アメリカ合衆国", "zoneName": "オアフ" },
+        "US-CAL-BANC": { "countryName": "アメリカ合衆国", "zoneName": "Balancing Authority Of Northern California" },
+        "US-CAL-CISO": { "countryName": "アメリカ合衆国", "zoneName": "California Independent System Operator" },
+        "US-CAL-IID": { "countryName": "アメリカ合衆国", "zoneName": "Imperial Irrigation District" },
+        "US-CAL-LDWP": { "countryName": "アメリカ合衆国", "zoneName": "Los Angeles Department Of Water And Power" },
+        "US-CAL-TIDC": { "countryName": "アメリカ合衆国", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "アメリカ合衆国", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "アメリカ合衆国", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "アメリカ合衆国", "zoneName": "Duke Energy Carolinas" },
+        "US-CAR-SC": { "countryName": "アメリカ合衆国", "zoneName": "South Carolina Public Service Authority" },
+        "US-CAR-SCEG": { "countryName": "アメリカ合衆国", "zoneName": "South Carolina Electric & Gas Company" },
+        "US-CAR-YAD": { "countryName": "アメリカ合衆国", "zoneName": "Alcoa Power Generating, Inc. Yadkin Division" },
+        "US-CENT-SPA": { "countryName": "アメリカ合衆国", "zoneName": "Southwestern Power Administration" },
+        "US-CENT-SWPP": { "countryName": "アメリカ合衆国", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "アメリカ合衆国", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "アメリカ合衆国", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "アメリカ合衆国", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "アメリカ合衆国", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "アメリカ合衆国", "zoneName": "City Of Homestead" },
+        "US-FLA-JEA": { "countryName": "アメリカ合衆国", "zoneName": "JEA" },
+        "US-FLA-NSB": { "countryName": "アメリカ合衆国", "zoneName": "Utilities Commission Of New Smyrna Beach" },
+        "US-FLA-SEC": { "countryName": "アメリカ合衆国", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "アメリカ合衆国", "zoneName": "City Of Tallahassee" },
+        "US-FLA-TEC": { "countryName": "アメリカ合衆国", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "アメリカ合衆国", "zoneName": "PJM Interconnection, Llc" },
+        "US-MIDW-AECI": { "countryName": "アメリカ合衆国", "zoneName": "Associated Electric Cooperative, Inc." },
+        "US-MIDW-GLHB": { "countryName": "アメリカ合衆国", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "アメリカ合衆国",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1494,78 +576,24 @@
             "countryName": "アメリカ合衆国",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc.."
         },
-        "US-NE-ISNE": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
-        "US-NW-GCPD": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "PUD No. 2 Of Grant County, Washington"
-        },
-        "US-NW-GRID": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Portland General Electric Company"
-        },
-        "US-NW-PSCO": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Public Service Company Of Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NE-ISNE": { "countryName": "アメリカ合衆国", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "アメリカ合衆国", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "アメリカ合衆国", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "アメリカ合衆国", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "アメリカ合衆国", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "アメリカ合衆国", "zoneName": "PUD No. 1 Of Douglas County" },
+        "US-NW-GCPD": { "countryName": "アメリカ合衆国", "zoneName": "PUD No. 2 Of Grant County, Washington" },
+        "US-NW-GRID": { "countryName": "アメリカ合衆国", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "アメリカ合衆国", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "アメリカ合衆国", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "アメリカ合衆国", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "アメリカ合衆国", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "アメリカ合衆国", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "アメリカ合衆国", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "アメリカ合衆国", "zoneName": "Portland General Electric Company" },
+        "US-NW-PSCO": { "countryName": "アメリカ合衆国", "zoneName": "Public Service Company Of Colorado" },
+        "US-NW-PSEI": { "countryName": "アメリカ合衆国", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "アメリカ合衆国", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "アメリカ合衆国",
             "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
@@ -1574,133 +602,44 @@
             "countryName": "アメリカ合衆国",
             "zoneName": "Western Area Power Administration - Rocky Mountain Region"
         },
-        "US-NW-WAUW": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Western Area Power Administration UGP West"
-        },
-        "US-NW-WWA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "New York Independent System Operator"
-        },
-        "US-SE-AEC": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Southeastern Power Administration"
-        },
-        "US-SE-SOCO": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Southern Company Services, Inc. - Trans"
-        },
-        "US-SW-AZPS": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Gila River Power, LLC"
-        },
-        "US-SW-HGMA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "New Harquahala Generating Company, LLC"
-        },
-        "US-SW-PNM": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Public Service Company Of New Mexico"
-        },
-        "US-SW-SRP": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-NW-WAUW": { "countryName": "アメリカ合衆国", "zoneName": "Western Area Power Administration UGP West" },
+        "US-NW-WWA": { "countryName": "アメリカ合衆国", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "アメリカ合衆国", "zoneName": "New York Independent System Operator" },
+        "US-SE-AEC": { "countryName": "アメリカ合衆国", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "アメリカ合衆国", "zoneName": "Southeastern Power Administration" },
+        "US-SE-SOCO": { "countryName": "アメリカ合衆国", "zoneName": "Southern Company Services, Inc. - Trans" },
+        "US-SW-AZPS": { "countryName": "アメリカ合衆国", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "アメリカ合衆国", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "アメリカ合衆国", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "アメリカ合衆国", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "アメリカ合衆国", "zoneName": "Gila River Power, LLC" },
+        "US-SW-HGMA": { "countryName": "アメリカ合衆国", "zoneName": "New Harquahala Generating Company, LLC" },
+        "US-SW-PNM": { "countryName": "アメリカ合衆国", "zoneName": "Public Service Company Of New Mexico" },
+        "US-SW-SRP": { "countryName": "アメリカ合衆国", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "アメリカ合衆国", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "アメリカ合衆国",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Tennessee Valley Authority"
-        },
-        "US-TEX-ERCO": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "Electric Reliability Council Of Texas, Inc."
-        },
-        "UY": {
-            "zoneName": "ウルグアイ"
-        },
-        "UZ": {
-            "zoneName": "ウズベキスタン"
-        },
-        "VA": {
-            "zoneName": "バチカン市国"
-        },
-        "VC": {
-            "zoneName": "セントビンセント及びグレナディーン諸島"
-        },
-        "VE": {
-            "zoneName": "ベネズエラ"
-        },
-        "VG": {
-            "countryName": "ヴァージン諸島",
-            "zoneName": "ヴァージン諸島"
-        },
-        "VI": {
-            "countryName": "アメリカ合衆国",
-            "zoneName": "ヴァージン諸島"
-        },
-        "VN": {
-            "zoneName": "ベトナム"
-        },
-        "VU": {
-            "zoneName": "バヌアツ"
-        },
-        "WF": {
-            "zoneName": "ウォリス・フツナ"
-        },
-        "WS": {
-            "zoneName": "サモア"
-        },
-        "XK": {
-            "zoneName": "コソボ"
-        },
-        "XX": {
-            "zoneName": "北キプロス"
-        },
-        "YE": {
-            "zoneName": "イエメン"
-        },
-        "YT": {
-            "zoneName": "マヨット"
-        },
-        "ZA": {
-            "zoneName": "南アフリカ"
-        },
-        "ZM": {
-            "zoneName": "ザンビア"
-        },
-        "ZW": {
-            "zoneName": "ジンバブエ"
-        }
+        "US-TEN-TVA": { "countryName": "アメリカ合衆国", "zoneName": "Tennessee Valley Authority" },
+        "US-TEX-ERCO": { "countryName": "アメリカ合衆国", "zoneName": "Electric Reliability Council Of Texas, Inc." },
+        "UY": { "zoneName": "ウルグアイ" },
+        "UZ": { "zoneName": "ウズベキスタン" },
+        "VA": { "zoneName": "バチカン市国" },
+        "VC": { "zoneName": "セントビンセント及びグレナディーン諸島" },
+        "VE": { "zoneName": "ベネズエラ" },
+        "VG": { "countryName": "ヴァージン諸島", "zoneName": "ヴァージン諸島" },
+        "VI": { "countryName": "アメリカ合衆国", "zoneName": "ヴァージン諸島" },
+        "VN": { "zoneName": "ベトナム" },
+        "VU": { "zoneName": "バヌアツ" },
+        "WF": { "zoneName": "ウォリス・フツナ" },
+        "WS": { "zoneName": "サモア" },
+        "XK": { "zoneName": "コソボ" },
+        "XX": { "zoneName": "北キプロス" },
+        "YE": { "zoneName": "イエメン" },
+        "YT": { "zoneName": "マヨット" },
+        "ZA": { "zoneName": "南アフリカ" },
+        "ZM": { "zoneName": "ザンビア" },
+        "ZW": { "zoneName": "ジンバブエ" }
     }
 }

--- a/web/public/locales/ko.json
+++ b/web/public/locales/ko.json
@@ -6,15 +6,9 @@
         "datasources": "데이터 정보",
         "contribute": "공헌으로<a href=\"%s\" target=\"_blank\">자기 지역을 추가해주세요</a>"
     },
-    "mobile-main-menu": {
-        "map": "전력 지도",
-        "areas": "지역",
-        "about": "에 관하여"
-    },
+    "mobile-main-menu": { "map": "전력 지도", "areas": "지역", "about": "에 관하여" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "기후가 전력생산에 미치는 영향"
-        },
+        "view1": { "subtitle": "기후가 전력생산에 미치는 영향" },
         "view2": {
             "header": "전력 생산으로 인해향 얼마나 많은 이산화탄소가 실시간으로 배출되는지 보십시오",
             "text": "우리는 전세계의 전력소비로 인한 탄소밀집도(온실가스를 포함)를 색깔로 표시했습니다. 녹색에 가까운 색일수록 친환경적인 전력생산을 의미합니다."
@@ -50,13 +44,13 @@
         "search": "지역 찾기"
     },
     "country-history": {
-        "carbonintensity24h": "24시간 내 탄소밀집도",
-        "emissionsorigin24h": "24시간 내 배출 원인지역",
-        "emissionsproduction24h": "24시간 내 생산된 배출량",
-        "electricityorigin24h": "24시간 내 전력 원천",
-        "electricityproduction24h": "24시간 동안 전력생산",
-        "electricityprices24h": "24시간 동안 전력 사용 요금",
-        "Getdata": "역사적 자료, marginal 그리고 예상된 API."
+        "Getdata": "역사적 자료, marginal 그리고 예상된 API.",
+        "carbonintensity": { "hourly": "24시간 내 탄소밀집도" },
+        "emissionsorigin": { "hourly": "24시간 내 배출 원인지역" },
+        "emissionsproduction": { "hourly": "24시간 내 생산된 배출량" },
+        "electricityorigin": { "hourly": "24시간 내 전력 원천" },
+        "electricityproduction": { "hourly": "24시간 동안 전력생산" },
+        "electricityprices": { "hourly": "24시간 동안 전력 사용 요금" }
     },
     "footer": {
         "foundbugs": "버그가 발견되었거나 의견이 있으신가요? 알려주세요",
@@ -190,1245 +184,375 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a>는 <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a>에 정보제공 목적으로 이미지를 포함한 데이터를 사용합니다. 정보의 정확성에 대해 책임지지 않으며 어떤 형태의 보증도 제공하지 않습니다. the electricityMap 은 언제든 별도의 고지 없이 콘텐츠를 변경하거나 삭제할 권리를 유보합니다. electricityMap는 the electricityMap의 정보나 그로부터 유추되는 내용의 부정확성, 불완전성, 시기부적절성, 진부화로 인해 발생하는 손해나 비용에 대해 어떤 법적 책임도 지지 않습니다. 다른 웹페이지에 사전 공식 서면 허가 없이 본 웹페이지 자체나 부분적인 요소들을 포함시키는 것은 허용하지 않습니다.<br><br> 모든 지적 재산권은 정당한 소유자와 그 라이센스 소유자에게 있습니다. 에너지 데이터를 비롯한 모든 정보의 복사, 배포, 또는 그 외 모든 자료 사용은 특정 자료에 대해 따로 공지하지 않는 이상 electricityMap의 서면 허가 없이는 허용하지 않는다. (인용할 권리와 같이) 법적 규정에서 지정하는 경우만 예외로 둡니다. <br><br>본 고지 내용은 추후에 변경될 수 있습니다."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "안도라"
-        },
-        "AE": {
-            "zoneName": "아랍 에미리트 연합국"
-        },
-        "AF": {
-            "zoneName": "아프가니스탄"
-        },
-        "AG": {
-            "zoneName": "앤티가 바부다"
-        },
-        "AI": {
-            "zoneName": "앙귈라"
-        },
-        "AL": {
-            "zoneName": "알바니아"
-        },
-        "AM": {
-            "zoneName": "아르메니아"
-        },
-        "AO": {
-            "zoneName": "앙골라"
-        },
-        "AQ": {
-            "zoneName": "남극 대륙"
-        },
-        "AS": {
-            "zoneName": "미국령 사모아"
-        },
-        "AT": {
-            "zoneName": "오스트리아"
-        },
-        "AR": {
-            "zoneName": "아르헨티나"
-        },
-        "AUS-NSW": {
-            "countryName": "호주",
-            "zoneName": "뉴사우스웨일스 주"
-        },
-        "AUS-NT": {
-            "countryName": "호주",
-            "zoneName": "노던 준주"
-        },
-        "AUS-QLD": {
-            "countryName": "호주",
-            "zoneName": "퀸즐랜드 주"
-        },
-        "AUS-SA": {
-            "countryName": "호주",
-            "zoneName": "사우스오스트레일리아 주"
-        },
-        "AUS-TAS": {
-            "countryName": "호주",
-            "zoneName": "태즈메이니아 주"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "태즈메이니아 주",
-            "zoneName": "킹섬"
-        },
-        "AUS-VIC": {
-            "countryName": "호주",
-            "zoneName": "빅토리아 주"
-        },
-        "AUS-WA": {
-            "countryName": "호주",
-            "zoneName": "웨스턴 오스트레일리아 주"
-        },
-        "AW": {
-            "zoneName": "아루바"
-        },
-        "AX": {
-            "zoneName": "올란드 제도"
-        },
-        "AZ": {
-            "zoneName": "아제르바이잔"
-        },
-        "BA": {
-            "zoneName": "보스니아 헤르체코비나"
-        },
-        "BB": {
-            "zoneName": "바베이도스"
-        },
-        "BD": {
-            "zoneName": "방글라데시"
-        },
-        "BE": {
-            "zoneName": "벨기에"
-        },
-        "BF": {
-            "zoneName": "부르키나 파소"
-        },
-        "BG": {
-            "zoneName": "불가리아"
-        },
-        "BH": {
-            "zoneName": "바레인"
-        },
-        "BI": {
-            "zoneName": "부룬디"
-        },
-        "BJ": {
-            "zoneName": "베냉"
-        },
-        "BM": {
-            "zoneName": "버뮤다"
-        },
-        "BN": {
-            "zoneName": "브루나이"
-        },
-        "BO": {
-            "zoneName": "볼리비아"
-        },
-        "BQ": {
-            "zoneName": "보네르섬, 신트외스타티위스섬, 사바섬 제도"
-        },
-        "BR-CS": {
-            "countryName": "브라질",
-            "zoneName": "중부 브라질"
-        },
-        "BR-N": {
-            "countryName": "브라질",
-            "zoneName": "북부 브라질"
-        },
-        "BR-NE": {
-            "countryName": "브라질",
-            "zoneName": "북동부 브라질"
-        },
-        "BR-S": {
-            "countryName": "브라질",
-            "zoneName": "남부 브라질"
-        },
-        "BS": {
-            "zoneName": "바하마"
-        },
-        "BT": {
-            "zoneName": "부탄"
-        },
-        "BV": {
-            "zoneName": "부베섬"
-        },
-        "BW": {
-            "zoneName": "보츠와나"
-        },
-        "BY": {
-            "zoneName": "벨로루시"
-        },
-        "BZ": {
-            "zoneName": "벨리즈"
-        },
-        "CA-AB": {
-            "countryName": "캐나다",
-            "zoneName": "앨버타 주"
-        },
-        "CA-BC": {
-            "countryName": "캐나다",
-            "zoneName": "브리티시컬럼비아 주"
-        },
-        "CA-MB": {
-            "countryName": "캐나다",
-            "zoneName": "매니토바 주"
-        },
-        "CA-NL": {
-            "countryName": "캐나다",
-            "zoneName": "뉴펀들랜드 래브라도 주"
-        },
-        "CA-NB": {
-            "countryName": "캐나다",
-            "zoneName": "뉴브런즈윅 주"
-        },
-        "CA-NT": {
-            "countryName": "캐나다",
-            "zoneName": "노스웨스트 준주"
-        },
-        "CA-NS": {
-            "countryName": "캐나다",
-            "zoneName": "노바스코샤 주"
-        },
-        "CA-NU": {
-            "countryName": "캐나다",
-            "zoneName": "누나부트 준주"
-        },
-        "CA-ON": {
-            "countryName": "캐나다",
-            "zoneName": "온타리오 주"
-        },
-        "CA-PE": {
-            "countryName": "캐나다",
-            "zoneName": "프린스에드워드아일랜드 주"
-        },
-        "CA-QC": {
-            "countryName": "캐나다",
-            "zoneName": "퀘벡 주"
-        },
-        "CA-SK": {
-            "countryName": "캐나다",
-            "zoneName": "서스캐처원 주"
-        },
-        "CA-YT": {
-            "countryName": "캐나다",
-            "zoneName": "유콘 준주"
-        },
-        "CC": {
-            "zoneName": "코코스 제도"
-        },
-        "CD": {
-            "zoneName": "콩고민주공화국"
-        },
-        "CF": {
-            "zoneName": "중앙아프리카 공화국"
-        },
-        "CG": {
-            "zoneName": "콩고"
-        },
-        "CH": {
-            "zoneName": "스위스"
-        },
-        "CI": {
-            "zoneName": "코트디부아르"
-        },
-        "CK": {
-            "zoneName": "쿡 제도"
-        },
-        "CL-SING-SIC": {
-            "countryName": "칠레",
-            "zoneName": "SING/SIC"
-        },
-        "CL-SEM": {
-            "countryName": "칠레",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "칠레",
-            "zoneName": "SEA"
-        },
-        "CM": {
-            "zoneName": "카메룬"
-        },
-        "CN": {
-            "zoneName": "중국"
-        },
-        "CO": {
-            "zoneName": "콜롬비아"
-        },
-        "CR": {
-            "zoneName": "코스타리카"
-        },
-        "CU": {
-            "zoneName": "쿠바"
-        },
-        "CV": {
-            "zoneName": "카보베르데"
-        },
-        "CW": {
-            "zoneName": "퀴라소"
-        },
-        "CX": {
-            "zoneName": "크리스마스섬"
-        },
-        "CY": {
-            "zoneName": "키프로스"
-        },
-        "CZ": {
-            "zoneName": "체코"
-        },
-        "DE": {
-            "zoneName": "독일"
-        },
-        "DJ": {
-            "zoneName": "지부티"
-        },
-        "DK": {
-            "zoneName": "덴마크"
-        },
-        "DK-DK1": {
-            "countryName": "덴마크",
-            "zoneName": "서부 덴마크"
-        },
-        "DK-DK2": {
-            "countryName": "덴마크",
-            "zoneName": "동부 덴마크"
-        },
-        "DK-BHM": {
-            "countryName": "덴마크",
-            "zoneName": "보른홀름섬"
-        },
-        "DM": {
-            "zoneName": "도미니카 연방"
-        },
-        "DO": {
-            "zoneName": "도미니카 공화국"
-        },
-        "DZ": {
-            "zoneName": "알제리"
-        },
-        "EC": {
-            "zoneName": "에콰도르"
-        },
-        "EE": {
-            "zoneName": "에스토니아"
-        },
-        "EG": {
-            "zoneName": "이집트"
-        },
-        "EH": {
-            "zoneName": "서 사하라"
-        },
-        "ER": {
-            "zoneName": "에리트레아"
-        },
-        "ES": {
-            "zoneName": "스페인"
-        },
-        "ES-IB-FO": {
-            "countryName": "스페인",
-            "zoneName": "포르멘테라섬"
-        },
-        "ES-IB-IZ": {
-            "countryName": "스페인",
-            "zoneName": "이비사섬"
-        },
-        "ES-IB-MA": {
-            "countryName": "스페인",
-            "zoneName": "마요르카섬"
-        },
-        "ES-IB-ME": {
-            "countryName": "스페인",
-            "zoneName": "메노르카섬"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "스페인",
-            "zoneName": "푸에르테벤투라섬/란사로테섬"
-        },
-        "ES-CN-GC": {
-            "countryName": "스페인",
-            "zoneName": "그란카나리아섬"
-        },
-        "ES-CN-HI": {
-            "countryName": "스페인",
-            "zoneName": "엘이에로섬"
-        },
-        "ES-CN-IG": {
-            "countryName": "스페인",
-            "zoneName": "라고메라섬"
-        },
-        "ES-CN-LP": {
-            "countryName": "스페인",
-            "zoneName": "라팔마섬"
-        },
-        "ES-CN-TE": {
-            "countryName": "스페인",
-            "zoneName": "테네리페섬"
-        },
-        "ET": {
-            "zoneName": "에티오피아"
-        },
-        "FI": {
-            "zoneName": "핀란드"
-        },
-        "FJ": {
-            "zoneName": "피지"
-        },
-        "FK": {
-            "zoneName": "포클랜드 제도"
-        },
-        "FM": {
-            "zoneName": "미크로네시아"
-        },
-        "FO": {
-            "zoneName": "패로 제도"
-        },
-        "FR": {
-            "zoneName": "프랑스"
-        },
-        "FR-COR": {
-            "countryName": "프랑스",
-            "zoneName": "코르시카"
-        },
-        "GA": {
-            "zoneName": "가봉"
-        },
-        "GB": {
-            "zoneName": "영국"
-        },
-        "GB-NIR": {
-            "zoneName": "북 아일랜드"
-        },
-        "GB-ORK": {
-            "countryName": "영국",
-            "zoneName": "오크니 제도"
-        },
-        "GB-SHI": {
-            "countryName": "영국",
-            "zoneName": "셰틀랜드 제도"
-        },
-        "GB-ZET": {
-            "countryName": "영국",
-            "zoneName": "셰틀랜드 제도"
-        },
-        "GD": {
-            "zoneName": "그레나다"
-        },
-        "GE": {
-            "zoneName": "그루지야"
-        },
-        "GF": {
-            "zoneName": "프랑스령 기아나"
-        },
-        "GG": {
-            "zoneName": "건지"
-        },
-        "GH": {
-            "zoneName": "가나"
-        },
-        "GI": {
-            "zoneName": "지브롤터"
-        },
-        "GL": {
-            "zoneName": "그린란드"
-        },
-        "GM": {
-            "zoneName": "감비아"
-        },
-        "GN": {
-            "zoneName": "기니"
-        },
-        "GP": {
-            "zoneName": "과들루프섬"
-        },
-        "GQ": {
-            "zoneName": "적도 기니"
-        },
-        "GR": {
-            "zoneName": "그리스"
-        },
-        "GR-IS": {
-            "countryName": "그리스",
-            "zoneName": "에게해 제도"
-        },
-        "GS": {
-            "zoneName": "사우스조지아 사우스샌드위치 제도"
-        },
-        "GT": {
-            "zoneName": "과테말라"
-        },
-        "GU": {
-            "zoneName": "괌"
-        },
-        "GW": {
-            "zoneName": "기니비사우"
-        },
-        "GY": {
-            "zoneName": "가이아나"
-        },
-        "HK": {
-            "zoneName": "홍콩"
-        },
-        "HM": {
-            "zoneName": "허드 맥도널드 제도"
-        },
-        "HN": {
-            "zoneName": "온두라스"
-        },
-        "HR": {
-            "zoneName": "크로아티아"
-        },
-        "HT": {
-            "zoneName": "아이티"
-        },
-        "HU": {
-            "zoneName": "헝가리"
-        },
-        "ID": {
-            "zoneName": "인도네시아"
-        },
-        "IE": {
-            "zoneName": "아일랜드"
-        },
-        "IL": {
-            "zoneName": "이스라엘"
-        },
-        "IM": {
-            "zoneName": "맨섬"
-        },
-        "IN-AN": {
-            "countryName": "인도",
-            "zoneName": "안다만 니코바르 제도"
-        },
-        "IN-AP": {
-            "countryName": "인도",
-            "zoneName": "안드라프라데시 주"
-        },
-        "IN-AR": {
-            "countryName": "인도",
-            "zoneName": "아루나찰프라데시 주"
-        },
-        "IN-AS": {
-            "countryName": "인도",
-            "zoneName": "아삼 주"
-        },
-        "IN-BR": {
-            "countryName": "인도",
-            "zoneName": "비하르 주"
-        },
-        "IN-CT": {
-            "countryName": "인도",
-            "zoneName": "차티스가르 주"
-        },
-        "IN-DL": {
-            "countryName": "인도",
-            "zoneName": "델리"
-        },
-        "IN-DN": {
-            "countryName": "인도",
-            "zoneName": "다드라 나가르하벨리"
-        },
-        "IN-GA": {
-            "countryName": "인도",
-            "zoneName": "고아"
-        },
-        "IN-GJ": {
-            "countryName": "인도",
-            "zoneName": "구자라트 주"
-        },
-        "IN-HP": {
-            "countryName": "인도",
-            "zoneName": "히마찰프라데시 주"
-        },
-        "IN-HR": {
-            "countryName": "인도",
-            "zoneName": "하리아나 주"
-        },
-        "IN-JH": {
-            "countryName": "인도",
-            "zoneName": "자르칸드 주"
-        },
-        "IN-JK": {
-            "countryName": "인도",
-            "zoneName": "잠무카슈미르 주"
-        },
-        "IN-KA": {
-            "countryName": "인도",
-            "zoneName": "카르나타카 주"
-        },
-        "IN-KL": {
-            "countryName": "인도",
-            "zoneName": "케랄라 주"
-        },
-        "IN-MH": {
-            "countryName": "인도",
-            "zoneName": "마하라슈트라 주"
-        },
-        "IN-ML": {
-            "countryName": "인도",
-            "zoneName": "메갈라야 주"
-        },
-        "IN-MN": {
-            "countryName": "인도",
-            "zoneName": "마니푸르 주"
-        },
-        "IN-MP": {
-            "countryName": "인도",
-            "zoneName": "마디아프라데시 주"
-        },
-        "IN-MZ": {
-            "countryName": "인도",
-            "zoneName": "미조람 주"
-        },
-        "IN-NL": {
-            "countryName": "인도",
-            "zoneName": "나갈랜드 주"
-        },
-        "IN-OR": {
-            "countryName": "인도",
-            "zoneName": "오디샤 주"
-        },
-        "IN-PB": {
-            "countryName": "인도",
-            "zoneName": "펀자브 주"
-        },
-        "IN-PY": {
-            "countryName": "인도",
-            "zoneName": "퐁디셰리"
-        },
-        "IN-RJ": {
-            "countryName": "인도",
-            "zoneName": "라자스탄 주"
-        },
-        "IN-SK": {
-            "countryName": "인도",
-            "zoneName": "시킴 주"
-        },
-        "IN-TN": {
-            "countryName": "인도",
-            "zoneName": "타밀나두 주"
-        },
-        "IN-TR": {
-            "countryName": "인도",
-            "zoneName": "트리푸라 주"
-        },
-        "IN-UP": {
-            "countryName": "인도",
-            "zoneName": "우타르프라데시 주"
-        },
-        "IN-UT": {
-            "countryName": "인도",
-            "zoneName": "우타라칸드 주"
-        },
-        "IN-WB": {
-            "countryName": "인도",
-            "zoneName": "서벵골 주"
-        },
-        "IO": {
-            "zoneName": "영국령 인도양 지역"
-        },
-        "IQ": {
-            "zoneName": "이라크"
-        },
-        "IQ-KUR": {
-            "countryName": "이라크",
-            "zoneName": "쿠르디스탄"
-        },
-        "IR": {
-            "zoneName": "이란"
-        },
-        "IS": {
-            "zoneName": "아이슬란드"
-        },
-        "IT": {
-            "zoneName": "이탈리아"
-        },
-        "IT-CNO": {
-            "countryName": "이탈리아",
-            "zoneName": "중앙 북부"
-        },
-        "IT-CSO": {
-            "countryName": "이탈리아",
-            "zoneName": "중앙 남부"
-        },
-        "IT-NO": {
-            "countryName": "이탈리아",
-            "zoneName": "북부"
-        },
-        "IT-SAR": {
-            "countryName": "이탈리아",
-            "zoneName": "사르데냐 주"
-        },
-        "IT-SIC": {
-            "countryName": "이탈리아",
-            "zoneName": "시칠리아 주"
-        },
-        "IT-SO": {
-            "countryName": "이탈리아",
-            "zoneName": "남부"
-        },
-        "JE": {
-            "zoneName": "저지섬"
-        },
-        "JM": {
-            "zoneName": "자메이카"
-        },
-        "JO": {
-            "zoneName": "요르단"
-        },
-        "JP-CB": {
-            "countryName": "일본",
-            "zoneName": "주부 지방"
-        },
-        "JP-CG": {
-            "countryName": "일본",
-            "zoneName": "주고쿠 지방"
-        },
-        "JP-HKD": {
-            "countryName": "일본",
-            "zoneName": "홋카이도"
-        },
-        "JP-HR": {
-            "countryName": "일본",
-            "zoneName": "호쿠리쿠 지방"
-        },
-        "JP-KN": {
-            "countryName": "일본",
-            "zoneName": "간사이 지방"
-        },
-        "JP-KY": {
-            "countryName": "일본",
-            "zoneName": "규슈"
-        },
-        "JP-ON": {
-            "countryName": "일본",
-            "zoneName": "오키나와 제도"
-        },
-        "JP-SK": {
-            "countryName": "일본",
-            "zoneName": "시코쿠"
-        },
-        "JP-TH": {
-            "countryName": "일본",
-            "zoneName": "도호쿠 지방"
-        },
-        "JP-TK": {
-            "countryName": "일본",
-            "zoneName": "도쿄"
-        },
-        "KE": {
-            "zoneName": "케냐"
-        },
-        "KG": {
-            "zoneName": "키르기스스탄"
-        },
-        "KH": {
-            "zoneName": "캄보디아"
-        },
-        "KI": {
-            "zoneName": "키리바시"
-        },
-        "KM": {
-            "zoneName": "코모로"
-        },
-        "KN": {
-            "zoneName": "세인트키츠 네비스"
-        },
-        "KP": {
-            "zoneName": "북한"
-        },
-        "KR": {
-            "zoneName": "대한민국"
-        },
-        "KW": {
-            "zoneName": "쿠웨이트"
-        },
-        "KY": {
-            "zoneName": "케이맨 제도"
-        },
-        "KZ": {
-            "zoneName": "카자흐스탄"
-        },
-        "LA": {
-            "zoneName": "라오스"
-        },
-        "LB": {
-            "zoneName": "레바논"
-        },
-        "LC": {
-            "zoneName": "세인트루시아"
-        },
-        "LI": {
-            "zoneName": "리히텐슈타인"
-        },
-        "LK": {
-            "zoneName": "스리랑카"
-        },
-        "LR": {
-            "zoneName": "라이베리아"
-        },
-        "LS": {
-            "zoneName": "레소토"
-        },
-        "LT": {
-            "zoneName": "리투아니아"
-        },
-        "LU": {
-            "zoneName": "룩셈부르크"
-        },
-        "LV": {
-            "zoneName": "라트비아"
-        },
-        "LY": {
-            "zoneName": "리비아"
-        },
-        "MA": {
-            "zoneName": "모로코"
-        },
-        "MC": {
-            "zoneName": "모나코"
-        },
-        "MD": {
-            "zoneName": "몰도바"
-        },
-        "ME": {
-            "zoneName": "몬테네그로"
-        },
-        "MF": {
-            "countryName": "세인트마틴섬",
-            "zoneName": "프랑스령"
-        },
-        "MG": {
-            "zoneName": "마다가스카르"
-        },
-        "MH": {
-            "zoneName": "마셜 제도"
-        },
-        "MK": {
-            "zoneName": "북마케도니아"
-        },
-        "ML": {
-            "zoneName": "말리"
-        },
-        "MM": {
-            "zoneName": "미얀마"
-        },
-        "MN": {
-            "zoneName": "몽골"
-        },
-        "MO": {
-            "zoneName": "마카오"
-        },
-        "MP": {
-            "zoneName": "북마리아나 제도"
-        },
-        "MQ": {
-            "zoneName": "마르티니크"
-        },
-        "MR": {
-            "zoneName": "모리타니아"
-        },
-        "MS": {
-            "zoneName": "몬트세랫"
-        },
-        "MT": {
-            "zoneName": "몰타"
-        },
-        "MU": {
-            "zoneName": "모리셔스"
-        },
-        "MV": {
-            "zoneName": "몰디브"
-        },
-        "MW": {
-            "zoneName": "말라위"
-        },
-        "MX": {
-            "zoneName": "멕시코"
-        },
-        "MX-BC": {
-            "countryName": "멕시코",
-            "zoneName": "바하칼리포르니아 주"
-        },
-        "MX-CE": {
-            "countryName": "멕시코",
-            "zoneName": "중앙부"
-        },
-        "MX-NE": {
-            "countryName": "멕시코",
-            "zoneName": "동북부"
-        },
-        "MX-NO": {
-            "countryName": "멕시코",
-            "zoneName": "북부"
-        },
-        "MX-NW": {
-            "countryName": "멕시코",
-            "zoneName": "서북부"
-        },
-        "MX-OC": {
-            "countryName": "멕시코",
-            "zoneName": "서부"
-        },
-        "MX-OR": {
-            "countryName": "멕시코",
-            "zoneName": "동부"
-        },
-        "MX-PN": {
-            "countryName": "멕시코",
-            "zoneName": "반도"
-        },
-        "MY-EM": {
-            "countryName": "말레이시아",
-            "zoneName": "보르네오"
-        },
-        "MY-WM": {
-            "countryName": "말레이시아",
-            "zoneName": "반도"
-        },
-        "MZ": {
-            "zoneName": "모잠비크"
-        },
-        "NA": {
-            "zoneName": "나미비아"
-        },
-        "NC": {
-            "zoneName": "뉴칼레도니아"
-        },
-        "NE": {
-            "zoneName": "니제르"
-        },
-        "NF": {
-            "zoneName": "노퍽섬"
-        },
-        "NG": {
-            "zoneName": "나이지리아"
-        },
-        "NI": {
-            "zoneName": "니카라과"
-        },
-        "NKR": {
-            "zoneName": "나고르노카라바흐"
-        },
-        "NL": {
-            "zoneName": "네덜란드"
-        },
-        "NO-NO1": {
-            "countryName": "노르웨이",
-            "zoneName": "동남부 노르웨이"
-        },
-        "NO-NO2": {
-            "countryName": "노르웨이",
-            "zoneName": "서남부 노르웨이"
-        },
-        "NO-NO3": {
-            "countryName": "노르웨이",
-            "zoneName": "중앙부 노르웨이"
-        },
-        "NO-NO4": {
-            "countryName": "노르웨이",
-            "zoneName": "북부 노르웨이"
-        },
-        "NO-NO5": {
-            "countryName": "노르웨이",
-            "zoneName": "서부 노르웨이"
-        },
-        "NP": {
-            "zoneName": "네팔"
-        },
-        "NR": {
-            "zoneName": "나우루"
-        },
-        "NU": {
-            "zoneName": "니우에"
-        },
-        "NZ": {
-            "zoneName": "뉴질랜드"
-        },
-        "NZ-NZA": {
-            "countryName": "뉴질랜드",
-            "zoneName": "오클랜드 제도"
-        },
-        "NZ-NZC": {
-            "countryName": "뉴질랜드",
-            "zoneName": "채텀 제도"
-        },
-        "OM": {
-            "zoneName": "오만"
-        },
-        "PA": {
-            "zoneName": "파나마"
-        },
-        "PE": {
-            "zoneName": "페루"
-        },
-        "PF": {
-            "zoneName": "프랑스령 폴리네시아"
-        },
-        "PG": {
-            "zoneName": "파푸아뉴기니"
-        },
-        "PH": {
-            "zoneName": "필리핀"
-        },
-        "PK": {
-            "zoneName": "파키스탄"
-        },
-        "PL": {
-            "zoneName": "폴란드"
-        },
-        "PM": {
-            "zoneName": "생피에르 미클롱"
-        },
-        "PN": {
-            "zoneName": "핏케언 제도"
-        },
-        "PR": {
-            "zoneName": "푸에르토리코"
-        },
-        "PS": {
-            "zoneName": "팔레스타인"
-        },
-        "PT": {
-            "zoneName": "포르투갈"
-        },
-        "PT-AC": {
-            "countryName": "포르투갈",
-            "zoneName": "아소르스 제도"
-        },
-        "PT-MA": {
-            "countryName": "포르투갈",
-            "zoneName": "마데이라 제도"
-        },
-        "PW": {
-            "zoneName": "팔라우"
-        },
-        "PY": {
-            "zoneName": "파라과이"
-        },
-        "QA": {
-            "zoneName": "카타르"
-        },
-        "RE": {
-            "zoneName": "레위니옹"
-        },
-        "RO": {
-            "zoneName": "루마니아"
-        },
-        "RS": {
-            "zoneName": "세르비아"
-        },
-        "RU": {
-            "zoneName": "러시아"
-        },
-        "RU-1": {
-            "countryName": "러시아",
-            "zoneName": "유럽 러시아 및 우랄"
-        },
-        "RU-2": {
-            "countryName": "러시아",
-            "zoneName": "시베리아"
-        },
-        "RU-EU": {
-            "zoneName": "러시아"
-        },
-        "RU-AS": {
-            "zoneName": "러시아"
-        },
-        "RU-KGD": {
-            "countryName": "러시아",
-            "zoneName": "칼리닌그라드"
-        },
-        "RW": {
-            "zoneName": "르완다"
-        },
-        "SA": {
-            "zoneName": "사우디 아라비아"
-        },
-        "SB": {
-            "zoneName": "솔로몬 제도"
-        },
-        "SC": {
-            "zoneName": "세이셸"
-        },
-        "SD": {
-            "zoneName": "수단"
-        },
-        "SE": {
-            "zoneName": "스웨덴"
-        },
-        "SG": {
-            "zoneName": "싱가포르"
-        },
-        "SH": {
-            "zoneName": "세인트헬레나 어센션 트리스탄다쿠냐"
-        },
-        "SI": {
-            "zoneName": "슬로베니아"
-        },
-        "SJ": {
-            "zoneName": "스발바르 얀마옌 제도"
-        },
-        "SK": {
-            "zoneName": "슬로바키아"
-        },
-        "SL": {
-            "zoneName": "시에라리온"
-        },
-        "SM": {
-            "zoneName": "산마리노"
-        },
-        "SN": {
-            "zoneName": "세네갈"
-        },
-        "SO": {
-            "zoneName": "소말리아"
-        },
-        "SR": {
-            "zoneName": "수리남"
-        },
-        "SS": {
-            "zoneName": "남수단"
-        },
-        "ST": {
-            "zoneName": "상투메 프린시페"
-        },
-        "SV": {
-            "zoneName": "엘살바도르"
-        },
-        "SX": {
-            "countryName": "신트마르턴",
-            "zoneName": "네덜란드령"
-        },
-        "SY": {
-            "zoneName": "시리아"
-        },
-        "SZ": {
-            "zoneName": "스와질란드"
-        },
-        "TC": {
-            "zoneName": "터크스케이커스 제도"
-        },
-        "TD": {
-            "zoneName": "차드"
-        },
-        "TF": {
-            "zoneName": "프랑스령 남부 및 남극"
-        },
-        "TG": {
-            "zoneName": "토고"
-        },
-        "TH": {
-            "zoneName": "태국"
-        },
-        "TJ": {
-            "zoneName": "타지키스탄"
-        },
-        "TK": {
-            "zoneName": "토켈라우"
-        },
-        "TL": {
-            "zoneName": "동티모르"
-        },
-        "TM": {
-            "zoneName": "투르크메니스탄"
-        },
-        "TN": {
-            "zoneName": "튀니지"
-        },
-        "TO": {
-            "zoneName": "통가"
-        },
-        "TR": {
-            "zoneName": "터키"
-        },
-        "TT": {
-            "zoneName": "트리니다드토바고"
-        },
-        "TV": {
-            "zoneName": "투발루"
-        },
-        "TW": {
-            "zoneName": "대만"
-        },
-        "TZ": {
-            "zoneName": "탄자니아"
-        },
-        "UA": {
-            "zoneName": "우크라이나"
-        },
-        "UA-CR": {
-            "countryName": "크림 반도",
-            "zoneName": "우크라이나"
-        },
-        "UG": {
-            "zoneName": "우간다"
-        },
-        "UM": {
-            "zoneName": "미국령 군소 제도"
-        },
-        "US-HI-HA": {
-            "countryName": "미국",
-            "zoneName": "하와이섬"
-        },
-        "US-HI-KA": {
-            "countryName": "미국",
-            "zoneName": "카우아이섬"
-        },
-        "US-HI-KH": {
-            "countryName": "미국",
-            "zoneName": "카호올라웨섬"
-        },
-        "US-HI-LA": {
-            "countryName": "미국",
-            "zoneName": "라나이섬"
-        },
-        "US-HI-MA": {
-            "countryName": "미국",
-            "zoneName": "마우이섬"
-        },
-        "US-HI-MO": {
-            "countryName": "미국",
-            "zoneName": "몰로카이섬"
-        },
-        "US-HI-NI": {
-            "countryName": "미국",
-            "zoneName": "니하우섬"
-        },
-        "US-HI-OA": {
-            "countryName": "미국",
-            "zoneName": "오아후섬"
-        },
-        "UY": {
-            "zoneName": "우루과이"
-        },
-        "UZ": {
-            "zoneName": "우즈베키스탄"
-        },
-        "VA": {
-            "zoneName": "바티칸 시국"
-        },
-        "VC": {
-            "zoneName": "세인트빈센트 그레나딘"
-        },
-        "VE": {
-            "zoneName": "베네수엘라"
-        },
-        "VG": {
-            "countryName": "버진 제도",
-            "zoneName": "버진 제도"
-        },
-        "VI": {
-            "countryName": "미국",
-            "zoneName": "버진 제도"
-        },
-        "VN": {
-            "zoneName": "베트남"
-        },
-        "VU": {
-            "zoneName": "바누아투"
-        },
-        "WF": {
-            "zoneName": "월리스푸투나 제도"
-        },
-        "WS": {
-            "zoneName": "사모아"
-        },
-        "XX": {
-            "zoneName": "북부 키프로스"
-        },
-        "YE": {
-            "zoneName": "예멘"
-        },
-        "YT": {
-            "zoneName": "마요트"
-        },
-        "ZA": {
-            "zoneName": "남아프리카공화국"
-        },
-        "ZM": {
-            "zoneName": "잠비아"
-        },
-        "ZW": {
-            "zoneName": "짐바브웨"
-        }
+        "AD": { "zoneName": "안도라" },
+        "AE": { "zoneName": "아랍 에미리트 연합국" },
+        "AF": { "zoneName": "아프가니스탄" },
+        "AG": { "zoneName": "앤티가 바부다" },
+        "AI": { "zoneName": "앙귈라" },
+        "AL": { "zoneName": "알바니아" },
+        "AM": { "zoneName": "아르메니아" },
+        "AO": { "zoneName": "앙골라" },
+        "AQ": { "zoneName": "남극 대륙" },
+        "AS": { "zoneName": "미국령 사모아" },
+        "AT": { "zoneName": "오스트리아" },
+        "AR": { "zoneName": "아르헨티나" },
+        "AUS-NSW": { "countryName": "호주", "zoneName": "뉴사우스웨일스 주" },
+        "AUS-NT": { "countryName": "호주", "zoneName": "노던 준주" },
+        "AUS-QLD": { "countryName": "호주", "zoneName": "퀸즐랜드 주" },
+        "AUS-SA": { "countryName": "호주", "zoneName": "사우스오스트레일리아 주" },
+        "AUS-TAS": { "countryName": "호주", "zoneName": "태즈메이니아 주" },
+        "AUS-TAS-KI": { "countryName": "태즈메이니아 주", "zoneName": "킹섬" },
+        "AUS-VIC": { "countryName": "호주", "zoneName": "빅토리아 주" },
+        "AUS-WA": { "countryName": "호주", "zoneName": "웨스턴 오스트레일리아 주" },
+        "AW": { "zoneName": "아루바" },
+        "AX": { "zoneName": "올란드 제도" },
+        "AZ": { "zoneName": "아제르바이잔" },
+        "BA": { "zoneName": "보스니아 헤르체코비나" },
+        "BB": { "zoneName": "바베이도스" },
+        "BD": { "zoneName": "방글라데시" },
+        "BE": { "zoneName": "벨기에" },
+        "BF": { "zoneName": "부르키나 파소" },
+        "BG": { "zoneName": "불가리아" },
+        "BH": { "zoneName": "바레인" },
+        "BI": { "zoneName": "부룬디" },
+        "BJ": { "zoneName": "베냉" },
+        "BM": { "zoneName": "버뮤다" },
+        "BN": { "zoneName": "브루나이" },
+        "BO": { "zoneName": "볼리비아" },
+        "BQ": { "zoneName": "보네르섬, 신트외스타티위스섬, 사바섬 제도" },
+        "BR-CS": { "countryName": "브라질", "zoneName": "중부 브라질" },
+        "BR-N": { "countryName": "브라질", "zoneName": "북부 브라질" },
+        "BR-NE": { "countryName": "브라질", "zoneName": "북동부 브라질" },
+        "BR-S": { "countryName": "브라질", "zoneName": "남부 브라질" },
+        "BS": { "zoneName": "바하마" },
+        "BT": { "zoneName": "부탄" },
+        "BV": { "zoneName": "부베섬" },
+        "BW": { "zoneName": "보츠와나" },
+        "BY": { "zoneName": "벨로루시" },
+        "BZ": { "zoneName": "벨리즈" },
+        "CA-AB": { "countryName": "캐나다", "zoneName": "앨버타 주" },
+        "CA-BC": { "countryName": "캐나다", "zoneName": "브리티시컬럼비아 주" },
+        "CA-MB": { "countryName": "캐나다", "zoneName": "매니토바 주" },
+        "CA-NL": { "countryName": "캐나다", "zoneName": "뉴펀들랜드 래브라도 주" },
+        "CA-NB": { "countryName": "캐나다", "zoneName": "뉴브런즈윅 주" },
+        "CA-NT": { "countryName": "캐나다", "zoneName": "노스웨스트 준주" },
+        "CA-NS": { "countryName": "캐나다", "zoneName": "노바스코샤 주" },
+        "CA-NU": { "countryName": "캐나다", "zoneName": "누나부트 준주" },
+        "CA-ON": { "countryName": "캐나다", "zoneName": "온타리오 주" },
+        "CA-PE": { "countryName": "캐나다", "zoneName": "프린스에드워드아일랜드 주" },
+        "CA-QC": { "countryName": "캐나다", "zoneName": "퀘벡 주" },
+        "CA-SK": { "countryName": "캐나다", "zoneName": "서스캐처원 주" },
+        "CA-YT": { "countryName": "캐나다", "zoneName": "유콘 준주" },
+        "CC": { "zoneName": "코코스 제도" },
+        "CD": { "zoneName": "콩고민주공화국" },
+        "CF": { "zoneName": "중앙아프리카 공화국" },
+        "CG": { "zoneName": "콩고" },
+        "CH": { "zoneName": "스위스" },
+        "CI": { "zoneName": "코트디부아르" },
+        "CK": { "zoneName": "쿡 제도" },
+        "CL-SING-SIC": { "countryName": "칠레", "zoneName": "SING/SIC" },
+        "CL-SEM": { "countryName": "칠레", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "칠레", "zoneName": "SEA" },
+        "CM": { "zoneName": "카메룬" },
+        "CN": { "zoneName": "중국" },
+        "CO": { "zoneName": "콜롬비아" },
+        "CR": { "zoneName": "코스타리카" },
+        "CU": { "zoneName": "쿠바" },
+        "CV": { "zoneName": "카보베르데" },
+        "CW": { "zoneName": "퀴라소" },
+        "CX": { "zoneName": "크리스마스섬" },
+        "CY": { "zoneName": "키프로스" },
+        "CZ": { "zoneName": "체코" },
+        "DE": { "zoneName": "독일" },
+        "DJ": { "zoneName": "지부티" },
+        "DK": { "zoneName": "덴마크" },
+        "DK-DK1": { "countryName": "덴마크", "zoneName": "서부 덴마크" },
+        "DK-DK2": { "countryName": "덴마크", "zoneName": "동부 덴마크" },
+        "DK-BHM": { "countryName": "덴마크", "zoneName": "보른홀름섬" },
+        "DM": { "zoneName": "도미니카 연방" },
+        "DO": { "zoneName": "도미니카 공화국" },
+        "DZ": { "zoneName": "알제리" },
+        "EC": { "zoneName": "에콰도르" },
+        "EE": { "zoneName": "에스토니아" },
+        "EG": { "zoneName": "이집트" },
+        "EH": { "zoneName": "서 사하라" },
+        "ER": { "zoneName": "에리트레아" },
+        "ES": { "zoneName": "스페인" },
+        "ES-IB-FO": { "countryName": "스페인", "zoneName": "포르멘테라섬" },
+        "ES-IB-IZ": { "countryName": "스페인", "zoneName": "이비사섬" },
+        "ES-IB-MA": { "countryName": "스페인", "zoneName": "마요르카섬" },
+        "ES-IB-ME": { "countryName": "스페인", "zoneName": "메노르카섬" },
+        "ES-CN-FVLZ": { "countryName": "스페인", "zoneName": "푸에르테벤투라섬/란사로테섬" },
+        "ES-CN-GC": { "countryName": "스페인", "zoneName": "그란카나리아섬" },
+        "ES-CN-HI": { "countryName": "스페인", "zoneName": "엘이에로섬" },
+        "ES-CN-IG": { "countryName": "스페인", "zoneName": "라고메라섬" },
+        "ES-CN-LP": { "countryName": "스페인", "zoneName": "라팔마섬" },
+        "ES-CN-TE": { "countryName": "스페인", "zoneName": "테네리페섬" },
+        "ET": { "zoneName": "에티오피아" },
+        "FI": { "zoneName": "핀란드" },
+        "FJ": { "zoneName": "피지" },
+        "FK": { "zoneName": "포클랜드 제도" },
+        "FM": { "zoneName": "미크로네시아" },
+        "FO": { "zoneName": "패로 제도" },
+        "FR": { "zoneName": "프랑스" },
+        "FR-COR": { "countryName": "프랑스", "zoneName": "코르시카" },
+        "GA": { "zoneName": "가봉" },
+        "GB": { "zoneName": "영국" },
+        "GB-NIR": { "zoneName": "북 아일랜드" },
+        "GB-ORK": { "countryName": "영국", "zoneName": "오크니 제도" },
+        "GB-SHI": { "countryName": "영국", "zoneName": "셰틀랜드 제도" },
+        "GB-ZET": { "countryName": "영국", "zoneName": "셰틀랜드 제도" },
+        "GD": { "zoneName": "그레나다" },
+        "GE": { "zoneName": "그루지야" },
+        "GF": { "zoneName": "프랑스령 기아나" },
+        "GG": { "zoneName": "건지" },
+        "GH": { "zoneName": "가나" },
+        "GI": { "zoneName": "지브롤터" },
+        "GL": { "zoneName": "그린란드" },
+        "GM": { "zoneName": "감비아" },
+        "GN": { "zoneName": "기니" },
+        "GP": { "zoneName": "과들루프섬" },
+        "GQ": { "zoneName": "적도 기니" },
+        "GR": { "zoneName": "그리스" },
+        "GR-IS": { "countryName": "그리스", "zoneName": "에게해 제도" },
+        "GS": { "zoneName": "사우스조지아 사우스샌드위치 제도" },
+        "GT": { "zoneName": "과테말라" },
+        "GU": { "zoneName": "괌" },
+        "GW": { "zoneName": "기니비사우" },
+        "GY": { "zoneName": "가이아나" },
+        "HK": { "zoneName": "홍콩" },
+        "HM": { "zoneName": "허드 맥도널드 제도" },
+        "HN": { "zoneName": "온두라스" },
+        "HR": { "zoneName": "크로아티아" },
+        "HT": { "zoneName": "아이티" },
+        "HU": { "zoneName": "헝가리" },
+        "ID": { "zoneName": "인도네시아" },
+        "IE": { "zoneName": "아일랜드" },
+        "IL": { "zoneName": "이스라엘" },
+        "IM": { "zoneName": "맨섬" },
+        "IN-AN": { "countryName": "인도", "zoneName": "안다만 니코바르 제도" },
+        "IN-AP": { "countryName": "인도", "zoneName": "안드라프라데시 주" },
+        "IN-AR": { "countryName": "인도", "zoneName": "아루나찰프라데시 주" },
+        "IN-AS": { "countryName": "인도", "zoneName": "아삼 주" },
+        "IN-BR": { "countryName": "인도", "zoneName": "비하르 주" },
+        "IN-CT": { "countryName": "인도", "zoneName": "차티스가르 주" },
+        "IN-DL": { "countryName": "인도", "zoneName": "델리" },
+        "IN-DN": { "countryName": "인도", "zoneName": "다드라 나가르하벨리" },
+        "IN-GA": { "countryName": "인도", "zoneName": "고아" },
+        "IN-GJ": { "countryName": "인도", "zoneName": "구자라트 주" },
+        "IN-HP": { "countryName": "인도", "zoneName": "히마찰프라데시 주" },
+        "IN-HR": { "countryName": "인도", "zoneName": "하리아나 주" },
+        "IN-JH": { "countryName": "인도", "zoneName": "자르칸드 주" },
+        "IN-JK": { "countryName": "인도", "zoneName": "잠무카슈미르 주" },
+        "IN-KA": { "countryName": "인도", "zoneName": "카르나타카 주" },
+        "IN-KL": { "countryName": "인도", "zoneName": "케랄라 주" },
+        "IN-MH": { "countryName": "인도", "zoneName": "마하라슈트라 주" },
+        "IN-ML": { "countryName": "인도", "zoneName": "메갈라야 주" },
+        "IN-MN": { "countryName": "인도", "zoneName": "마니푸르 주" },
+        "IN-MP": { "countryName": "인도", "zoneName": "마디아프라데시 주" },
+        "IN-MZ": { "countryName": "인도", "zoneName": "미조람 주" },
+        "IN-NL": { "countryName": "인도", "zoneName": "나갈랜드 주" },
+        "IN-OR": { "countryName": "인도", "zoneName": "오디샤 주" },
+        "IN-PB": { "countryName": "인도", "zoneName": "펀자브 주" },
+        "IN-PY": { "countryName": "인도", "zoneName": "퐁디셰리" },
+        "IN-RJ": { "countryName": "인도", "zoneName": "라자스탄 주" },
+        "IN-SK": { "countryName": "인도", "zoneName": "시킴 주" },
+        "IN-TN": { "countryName": "인도", "zoneName": "타밀나두 주" },
+        "IN-TR": { "countryName": "인도", "zoneName": "트리푸라 주" },
+        "IN-UP": { "countryName": "인도", "zoneName": "우타르프라데시 주" },
+        "IN-UT": { "countryName": "인도", "zoneName": "우타라칸드 주" },
+        "IN-WB": { "countryName": "인도", "zoneName": "서벵골 주" },
+        "IO": { "zoneName": "영국령 인도양 지역" },
+        "IQ": { "zoneName": "이라크" },
+        "IQ-KUR": { "countryName": "이라크", "zoneName": "쿠르디스탄" },
+        "IR": { "zoneName": "이란" },
+        "IS": { "zoneName": "아이슬란드" },
+        "IT": { "zoneName": "이탈리아" },
+        "IT-CNO": { "countryName": "이탈리아", "zoneName": "중앙 북부" },
+        "IT-CSO": { "countryName": "이탈리아", "zoneName": "중앙 남부" },
+        "IT-NO": { "countryName": "이탈리아", "zoneName": "북부" },
+        "IT-SAR": { "countryName": "이탈리아", "zoneName": "사르데냐 주" },
+        "IT-SIC": { "countryName": "이탈리아", "zoneName": "시칠리아 주" },
+        "IT-SO": { "countryName": "이탈리아", "zoneName": "남부" },
+        "JE": { "zoneName": "저지섬" },
+        "JM": { "zoneName": "자메이카" },
+        "JO": { "zoneName": "요르단" },
+        "JP-CB": { "countryName": "일본", "zoneName": "주부 지방" },
+        "JP-CG": { "countryName": "일본", "zoneName": "주고쿠 지방" },
+        "JP-HKD": { "countryName": "일본", "zoneName": "홋카이도" },
+        "JP-HR": { "countryName": "일본", "zoneName": "호쿠리쿠 지방" },
+        "JP-KN": { "countryName": "일본", "zoneName": "간사이 지방" },
+        "JP-KY": { "countryName": "일본", "zoneName": "규슈" },
+        "JP-ON": { "countryName": "일본", "zoneName": "오키나와 제도" },
+        "JP-SK": { "countryName": "일본", "zoneName": "시코쿠" },
+        "JP-TH": { "countryName": "일본", "zoneName": "도호쿠 지방" },
+        "JP-TK": { "countryName": "일본", "zoneName": "도쿄" },
+        "KE": { "zoneName": "케냐" },
+        "KG": { "zoneName": "키르기스스탄" },
+        "KH": { "zoneName": "캄보디아" },
+        "KI": { "zoneName": "키리바시" },
+        "KM": { "zoneName": "코모로" },
+        "KN": { "zoneName": "세인트키츠 네비스" },
+        "KP": { "zoneName": "북한" },
+        "KR": { "zoneName": "대한민국" },
+        "KW": { "zoneName": "쿠웨이트" },
+        "KY": { "zoneName": "케이맨 제도" },
+        "KZ": { "zoneName": "카자흐스탄" },
+        "LA": { "zoneName": "라오스" },
+        "LB": { "zoneName": "레바논" },
+        "LC": { "zoneName": "세인트루시아" },
+        "LI": { "zoneName": "리히텐슈타인" },
+        "LK": { "zoneName": "스리랑카" },
+        "LR": { "zoneName": "라이베리아" },
+        "LS": { "zoneName": "레소토" },
+        "LT": { "zoneName": "리투아니아" },
+        "LU": { "zoneName": "룩셈부르크" },
+        "LV": { "zoneName": "라트비아" },
+        "LY": { "zoneName": "리비아" },
+        "MA": { "zoneName": "모로코" },
+        "MC": { "zoneName": "모나코" },
+        "MD": { "zoneName": "몰도바" },
+        "ME": { "zoneName": "몬테네그로" },
+        "MF": { "countryName": "세인트마틴섬", "zoneName": "프랑스령" },
+        "MG": { "zoneName": "마다가스카르" },
+        "MH": { "zoneName": "마셜 제도" },
+        "MK": { "zoneName": "북마케도니아" },
+        "ML": { "zoneName": "말리" },
+        "MM": { "zoneName": "미얀마" },
+        "MN": { "zoneName": "몽골" },
+        "MO": { "zoneName": "마카오" },
+        "MP": { "zoneName": "북마리아나 제도" },
+        "MQ": { "zoneName": "마르티니크" },
+        "MR": { "zoneName": "모리타니아" },
+        "MS": { "zoneName": "몬트세랫" },
+        "MT": { "zoneName": "몰타" },
+        "MU": { "zoneName": "모리셔스" },
+        "MV": { "zoneName": "몰디브" },
+        "MW": { "zoneName": "말라위" },
+        "MX": { "zoneName": "멕시코" },
+        "MX-BC": { "countryName": "멕시코", "zoneName": "바하칼리포르니아 주" },
+        "MX-CE": { "countryName": "멕시코", "zoneName": "중앙부" },
+        "MX-NE": { "countryName": "멕시코", "zoneName": "동북부" },
+        "MX-NO": { "countryName": "멕시코", "zoneName": "북부" },
+        "MX-NW": { "countryName": "멕시코", "zoneName": "서북부" },
+        "MX-OC": { "countryName": "멕시코", "zoneName": "서부" },
+        "MX-OR": { "countryName": "멕시코", "zoneName": "동부" },
+        "MX-PN": { "countryName": "멕시코", "zoneName": "반도" },
+        "MY-EM": { "countryName": "말레이시아", "zoneName": "보르네오" },
+        "MY-WM": { "countryName": "말레이시아", "zoneName": "반도" },
+        "MZ": { "zoneName": "모잠비크" },
+        "NA": { "zoneName": "나미비아" },
+        "NC": { "zoneName": "뉴칼레도니아" },
+        "NE": { "zoneName": "니제르" },
+        "NF": { "zoneName": "노퍽섬" },
+        "NG": { "zoneName": "나이지리아" },
+        "NI": { "zoneName": "니카라과" },
+        "NKR": { "zoneName": "나고르노카라바흐" },
+        "NL": { "zoneName": "네덜란드" },
+        "NO-NO1": { "countryName": "노르웨이", "zoneName": "동남부 노르웨이" },
+        "NO-NO2": { "countryName": "노르웨이", "zoneName": "서남부 노르웨이" },
+        "NO-NO3": { "countryName": "노르웨이", "zoneName": "중앙부 노르웨이" },
+        "NO-NO4": { "countryName": "노르웨이", "zoneName": "북부 노르웨이" },
+        "NO-NO5": { "countryName": "노르웨이", "zoneName": "서부 노르웨이" },
+        "NP": { "zoneName": "네팔" },
+        "NR": { "zoneName": "나우루" },
+        "NU": { "zoneName": "니우에" },
+        "NZ": { "zoneName": "뉴질랜드" },
+        "NZ-NZA": { "countryName": "뉴질랜드", "zoneName": "오클랜드 제도" },
+        "NZ-NZC": { "countryName": "뉴질랜드", "zoneName": "채텀 제도" },
+        "OM": { "zoneName": "오만" },
+        "PA": { "zoneName": "파나마" },
+        "PE": { "zoneName": "페루" },
+        "PF": { "zoneName": "프랑스령 폴리네시아" },
+        "PG": { "zoneName": "파푸아뉴기니" },
+        "PH": { "zoneName": "필리핀" },
+        "PK": { "zoneName": "파키스탄" },
+        "PL": { "zoneName": "폴란드" },
+        "PM": { "zoneName": "생피에르 미클롱" },
+        "PN": { "zoneName": "핏케언 제도" },
+        "PR": { "zoneName": "푸에르토리코" },
+        "PS": { "zoneName": "팔레스타인" },
+        "PT": { "zoneName": "포르투갈" },
+        "PT-AC": { "countryName": "포르투갈", "zoneName": "아소르스 제도" },
+        "PT-MA": { "countryName": "포르투갈", "zoneName": "마데이라 제도" },
+        "PW": { "zoneName": "팔라우" },
+        "PY": { "zoneName": "파라과이" },
+        "QA": { "zoneName": "카타르" },
+        "RE": { "zoneName": "레위니옹" },
+        "RO": { "zoneName": "루마니아" },
+        "RS": { "zoneName": "세르비아" },
+        "RU": { "zoneName": "러시아" },
+        "RU-1": { "countryName": "러시아", "zoneName": "유럽 러시아 및 우랄" },
+        "RU-2": { "countryName": "러시아", "zoneName": "시베리아" },
+        "RU-EU": { "zoneName": "러시아" },
+        "RU-AS": { "zoneName": "러시아" },
+        "RU-KGD": { "countryName": "러시아", "zoneName": "칼리닌그라드" },
+        "RW": { "zoneName": "르완다" },
+        "SA": { "zoneName": "사우디 아라비아" },
+        "SB": { "zoneName": "솔로몬 제도" },
+        "SC": { "zoneName": "세이셸" },
+        "SD": { "zoneName": "수단" },
+        "SE": { "zoneName": "스웨덴" },
+        "SG": { "zoneName": "싱가포르" },
+        "SH": { "zoneName": "세인트헬레나 어센션 트리스탄다쿠냐" },
+        "SI": { "zoneName": "슬로베니아" },
+        "SJ": { "zoneName": "스발바르 얀마옌 제도" },
+        "SK": { "zoneName": "슬로바키아" },
+        "SL": { "zoneName": "시에라리온" },
+        "SM": { "zoneName": "산마리노" },
+        "SN": { "zoneName": "세네갈" },
+        "SO": { "zoneName": "소말리아" },
+        "SR": { "zoneName": "수리남" },
+        "SS": { "zoneName": "남수단" },
+        "ST": { "zoneName": "상투메 프린시페" },
+        "SV": { "zoneName": "엘살바도르" },
+        "SX": { "countryName": "신트마르턴", "zoneName": "네덜란드령" },
+        "SY": { "zoneName": "시리아" },
+        "SZ": { "zoneName": "스와질란드" },
+        "TC": { "zoneName": "터크스케이커스 제도" },
+        "TD": { "zoneName": "차드" },
+        "TF": { "zoneName": "프랑스령 남부 및 남극" },
+        "TG": { "zoneName": "토고" },
+        "TH": { "zoneName": "태국" },
+        "TJ": { "zoneName": "타지키스탄" },
+        "TK": { "zoneName": "토켈라우" },
+        "TL": { "zoneName": "동티모르" },
+        "TM": { "zoneName": "투르크메니스탄" },
+        "TN": { "zoneName": "튀니지" },
+        "TO": { "zoneName": "통가" },
+        "TR": { "zoneName": "터키" },
+        "TT": { "zoneName": "트리니다드토바고" },
+        "TV": { "zoneName": "투발루" },
+        "TW": { "zoneName": "대만" },
+        "TZ": { "zoneName": "탄자니아" },
+        "UA": { "zoneName": "우크라이나" },
+        "UA-CR": { "countryName": "크림 반도", "zoneName": "우크라이나" },
+        "UG": { "zoneName": "우간다" },
+        "UM": { "zoneName": "미국령 군소 제도" },
+        "US-HI-HA": { "countryName": "미국", "zoneName": "하와이섬" },
+        "US-HI-KA": { "countryName": "미국", "zoneName": "카우아이섬" },
+        "US-HI-KH": { "countryName": "미국", "zoneName": "카호올라웨섬" },
+        "US-HI-LA": { "countryName": "미국", "zoneName": "라나이섬" },
+        "US-HI-MA": { "countryName": "미국", "zoneName": "마우이섬" },
+        "US-HI-MO": { "countryName": "미국", "zoneName": "몰로카이섬" },
+        "US-HI-NI": { "countryName": "미국", "zoneName": "니하우섬" },
+        "US-HI-OA": { "countryName": "미국", "zoneName": "오아후섬" },
+        "UY": { "zoneName": "우루과이" },
+        "UZ": { "zoneName": "우즈베키스탄" },
+        "VA": { "zoneName": "바티칸 시국" },
+        "VC": { "zoneName": "세인트빈센트 그레나딘" },
+        "VE": { "zoneName": "베네수엘라" },
+        "VG": { "countryName": "버진 제도", "zoneName": "버진 제도" },
+        "VI": { "countryName": "미국", "zoneName": "버진 제도" },
+        "VN": { "zoneName": "베트남" },
+        "VU": { "zoneName": "바누아투" },
+        "WF": { "zoneName": "월리스푸투나 제도" },
+        "WS": { "zoneName": "사모아" },
+        "XX": { "zoneName": "북부 키프로스" },
+        "YE": { "zoneName": "예멘" },
+        "YT": { "zoneName": "마요트" },
+        "ZA": { "zoneName": "남아프리카공화국" },
+        "ZM": { "zoneName": "잠비아" },
+        "ZW": { "zoneName": "짐바브웨" }
     }
 }

--- a/web/public/locales/nl.json
+++ b/web/public/locales/nl.json
@@ -6,11 +6,7 @@
         "datasources": "databronnen",
         "contribute": "Participeer mee door <a href=\"%s\" target=\"_blank\">jouw land toe te voegen</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Gebieden",
-        "about": "Over"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Gebieden", "about": "Over" },
     "country-panel": {
         "source": "bron",
         "lowcarbon": "Lage-uitstoot",
@@ -32,18 +28,15 @@
         "search": "Zoek gebieden"
     },
     "country-history": {
-        "carbonintensity24h": "Koolstofintensiteit laatste 24 uur",
-        "emissionsorigin24h": "Bron van uitstoot laatste 24 uur",
-        "emissionsproduction24h": "Uitstoot laatste 24 uur",
-        "electricityorigin24h": "Bron van elektriciteit laatste 24 uur",
-        "electricityproduction24h": "Elektriciteitsproductie laatste 24 uur",
-        "electricityprices24h": "Elektriciteitsprijs laatste 24 uur",
-        "Getdata": "Get historical data, marginal and forecast API"
+        "Getdata": "Get historical data, marginal and forecast API",
+        "carbonintensity": { "hourly": "Koolstofintensiteit laatste 24 uur" },
+        "emissionsorigin": { "hourly": "Bron van uitstoot laatste 24 uur" },
+        "emissionsproduction": { "hourly": "Uitstoot laatste 24 uur" },
+        "electricityorigin": { "hourly": "Bron van elektriciteit laatste 24 uur" },
+        "electricityproduction": { "hourly": "Elektriciteitsproductie laatste 24 uur" },
+        "electricityprices": { "hourly": "Elektriciteitsprijs laatste 24 uur" }
     },
-    "footer": {
-        "foundbugs": "Ondervind je problemen of heb je ideëen? Meld ze",
-        "here": "hier"
-    },
+    "footer": { "foundbugs": "Ondervind je problemen of heb je ideëen? Meld ze", "here": "hier" },
     "legends": {
         "windpotential": "potentieel aan Windenergie",
         "solarpotential": "potentieel aan Zonne-energie",
@@ -102,158 +95,56 @@
     "emissionsImportedFrom": "<b>%1$s %%</b> van de uitstoot in <img id=\"country-flag\"></img> <b>%2$s</b> wordt ingevoerd vanuit <img id=\"country-exchange-flag\"></img> <b>%3$s</b>",
     "ofCO2eqPerMinute": "CO₂eq per minuut",
     "zoneShortName": {
-        "AL": {
-            "zoneName": "Albanië"
-        },
-        "AT": {
-            "zoneName": "Oostenrijk"
-        },
-        "AX": {
-            "zoneName": "Åland"
-        },
-        "BA": {
-            "zoneName": "Bosnië-Herzegovina"
-        },
-        "BE": {
-            "zoneName": "België"
-        },
-        "BG": {
-            "zoneName": "Bulgarije"
-        },
-        "BY": {
-            "zoneName": "Wit-Rusland"
-        },
-        "CH": {
-            "zoneName": "Zwitserland"
-        },
-        "CZ": {
-            "zoneName": "Tsjechië"
-        },
-        "DE": {
-            "zoneName": "Duitsland"
-        },
-        "DK": {
-            "zoneName": "Denemarken"
-        },
-        "EE": {
-            "zoneName": "Estland"
-        },
-        "ES": {
-            "zoneName": "Spanje"
-        },
-        "FI": {
-            "zoneName": "Finland"
-        },
-        "FR": {
-            "zoneName": "Frankrijk"
-        },
-        "GB": {
-            "zoneName": "Groot-Brittannië"
-        },
-        "GB-NIR": {
-            "zoneName": "Noord-Ierland"
-        },
-        "GR": {
-            "zoneName": "Griekenland"
-        },
-        "HR": {
-            "zoneName": "Kroatië"
-        },
-        "HU": {
-            "zoneName": "Hongarije"
-        },
-        "IE": {
-            "zoneName": "Ierland"
-        },
-        "IS": {
-            "zoneName": "IJsland"
-        },
-        "IT": {
-            "zoneName": "Italië"
-        },
-        "LT": {
-            "zoneName": "Litouwen"
-        },
-        "LU": {
-            "zoneName": "Luxemburg"
-        },
-        "LV": {
-            "zoneName": "Letland"
-        },
-        "MD": {
-            "zoneName": "Moldavië"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MK": {
-            "zoneName": "Noord-Macedonië"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabach"
-        },
-        "NL": {
-            "zoneName": "Nederland"
-        },
-        "NO": {
-            "zoneName": "Noorwegen"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PL": {
-            "zoneName": "Polen"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "RO": {
-            "zoneName": "Roemenië"
-        },
-        "RS": {
-            "zoneName": "Servië"
-        },
-        "RU": {
-            "zoneName": "Rusland"
-        },
-        "SE": {
-            "zoneName": "Zweden"
-        },
-        "SG": {
-            "zoneName": "Singapore"
-        },
-        "SI": {
-            "zoneName": "Slovenië"
-        },
-        "SK": {
-            "zoneName": "Slowakije"
-        },
-        "TR": {
-            "zoneName": "Turkije"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "UA": {
-            "zoneName": "Oekraïne"
-        },
-        "PF": {
-            "zoneName": "Frans-Polynesië"
-        },
-        "DO": {
-            "zoneName": "Dominicaanse Republiek"
-        },
-        "IL": {
-            "zoneName": "Israël"
-        },
-        "KW": {
-            "zoneName": "Koeweit"
-        },
-        "GE": {
-            "zoneName": "Georgië"
-        }
+        "AL": { "zoneName": "Albanië" },
+        "AT": { "zoneName": "Oostenrijk" },
+        "AX": { "zoneName": "Åland" },
+        "BA": { "zoneName": "Bosnië-Herzegovina" },
+        "BE": { "zoneName": "België" },
+        "BG": { "zoneName": "Bulgarije" },
+        "BY": { "zoneName": "Wit-Rusland" },
+        "CH": { "zoneName": "Zwitserland" },
+        "CZ": { "zoneName": "Tsjechië" },
+        "DE": { "zoneName": "Duitsland" },
+        "DK": { "zoneName": "Denemarken" },
+        "EE": { "zoneName": "Estland" },
+        "ES": { "zoneName": "Spanje" },
+        "FI": { "zoneName": "Finland" },
+        "FR": { "zoneName": "Frankrijk" },
+        "GB": { "zoneName": "Groot-Brittannië" },
+        "GB-NIR": { "zoneName": "Noord-Ierland" },
+        "GR": { "zoneName": "Griekenland" },
+        "HR": { "zoneName": "Kroatië" },
+        "HU": { "zoneName": "Hongarije" },
+        "IE": { "zoneName": "Ierland" },
+        "IS": { "zoneName": "IJsland" },
+        "IT": { "zoneName": "Italië" },
+        "LT": { "zoneName": "Litouwen" },
+        "LU": { "zoneName": "Luxemburg" },
+        "LV": { "zoneName": "Letland" },
+        "MD": { "zoneName": "Moldavië" },
+        "ME": { "zoneName": "Montenegro" },
+        "MK": { "zoneName": "Noord-Macedonië" },
+        "MT": { "zoneName": "Malta" },
+        "NKR": { "zoneName": "Nagorno-Karabach" },
+        "NL": { "zoneName": "Nederland" },
+        "NO": { "zoneName": "Noorwegen" },
+        "PE": { "zoneName": "Peru" },
+        "PL": { "zoneName": "Polen" },
+        "PT": { "zoneName": "Portugal" },
+        "RO": { "zoneName": "Roemenië" },
+        "RS": { "zoneName": "Servië" },
+        "RU": { "zoneName": "Rusland" },
+        "SE": { "zoneName": "Zweden" },
+        "SG": { "zoneName": "Singapore" },
+        "SI": { "zoneName": "Slovenië" },
+        "SK": { "zoneName": "Slowakije" },
+        "TR": { "zoneName": "Turkije" },
+        "TW": { "zoneName": "Taiwan" },
+        "UA": { "zoneName": "Oekraïne" },
+        "PF": { "zoneName": "Frans-Polynesië" },
+        "DO": { "zoneName": "Dominicaanse Republiek" },
+        "IL": { "zoneName": "Israël" },
+        "KW": { "zoneName": "Koeweit" },
+        "GE": { "zoneName": "Georgië" }
     }
 }

--- a/web/public/locales/no-NB.json
+++ b/web/public/locales/no-NB.json
@@ -11,15 +11,9 @@
         "zone-list-header-subtitle": "Sortert etter CO₂-intensitet fra strømforbruk (gCO₂eq/kWh)",
         "search": "Søk etter land/region"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Regioner",
-        "about": "Om kartet"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Regioner", "about": "Om kartet" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Kartlegger klimaeffekten av el-energi"
-        },
+        "view1": { "subtitle": "Kartlegger klimaeffekten av el-energi" },
         "view2": {
             "header": "Hvor mye CO₂ blir sluppet ut for å produsere din elektrisitet, vist i sanntid",
             "text": "Vi fargelegger områdene i verden etter karbonintensitet (som inkluderer alle drivhusgasser) for elektrisitet forbrukt der. Jo grønnere fargen er, jo mer klimavennlig er elektrisiteten som forbrukes der."
@@ -55,14 +49,14 @@
         "now": "Nå"
     },
     "country-history": {
-        "carbonintensity24h": "CO₂-intensitet siste 24 timer",
-        "emissions24h": "Utslipp siste 24 timer",
-        "emissionsorigin24h": "CO₂-utslippskilde siste 24 timer",
-        "emissionsproduction24h": "CO₂-utslipp siste 24 timer",
-        "electricityorigin24h": "Elektrisitetskilde siste 24 timer",
-        "electricityproduction24h": "Strømproduksjonen i de siste 24 timer",
-        "electricityprices24h": "Strømpris siste 24 timer",
-        "Getdata": "Skaff tilgang til live, historiske eller fremskrivingsdata med electricityMap API"
+        "Getdata": "Skaff tilgang til live, historiske eller fremskrivingsdata med electricityMap API",
+        "carbonintensity": { "hourly": "CO₂-intensitet siste 24 timer" },
+        "emissionsorigin": { "hourly": "CO₂-utslippskilde siste 24 timer" },
+        "emissionsproduction": { "hourly": "CO₂-utslipp siste 24 timer" },
+        "electricityorigin": { "hourly": "Elektrisitetskilde siste 24 timer" },
+        "electricityproduction": { "hourly": "Strømproduksjonen i de siste 24 timer" },
+        "electricityprices": { "hourly": "Strømpris siste 24 timer" },
+        "emissions": { "hourly": "Utslipp siste 24 timer" }
     },
     "footer": {
         "foundbugs": "Funnet feil eller har du forbedringsforslag? Tips oss",
@@ -205,1335 +199,394 @@
     "emissionsImportedFrom": "<b>%1$s %%</b> av CO₂-utslipp i <img id=\"country-flag\"></img> <b>%2$s</b> importeres fra <img id=\"country-exchange-flag\"></img> <b>%3$s</b>",
     "ofCO2eqPerMinute": "av CO₂-ekvivalenter per minutt",
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "De forente arabiske emirater"
-        },
-        "AF": {
-            "zoneName": "Afghanistan"
-        },
-        "AG": {
-            "zoneName": "Antigua og Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albania"
-        },
-        "AM": {
-            "zoneName": "Armenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarctika"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AS": {
-            "zoneName": "Amerikansk Samoa"
-        },
-        "AT": {
-            "zoneName": "Østerrike"
-        },
-        "AUS-NSW": {
-            "countryName": "Australia",
-            "zoneName": "New South Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Australia",
-            "zoneName": "Northern Territory"
-        },
-        "AUS-QLD": {
-            "countryName": "Australia",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australia",
-            "zoneName": "South Australia"
-        },
-        "AUS-TAS": {
-            "countryName": "Australia",
-            "zoneName": "Tasmania"
-        },
-        "AUS-TAS-CBI": {
-            "countryName": "Australia",
-            "zoneName": "Cape Barren Island"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Australia",
-            "zoneName": "King Island"
-        },
-        "AUS-TAS-FI": {
-            "countryName": "Australia",
-            "zoneName": "Flinders Island"
-        },
-        "AUS-VIC": {
-            "countryName": "Australia",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australia",
-            "zoneName": "Western Australia"
-        },
-        "AUS-WA-RI": {
-            "countryName": "Australia",
-            "zoneName": "Rottnest Island"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Åland"
-        },
-        "AZ": {
-            "zoneName": "Azerbaijan"
-        },
-        "BA": {
-            "zoneName": "Bosnia-Hercegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Belgia"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgaria"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius og Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brasil",
-            "zoneName": "Sentral-Brasil"
-        },
-        "BR-N": {
-            "countryName": "Brasil",
-            "zoneName": "Nord-Brasil"
-        },
-        "BR-NE": {
-            "countryName": "Brasil",
-            "zoneName": "Nord-øst Brasil"
-        },
-        "BR-S": {
-            "countryName": "Brasil",
-            "zoneName": "Sør-Brasil"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Bouvetøya"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Belarus"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "Britisk Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland og Labrador"
-        },
-        "CA-NL-LB": {
-            "countryName": "Kanada",
-            "zoneName": "Labrador"
-        },
-        "CA-NL-NF": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland"
-        },
-        "CA-NS": {
-            "countryName": "Canada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Nordvestterritoriene"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Prince Edward Island"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Cocos Islands"
-        },
-        "CD": {
-            "zoneName": "Den demokratiske republikken Kongo"
-        },
-        "CF": {
-            "zoneName": "Den sentralafrikanske republikk"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Sveits"
-        },
-        "CI": {
-            "zoneName": "Elfenbenskysten"
-        },
-        "CK": {
-            "zoneName": "Cookøyene"
-        },
-        "CL-CHP": {
-            "countryName": "Chile",
-            "zoneName": "Påskeøya"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Aysén"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Magallanes"
-        },
-        "CL-SEN": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico Nacional"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Kina (folkerepublikken)"
-        },
-        "CO": {
-            "zoneName": "Colombia"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Cuba"
-        },
-        "CV": {
-            "zoneName": "Cabo Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Christmas Island"
-        },
-        "CY": {
-            "zoneName": "Cyprus"
-        },
-        "CZ": {
-            "zoneName": "Tjekkia"
-        },
-        "DE": {
-            "zoneName": "Tyskland"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Danmark"
-        },
-        "DK-DK1": {
-            "countryName": "Danmark",
-            "zoneName": "Vest-Danmark"
-        },
-        "DK-DK2": {
-            "countryName": "Danmark",
-            "zoneName": "Øst-Danmark"
-        },
-        "DK-BHM": {
-            "countryName": "Denmark",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "Den dominikanske republikk"
-        },
-        "DZ": {
-            "zoneName": "Algerie"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Estland"
-        },
-        "EG": {
-            "zoneName": "Egypt"
-        },
-        "EH": {
-            "zoneName": "Vestsahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Spania"
-        },
-        "ES-IB-FO": {
-            "countryName": "Spain",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Spain",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Spain",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Spain",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Spain",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Spain",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Spain",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Spain",
-            "zoneName": "Isla de la Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Spain",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Spain",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Ethiopia"
-        },
-        "FI": {
-            "zoneName": "Finland"
-        },
-        "FJ": {
-            "zoneName": "Fiji"
-        },
-        "FK": {
-            "zoneName": "Falklandøyene"
-        },
-        "FM": {
-            "zoneName": "Micronesia"
-        },
-        "FO": {
-            "zoneName": "Færøyene"
-        },
-        "FR": {
-            "zoneName": "Frankrike"
-        },
-        "FR-COR": {
-            "countryName": "Frankrike",
-            "zoneName": "Korsika"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Storbritannia"
-        },
-        "GB-NIR": {
-            "zoneName": "Nord-Irland"
-        },
-        "GB-ORK": {
-            "countryName": "Storbritannia",
-            "zoneName": "Orkenøyene"
-        },
-        "GB-SHI": {
-            "countryName": "Storbritannia",
-            "zoneName": "Shetland"
-        },
-        "GB-ZET": {
-            "countryName": "Storbritannia",
-            "zoneName": "Shetland"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgia"
-        },
-        "GF": {
-            "zoneName": "Fransk Guiana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Grønland"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Ekvatorial-Guinea"
-        },
-        "GR": {
-            "zoneName": "Hellas"
-        },
-        "GR-IS": {
-            "countryName": "Hellas",
-            "zoneName": "Egeiske øyer"
-        },
-        "GS": {
-            "zoneName": "Sør-Georgia og Sør-Sandwichøyene"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Heard- og McDonaldøyene"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Kroatia"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Ungarn"
-        },
-        "ID": {
-            "zoneName": "Indonesia"
-        },
-        "IE": {
-            "zoneName": "Irland"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Isle of Man"
-        },
-        "IN-AN": {
-            "countryName": "India",
-            "zoneName": "Andamanene og Nikobarene"
-        },
-        "IN-AP": {
-            "countryName": "India",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "India",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "India",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "India",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "India",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "India",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "India",
-            "zoneName": "Dadra og Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "India",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "India",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "India",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "India",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "India",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "India",
-            "zoneName": "Jammu og Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "India",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "India",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "India",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "India",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "India",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "India",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "India",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "India",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "India",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "India",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "India",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "India",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "India",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "India",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "India",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "India",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "India",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "India",
-            "zoneName": "West Bengal"
-        },
-        "IO": {
-            "zoneName": "Det britiske territoriet i Indiahavet"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Island"
-        },
-        "IT": {
-            "zoneName": "Italia"
-        },
-        "IT-CNO": {
-            "countryName": "Italy",
-            "zoneName": "Sentralt Nord-Italia"
-        },
-        "IT-CSO": {
-            "countryName": "Italy",
-            "zoneName": "Sentrale Sør-Italia"
-        },
-        "IT-NO": {
-            "countryName": "Italy",
-            "zoneName": "Nord-Italia"
-        },
-        "IT-SAR": {
-            "countryName": "Italy",
-            "zoneName": "Sardinia"
-        },
-        "IT-SIC": {
-            "countryName": "Italy",
-            "zoneName": "Sicilia"
-        },
-        "IT-SO": {
-            "countryName": "Italy",
-            "zoneName": "Sør-Italia"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaica"
-        },
-        "JO": {
-            "zoneName": "Jordan"
-        },
-        "JP-CB": {
-            "countryName": "Japan",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japan",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japan",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Japan",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japan",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japan",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Japan",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japan",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japan",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japan",
-            "zoneName": "Tōkyō"
-        },
-        "KE": {
-            "zoneName": "Kenya"
-        },
-        "KG": {
-            "zoneName": "Kyrgyzstan"
-        },
-        "KH": {
-            "zoneName": "Kambodsja"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comoros"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts and Nevis"
-        },
-        "KP": {
-            "zoneName": "Nord-Korea"
-        },
-        "KR": {
-            "zoneName": "Sør-Korea"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Cayman Islands"
-        },
-        "KZ": {
-            "zoneName": "Kazakhstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Lebanon"
-        },
-        "LC": {
-            "zoneName": "Saint Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Litauen"
-        },
-        "LU": {
-            "zoneName": "Luxemburg"
-        },
-        "LV": {
-            "zoneName": "Latvia"
-        },
-        "LY": {
-            "zoneName": "Libya"
-        },
-        "MA": {
-            "zoneName": "Morocco"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldavia"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Saint Martin",
-            "zoneName": "French"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Marshalløyene"
-        },
-        "MK": {
-            "zoneName": "Nord-Makedonia"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Mongolia"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Northern Mariana Islands"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Maldivene"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mexico"
-        },
-        "MX-BC": {
-            "countryName": "Mexico",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mexico",
-            "zoneName": "Sentral"
-        },
-        "MX-NE": {
-            "countryName": "Mexico",
-            "zoneName": "Nord-øst"
-        },
-        "MX-NO": {
-            "countryName": "Mexico",
-            "zoneName": "Nord"
-        },
-        "MX-NW": {
-            "countryName": "Mexico",
-            "zoneName": "Nord-vest"
-        },
-        "MX-OC": {
-            "countryName": "Mexico",
-            "zoneName": "Østlig"
-        },
-        "MX-OR": {
-            "countryName": "Mexico",
-            "zoneName": "Østlig"
-        },
-        "MX-PN": {
-            "countryName": "Mexico",
-            "zoneName": "Halvøya"
-        },
-        "MY-EM": {
-            "countryName": "Malaysia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malaysia",
-            "zoneName": "Halvøya"
-        },
-        "MZ": {
-            "zoneName": "Mozambique"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "Ny-Kaledonia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolk Island"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabakh"
-        },
-        "NL": {
-            "zoneName": "Holland"
-        },
-        "NO-NO1": {
-            "countryName": "Norge",
-            "zoneName": "Sørøst-Norge"
-        },
-        "NO-NO2": {
-            "countryName": "Norge",
-            "zoneName": "Sørvest-Norge"
-        },
-        "NO-NO3": {
-            "countryName": "Norge",
-            "zoneName": "Midt-Norge"
-        },
-        "NO-NO4": {
-            "countryName": "Norge",
-            "zoneName": "Nord-Norge"
-        },
-        "NO-NO5": {
-            "countryName": "Norge",
-            "zoneName": "Vest-Norge"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "New Zealand"
-        },
-        "NZ-NZA": {
-            "countryName": "New Zealand",
-            "zoneName": "Auckland Islands"
-        },
-        "NZ-NZC": {
-            "countryName": "New Zealand",
-            "zoneName": "Chatham Islands"
-        },
-        "NZ-NZST": {
-            "countryName": "New Zealand",
-            "zoneName": "Stewart Island"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Fransk Polynesia"
-        },
-        "PG": {
-            "zoneName": "Papua New Guinea"
-        },
-        "PH": {
-            "zoneName": "Filippinene"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Polen"
-        },
-        "PM": {
-            "zoneName": "Saint Pierre og Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Staten Palestina"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Azorene"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Qatar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Romania"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Russland"
-        },
-        "RU-1": {
-            "countryName": "Russia",
-            "zoneName": "Europe-Ural"
-        },
-        "RU-2": {
-            "countryName": "Russia",
-            "zoneName": "Siber"
-        },
-        "RU-AS": {
-            "countryName": "Russia",
-            "zoneName": "Øst"
-        },
-        "RU-EU": {
-            "countryName": "Russia",
-            "zoneName": "Arktis"
-        },
-        "RU-FE": {
-            "countryName": "Russia",
-            "zoneName": "Fjerne østen"
-        },
-        "RU-KGD": {
-            "countryName": "Russia",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Saudiarabia"
-        },
-        "SB": {
-            "zoneName": "Solomonøyene"
-        },
-        "SC": {
-            "zoneName": "Seychellene"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Sverige"
-        },
-        "SG": {
-            "zoneName": "Singapore"
-        },
-        "SH": {
-            "zoneName": "Sankt Helena, Ascension og Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard og Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovakia"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Sør-Sudan"
-        },
-        "ST": {
-            "zoneName": "Sao Tome og Principe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Dutch"
-        },
-        "SY": {
-            "zoneName": "Syria"
-        },
-        "SZ": {
-            "zoneName": "Swaziland"
-        },
-        "TC": {
-            "zoneName": "Turks- og Caicosøyene"
-        },
-        "TD": {
-            "zoneName": "Chad"
-        },
-        "TF": {
-            "zoneName": "De franske sørterritorier"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thailand"
-        },
-        "TJ": {
-            "zoneName": "Tajikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunisia"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Tyrkia"
-        },
-        "TT": {
-            "zoneName": "Trinidad og Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tanzania"
-        },
-        "UA": {
-            "zoneName": "Ukraina"
-        },
-        "UA-CR": {
-            "countryName": "Ukraina",
-            "zoneName": "Krim-halvøya"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "USAs ytre småøyer"
-        },
-        "US-HI-HA": {
-            "countryName": "USA",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "USA",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "USA",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "USA",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "USA",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "USA",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "USA",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "USA",
-            "zoneName": "Oahu"
-        },
-        "US-CAL-BANC": {
-            "countryName": "USA",
-            "zoneName": "Balancing Authority Of Northern California"
-        },
-        "US-CAL-CISO": {
-            "countryName": "USA",
-            "zoneName": "California Independent System Operator"
-        },
-        "US-CAL-IID": {
-            "countryName": "USA",
-            "zoneName": "Imperial Irrigation District"
-        },
-        "US-CAL-LDWP": {
-            "countryName": "USA",
-            "zoneName": "Los Angeles Department Of Water And Power"
-        },
-        "US-CAL-TIDC": {
-            "countryName": "USA",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "USA",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "USA",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "USA",
-            "zoneName": "Duke Energy Carolinas"
-        },
-        "US-CAR-SC": {
-            "countryName": "USA",
-            "zoneName": "South Carolina Public Service Authority"
-        },
-        "US-CAR-SCEG": {
-            "countryName": "USA",
-            "zoneName": "South Carolina Electric & Gas Company"
-        },
-        "US-CAR-YAD": {
-            "countryName": "USA",
-            "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
-        },
-        "US-CENT-SPA": {
-            "countryName": "USA",
-            "zoneName": "Southwestern Power Administration"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "USA",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "USA",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "USA",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "USA",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "USA",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "USA",
-            "zoneName": "City Of Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "USA",
-            "zoneName": "Jacksonville Electric Authority"
-        },
-        "US-FLA-NSB": {
-            "countryName": "USA",
-            "zoneName": "Utilities Commission Of New Smyrna Beach"
-        },
-        "US-FLA-SEC": {
-            "countryName": "USA",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "USA",
-            "zoneName": "City Of Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "USA",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-OVEC": {
-            "countryName": "USA",
-            "zoneName": "Ohio Valley Electric Corporation"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "USA",
-            "zoneName": "PJM Interconnection, Llc"
-        },
-        "US-MIDW-AECI": {
-            "countryName": "USA",
-            "zoneName": "Associated Electric Cooperative, Inc."
-        },
-        "US-MIDW-GLHB": {
-            "countryName": "USA",
-            "zoneName": "GridLiance"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "De forente arabiske emirater" },
+        "AF": { "zoneName": "Afghanistan" },
+        "AG": { "zoneName": "Antigua og Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albania" },
+        "AM": { "zoneName": "Armenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarctika" },
+        "AR": { "zoneName": "Argentina" },
+        "AS": { "zoneName": "Amerikansk Samoa" },
+        "AT": { "zoneName": "Østerrike" },
+        "AUS-NSW": { "countryName": "Australia", "zoneName": "New South Wales" },
+        "AUS-NT": { "countryName": "Australia", "zoneName": "Northern Territory" },
+        "AUS-QLD": { "countryName": "Australia", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australia", "zoneName": "South Australia" },
+        "AUS-TAS": { "countryName": "Australia", "zoneName": "Tasmania" },
+        "AUS-TAS-CBI": { "countryName": "Australia", "zoneName": "Cape Barren Island" },
+        "AUS-TAS-KI": { "countryName": "Australia", "zoneName": "King Island" },
+        "AUS-TAS-FI": { "countryName": "Australia", "zoneName": "Flinders Island" },
+        "AUS-VIC": { "countryName": "Australia", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australia", "zoneName": "Western Australia" },
+        "AUS-WA-RI": { "countryName": "Australia", "zoneName": "Rottnest Island" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Åland" },
+        "AZ": { "zoneName": "Azerbaijan" },
+        "BA": { "zoneName": "Bosnia-Hercegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Belgia" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgaria" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius og Saba" },
+        "BR-CS": { "countryName": "Brasil", "zoneName": "Sentral-Brasil" },
+        "BR-N": { "countryName": "Brasil", "zoneName": "Nord-Brasil" },
+        "BR-NE": { "countryName": "Brasil", "zoneName": "Nord-øst Brasil" },
+        "BR-S": { "countryName": "Brasil", "zoneName": "Sør-Brasil" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Bouvetøya" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Belarus" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "Britisk Columbia" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "New Brunswick" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland og Labrador" },
+        "CA-NL-LB": { "countryName": "Kanada", "zoneName": "Labrador" },
+        "CA-NL-NF": { "countryName": "Kanada", "zoneName": "Newfoundland" },
+        "CA-NS": { "countryName": "Canada", "zoneName": "Nova Scotia" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Nordvestterritoriene" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Prince Edward Island" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Cocos Islands" },
+        "CD": { "zoneName": "Den demokratiske republikken Kongo" },
+        "CF": { "zoneName": "Den sentralafrikanske republikk" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Sveits" },
+        "CI": { "zoneName": "Elfenbenskysten" },
+        "CK": { "zoneName": "Cookøyene" },
+        "CL-CHP": { "countryName": "Chile", "zoneName": "Påskeøya" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Aysén" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Magallanes" },
+        "CL-SEN": { "countryName": "Chile", "zoneName": "Sistema Eléctrico Nacional" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Kina (folkerepublikken)" },
+        "CO": { "zoneName": "Colombia" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Cuba" },
+        "CV": { "zoneName": "Cabo Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Christmas Island" },
+        "CY": { "zoneName": "Cyprus" },
+        "CZ": { "zoneName": "Tjekkia" },
+        "DE": { "zoneName": "Tyskland" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Danmark" },
+        "DK-DK1": { "countryName": "Danmark", "zoneName": "Vest-Danmark" },
+        "DK-DK2": { "countryName": "Danmark", "zoneName": "Øst-Danmark" },
+        "DK-BHM": { "countryName": "Denmark", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "Den dominikanske republikk" },
+        "DZ": { "zoneName": "Algerie" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Estland" },
+        "EG": { "zoneName": "Egypt" },
+        "EH": { "zoneName": "Vestsahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Spania" },
+        "ES-IB-FO": { "countryName": "Spain", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Spain", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Spain", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Spain", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Spain", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Spain", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Spain", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Spain", "zoneName": "Isla de la Gomera" },
+        "ES-CN-LP": { "countryName": "Spain", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Spain", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Ethiopia" },
+        "FI": { "zoneName": "Finland" },
+        "FJ": { "zoneName": "Fiji" },
+        "FK": { "zoneName": "Falklandøyene" },
+        "FM": { "zoneName": "Micronesia" },
+        "FO": { "zoneName": "Færøyene" },
+        "FR": { "zoneName": "Frankrike" },
+        "FR-COR": { "countryName": "Frankrike", "zoneName": "Korsika" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Storbritannia" },
+        "GB-NIR": { "zoneName": "Nord-Irland" },
+        "GB-ORK": { "countryName": "Storbritannia", "zoneName": "Orkenøyene" },
+        "GB-SHI": { "countryName": "Storbritannia", "zoneName": "Shetland" },
+        "GB-ZET": { "countryName": "Storbritannia", "zoneName": "Shetland" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgia" },
+        "GF": { "zoneName": "Fransk Guiana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Grønland" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Ekvatorial-Guinea" },
+        "GR": { "zoneName": "Hellas" },
+        "GR-IS": { "countryName": "Hellas", "zoneName": "Egeiske øyer" },
+        "GS": { "zoneName": "Sør-Georgia og Sør-Sandwichøyene" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Heard- og McDonaldøyene" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Kroatia" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Ungarn" },
+        "ID": { "zoneName": "Indonesia" },
+        "IE": { "zoneName": "Irland" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Isle of Man" },
+        "IN-AN": { "countryName": "India", "zoneName": "Andamanene og Nikobarene" },
+        "IN-AP": { "countryName": "India", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "India", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "India", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "India", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "India", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "India", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "India", "zoneName": "Dadra og Nagar Haveli" },
+        "IN-GA": { "countryName": "India", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "India", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "India", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "India", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "India", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "India", "zoneName": "Jammu og Kashmir" },
+        "IN-KA": { "countryName": "India", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "India", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "India", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "India", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "India", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "India", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "India", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "India", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "India", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "India", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "India", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "India", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "India", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "India", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "India", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "India", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "India", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "India", "zoneName": "West Bengal" },
+        "IO": { "zoneName": "Det britiske territoriet i Indiahavet" },
+        "IQ": { "zoneName": "Irak" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Island" },
+        "IT": { "zoneName": "Italia" },
+        "IT-CNO": { "countryName": "Italy", "zoneName": "Sentralt Nord-Italia" },
+        "IT-CSO": { "countryName": "Italy", "zoneName": "Sentrale Sør-Italia" },
+        "IT-NO": { "countryName": "Italy", "zoneName": "Nord-Italia" },
+        "IT-SAR": { "countryName": "Italy", "zoneName": "Sardinia" },
+        "IT-SIC": { "countryName": "Italy", "zoneName": "Sicilia" },
+        "IT-SO": { "countryName": "Italy", "zoneName": "Sør-Italia" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaica" },
+        "JO": { "zoneName": "Jordan" },
+        "JP-CB": { "countryName": "Japan", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Japan", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Japan", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Japan", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japan", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japan", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Japan", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japan", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japan", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Japan", "zoneName": "Tōkyō" },
+        "KE": { "zoneName": "Kenya" },
+        "KG": { "zoneName": "Kyrgyzstan" },
+        "KH": { "zoneName": "Kambodsja" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comoros" },
+        "KN": { "zoneName": "Saint Kitts and Nevis" },
+        "KP": { "zoneName": "Nord-Korea" },
+        "KR": { "zoneName": "Sør-Korea" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Cayman Islands" },
+        "KZ": { "zoneName": "Kazakhstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Lebanon" },
+        "LC": { "zoneName": "Saint Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Litauen" },
+        "LU": { "zoneName": "Luxemburg" },
+        "LV": { "zoneName": "Latvia" },
+        "LY": { "zoneName": "Libya" },
+        "MA": { "zoneName": "Morocco" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldavia" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Saint Martin", "zoneName": "French" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Marshalløyene" },
+        "MK": { "zoneName": "Nord-Makedonia" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Mongolia" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Northern Mariana Islands" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Maldivene" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mexico" },
+        "MX-BC": { "countryName": "Mexico", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mexico", "zoneName": "Sentral" },
+        "MX-NE": { "countryName": "Mexico", "zoneName": "Nord-øst" },
+        "MX-NO": { "countryName": "Mexico", "zoneName": "Nord" },
+        "MX-NW": { "countryName": "Mexico", "zoneName": "Nord-vest" },
+        "MX-OC": { "countryName": "Mexico", "zoneName": "Østlig" },
+        "MX-OR": { "countryName": "Mexico", "zoneName": "Østlig" },
+        "MX-PN": { "countryName": "Mexico", "zoneName": "Halvøya" },
+        "MY-EM": { "countryName": "Malaysia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malaysia", "zoneName": "Halvøya" },
+        "MZ": { "zoneName": "Mozambique" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "Ny-Kaledonia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolk Island" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Nagorno-Karabakh" },
+        "NL": { "zoneName": "Holland" },
+        "NO-NO1": { "countryName": "Norge", "zoneName": "Sørøst-Norge" },
+        "NO-NO2": { "countryName": "Norge", "zoneName": "Sørvest-Norge" },
+        "NO-NO3": { "countryName": "Norge", "zoneName": "Midt-Norge" },
+        "NO-NO4": { "countryName": "Norge", "zoneName": "Nord-Norge" },
+        "NO-NO5": { "countryName": "Norge", "zoneName": "Vest-Norge" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "New Zealand" },
+        "NZ-NZA": { "countryName": "New Zealand", "zoneName": "Auckland Islands" },
+        "NZ-NZC": { "countryName": "New Zealand", "zoneName": "Chatham Islands" },
+        "NZ-NZST": { "countryName": "New Zealand", "zoneName": "Stewart Island" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Fransk Polynesia" },
+        "PG": { "zoneName": "Papua New Guinea" },
+        "PH": { "zoneName": "Filippinene" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Polen" },
+        "PM": { "zoneName": "Saint Pierre og Miquelon" },
+        "PN": { "zoneName": "Pitcairn" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Staten Palestina" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Azorene" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Qatar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Romania" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Russland" },
+        "RU-1": { "countryName": "Russia", "zoneName": "Europe-Ural" },
+        "RU-2": { "countryName": "Russia", "zoneName": "Siber" },
+        "RU-AS": { "countryName": "Russia", "zoneName": "Øst" },
+        "RU-EU": { "countryName": "Russia", "zoneName": "Arktis" },
+        "RU-FE": { "countryName": "Russia", "zoneName": "Fjerne østen" },
+        "RU-KGD": { "countryName": "Russia", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Saudiarabia" },
+        "SB": { "zoneName": "Solomonøyene" },
+        "SC": { "zoneName": "Seychellene" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Sverige" },
+        "SG": { "zoneName": "Singapore" },
+        "SH": { "zoneName": "Sankt Helena, Ascension og Tristan da Cunha" },
+        "SI": { "zoneName": "Slovenia" },
+        "SJ": { "zoneName": "Svalbard og Jan Mayen" },
+        "SK": { "zoneName": "Slovakia" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Sør-Sudan" },
+        "ST": { "zoneName": "Sao Tome og Principe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Dutch" },
+        "SY": { "zoneName": "Syria" },
+        "SZ": { "zoneName": "Swaziland" },
+        "TC": { "zoneName": "Turks- og Caicosøyene" },
+        "TD": { "zoneName": "Chad" },
+        "TF": { "zoneName": "De franske sørterritorier" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thailand" },
+        "TJ": { "zoneName": "Tajikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunisia" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Tyrkia" },
+        "TT": { "zoneName": "Trinidad og Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tanzania" },
+        "UA": { "zoneName": "Ukraina" },
+        "UA-CR": { "countryName": "Ukraina", "zoneName": "Krim-halvøya" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "USAs ytre småøyer" },
+        "US-HI-HA": { "countryName": "USA", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "USA", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "USA", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "USA", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "USA", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "USA", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "USA", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "USA", "zoneName": "Oahu" },
+        "US-CAL-BANC": { "countryName": "USA", "zoneName": "Balancing Authority Of Northern California" },
+        "US-CAL-CISO": { "countryName": "USA", "zoneName": "California Independent System Operator" },
+        "US-CAL-IID": { "countryName": "USA", "zoneName": "Imperial Irrigation District" },
+        "US-CAL-LDWP": { "countryName": "USA", "zoneName": "Los Angeles Department Of Water And Power" },
+        "US-CAL-TIDC": { "countryName": "USA", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "USA", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "USA", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "USA", "zoneName": "Duke Energy Carolinas" },
+        "US-CAR-SC": { "countryName": "USA", "zoneName": "South Carolina Public Service Authority" },
+        "US-CAR-SCEG": { "countryName": "USA", "zoneName": "South Carolina Electric & Gas Company" },
+        "US-CAR-YAD": { "countryName": "USA", "zoneName": "Alcoa Power Generating, Inc. Yadkin Division" },
+        "US-CENT-SPA": { "countryName": "USA", "zoneName": "Southwestern Power Administration" },
+        "US-CENT-SWPP": { "countryName": "USA", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "USA", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "USA", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "USA", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "USA", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "USA", "zoneName": "City Of Homestead" },
+        "US-FLA-JEA": { "countryName": "USA", "zoneName": "Jacksonville Electric Authority" },
+        "US-FLA-NSB": { "countryName": "USA", "zoneName": "Utilities Commission Of New Smyrna Beach" },
+        "US-FLA-SEC": { "countryName": "USA", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "USA", "zoneName": "City Of Tallahassee" },
+        "US-FLA-TEC": { "countryName": "USA", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-OVEC": { "countryName": "USA", "zoneName": "Ohio Valley Electric Corporation" },
+        "US-MIDA-PJM": { "countryName": "USA", "zoneName": "PJM Interconnection, Llc" },
+        "US-MIDW-AECI": { "countryName": "USA", "zoneName": "Associated Electric Cooperative, Inc." },
+        "US-MIDW-GLHB": { "countryName": "USA", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "USA",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1542,216 +595,68 @@
             "countryName": "USA",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc."
         },
-        "US-NE-ISNE": {
-            "countryName": "USA",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "USA",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "USA",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "USA",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "USA",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "USA",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
-        "US-NW-GCPD": {
-            "countryName": "USA",
-            "zoneName": "PUD No. 2 Of Grant County, Washington"
-        },
-        "US-NW-GRID": {
-            "countryName": "USA",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "USA",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "USA",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "USA",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "USA",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "USA",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "USA",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "USA",
-            "zoneName": "Portland General Electric Company"
-        },
-        "US-NW-PSCO": {
-            "countryName": "USA",
-            "zoneName": "Public Service Company Of Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "USA",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "USA",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NE-ISNE": { "countryName": "USA", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "USA", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "USA", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "USA", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "USA", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "USA", "zoneName": "PUD No. 1 Of Douglas County" },
+        "US-NW-GCPD": { "countryName": "USA", "zoneName": "PUD No. 2 Of Grant County, Washington" },
+        "US-NW-GRID": { "countryName": "USA", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "USA", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "USA", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "USA", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "USA", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "USA", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "USA", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "USA", "zoneName": "Portland General Electric Company" },
+        "US-NW-PSCO": { "countryName": "USA", "zoneName": "Public Service Company Of Colorado" },
+        "US-NW-PSEI": { "countryName": "USA", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "USA", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "USA",
             "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
         },
-        "US-NW-WACM": {
-            "countryName": "USA",
-            "zoneName": "Western Area Power Administration - Rocky Mountain Region"
-        },
-        "US-NW-WAUW": {
-            "countryName": "USA",
-            "zoneName": "Western Area Power Administration UGP West"
-        },
-        "US-NW-WWA": {
-            "countryName": "USA",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "USA",
-            "zoneName": "New York Independent System Operator"
-        },
-        "US-SE-AEC": {
-            "countryName": "USA",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "USA",
-            "zoneName": "Southeastern Power Administration"
-        },
-        "US-SE-SOCO": {
-            "countryName": "USA",
-            "zoneName": "Southern Company Services, Inc. - Trans"
-        },
-        "US-SW-AZPS": {
-            "countryName": "USA",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "USA",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "USA",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "USA",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "USA",
-            "zoneName": "Gila River Power, LLC"
-        },
-        "US-SW-HGMA": {
-            "countryName": "USA",
-            "zoneName": "New Harquahala Generating Company, LLC"
-        },
-        "US-SW-PNM": {
-            "countryName": "USA",
-            "zoneName": "Public Service Company Of New Mexico"
-        },
-        "US-SW-SRP": {
-            "countryName": "USA",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "USA",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-NW-WACM": { "countryName": "USA", "zoneName": "Western Area Power Administration - Rocky Mountain Region" },
+        "US-NW-WAUW": { "countryName": "USA", "zoneName": "Western Area Power Administration UGP West" },
+        "US-NW-WWA": { "countryName": "USA", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "USA", "zoneName": "New York Independent System Operator" },
+        "US-SE-AEC": { "countryName": "USA", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "USA", "zoneName": "Southeastern Power Administration" },
+        "US-SE-SOCO": { "countryName": "USA", "zoneName": "Southern Company Services, Inc. - Trans" },
+        "US-SW-AZPS": { "countryName": "USA", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "USA", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "USA", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "USA", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "USA", "zoneName": "Gila River Power, LLC" },
+        "US-SW-HGMA": { "countryName": "USA", "zoneName": "New Harquahala Generating Company, LLC" },
+        "US-SW-PNM": { "countryName": "USA", "zoneName": "Public Service Company Of New Mexico" },
+        "US-SW-SRP": { "countryName": "USA", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "USA", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "USA",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "USA",
-            "zoneName": "Tennessee Valley Authority"
-        },
-        "US-TEX-ERCO": {
-            "countryName": "USA",
-            "zoneName": "Electric Reliability Council Of Texas, Inc."
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatikanet"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent og Grenadinene"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Jomfruøyene",
-            "zoneName": "Jomfruøyene"
-        },
-        "VI": {
-            "countryName": "USA",
-            "zoneName": "Jomfruøyene"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis- og Futunaøyene"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XK": {
-            "zoneName": "Kosovo"
-        },
-        "XX": {
-            "zoneName": "Nord-Kypros"
-        },
-        "YE": {
-            "zoneName": "Yemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Sør-Afrika"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        },
-        "NO": {
-            "zoneName": "Norge"
-        }
+        "US-TEN-TVA": { "countryName": "USA", "zoneName": "Tennessee Valley Authority" },
+        "US-TEX-ERCO": { "countryName": "USA", "zoneName": "Electric Reliability Council Of Texas, Inc." },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Vatikanet" },
+        "VC": { "zoneName": "Saint Vincent og Grenadinene" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Jomfruøyene", "zoneName": "Jomfruøyene" },
+        "VI": { "countryName": "USA", "zoneName": "Jomfruøyene" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis- og Futunaøyene" },
+        "WS": { "zoneName": "Samoa" },
+        "XK": { "zoneName": "Kosovo" },
+        "XX": { "zoneName": "Nord-Kypros" },
+        "YE": { "zoneName": "Yemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Sør-Afrika" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" },
+        "NO": { "zoneName": "Norge" }
     }
 }

--- a/web/public/locales/pl.json
+++ b/web/public/locales/pl.json
@@ -6,15 +6,9 @@
         "datasources": "źródła danych",
         "contribute": "Pomóż nam <a href=\"%s\" target=\"_blank\">dodając więcej regionów</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Obszary",
-        "about": "O nas"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Obszary", "about": "O nas" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Obrazujemy wpływ produkcji energii elektrycznej na klimat"
-        },
+        "view1": { "subtitle": "Obrazujemy wpływ produkcji energii elektrycznej na klimat" },
         "view2": {
             "header": "Zobacz ile CO₂ jest aktualnie emitowane podczas produkcji twojej energii elektrycznej, w czasie rzeczywistym",
             "text": "Regiony świata są kolorowane według intensywności emisji CO₂ (uwzględniając wszystkie gazy cieplarniane) zużywanej tam energii elektrycznej. Im bardziej zielony jest kolor, tym bardziej przyjazna jest energia elektryczna dla klimatu."
@@ -50,14 +44,14 @@
         "search": "Szukaj"
     },
     "country-history": {
-        "carbonintensity24h": "Emisja CO₂ w ciągu ostatnich 24 godzin",
-        "emissionsorigin24h": "Źródła emisji CO₂ w ciągu ostatnich 24 godzin",
-        "electricityorigin24h": "Źródła energii elektrycznej w ciągu ostatnich 24 godzin",
-        "electricityprices24h": "Ceny energii elektrycznej w ciągu ostatnich 24 godzin",
-        "emissions24h": "Emisja w ciągu ostatnich 24 godzin",
-        "emissionsproduction24h": "Emisja wyprodukowana w ciągu ostatnich 24 godzin",
-        "electricityproduction24h": "Energia elektryczna wyprodukowana w ciągu ostatnich 24 godzin",
-        "Getdata": "Uzyskaj dane godzinowe, bieżące oraz prognozy za pomocą API electricityMap"
+        "Getdata": "Uzyskaj dane godzinowe, bieżące oraz prognozy za pomocą API electricityMap",
+        "carbonintensity": { "hourly": "Emisja CO₂ w ciągu ostatnich 24 godzin" },
+        "emissionsorigin": { "hourly": "Źródła emisji CO₂ w ciągu ostatnich 24 godzin" },
+        "emissionsproduction": { "hourly": "Emisja wyprodukowana w ciągu ostatnich 24 godzin" },
+        "electricityorigin": { "hourly": "Źródła energii elektrycznej w ciągu ostatnich 24 godzin" },
+        "electricityproduction": { "hourly": "Energia elektryczna wyprodukowana w ciągu ostatnich 24 godzin" },
+        "electricityprices": { "hourly": "Ceny energii elektrycznej w ciągu ostatnich 24 godzin" },
+        "emissions": { "hourly": "Emisja w ciągu ostatnich 24 godzin" }
     },
     "footer": {
         "foundbugs": "Znalazłeś błąd lub masz własny pomysł? Daj nam znać",
@@ -194,944 +188,281 @@
     "emissionsImportedFrom": "<img id=\"country-flag\"></img> <b>%2$s</b>: <b>%1$d %%</b> emisji jest importowane z <img id=\"country-exchange-flag\"></img> <b>%3$s</b>",
     "ofCO2eqPerMinute": "CO₂eq na minutę",
     "zoneShortName": {
-        "AE": {
-            "zoneName": "Zjednoczone Emiraty Arabskie"
-        },
-        "AL": {
-            "zoneName": "Albania"
-        },
-        "AF": {
-            "zoneName": "Afganistan"
-        },
-        "AR": {
-            "zoneName": "Argentyna"
-        },
-        "AT": {
-            "zoneName": "Austria"
-        },
-        "AUS-NSW": {
-            "countryName": "Australia",
-            "zoneName": "Nowa Południowa Walia"
-        },
-        "AUS-NT": {
-            "countryName": "Australia",
-            "zoneName": "Terytorium Północne"
-        },
-        "AUS-QLD": {
-            "countryName": "Australia",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australia",
-            "zoneName": "Australia Południowa"
-        },
-        "AUS-TAS": {
-            "countryName": "Australia",
-            "zoneName": "Tasmania"
-        },
-        "AUS-VIC": {
-            "countryName": "Australia",
-            "zoneName": "Wiktoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australia",
-            "zoneName": "Australia Zachodnia"
-        },
-        "AX": {
-            "zoneName": "Wyspy Alandzkie"
-        },
-        "AZ": {
-            "zoneName": "Azerbejdżan"
-        },
-        "BA": {
-            "zoneName": "Bośnia i Hercegowina"
-        },
-        "BD": {
-            "zoneName": "Bangladesz"
-        },
-        "BE": {
-            "zoneName": "Belgia"
-        },
-        "BG": {
-            "zoneName": "Bułgaria"
-        },
-        "BH": {
-            "zoneName": "Bahrajn"
-        },
-        "BO": {
-            "zoneName": "Boliwia"
-        },
-        "BR-CS": {
-            "countryName": "Brazylia",
-            "zoneName": "Brazylia centralna"
-        },
-        "BR-N": {
-            "countryName": "Brazylia",
-            "zoneName": "Brazylia północna"
-        },
-        "BR-NE": {
-            "countryName": "Brazylia",
-            "zoneName": "Brazylia północno-wschodnia"
-        },
-        "BR-S": {
-            "countryName": "Brazylia",
-            "zoneName": "Brazylia południowa"
-        },
-        "BY": {
-            "zoneName": "Białoruś"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "Kolumbia Brytyjska"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Nowa Fundlandia i Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "Nowy Brunszwik"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Terytoria Północno-Zachodnie"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nowa Szkocja"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Wyspa Księcia Edwarda"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Quebec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Jukon"
-        },
-        "CD": {
-            "zoneName": "Demokratyczna Republika Konga"
-        },
-        "CF": {
-            "zoneName": "Republika Środkowoafrykańska"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Szwajcaria"
-        },
-        "CI": {
-            "zoneName": "Wybrzeże Kości Słoniowej"
-        },
-        "CL": {
-            "zoneName": "Chile"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Chiny"
-        },
-        "CO": {
-            "zoneName": "Kolumbia"
-        },
-        "CR": {
-            "zoneName": "Kostaryka"
-        },
-        "CU": {
-            "zoneName": "Kuba"
-        },
-        "CV": {
-            "zoneName": "Republika Zielonego Przylądka"
-        },
-        "CZ": {
-            "zoneName": "Czechy"
-        },
-        "DE": {
-            "zoneName": "Niemcy"
-        },
-        "DJ": {
-            "zoneName": "Dżibuti"
-        },
-        "DK": {
-            "zoneName": "Dania"
-        },
-        "DK-DK1": {
-            "countryName": "Dania",
-            "zoneName": "Dania zachodnia"
-        },
-        "DK-DK2": {
-            "countryName": "Denmark",
-            "zoneName": "Dania wschodnia"
-        },
-        "DK-BHM": {
-            "countryName": "Dania",
-            "zoneName": "Bornholm"
-        },
-        "DO": {
-            "zoneName": "Dominikana"
-        },
-        "DZ": {
-            "zoneName": "Algieria"
-        },
-        "EC": {
-            "zoneName": "Ekwador"
-        },
-        "EE": {
-            "zoneName": "Estonia"
-        },
-        "EG": {
-            "zoneName": "Egipt"
-        },
-        "EH": {
-            "zoneName": "Sahara Zachodnia"
-        },
-        "ER": {
-            "zoneName": "Erytrea"
-        },
-        "ES": {
-            "zoneName": "Hiszpania"
-        },
-        "ES-IB": {
-            "countryName": "Hiszpania",
-            "zoneName": "Baleary"
-        },
-        "ES-IB-ML": {
-            "countryName": "Hiszpania",
-            "zoneName": "Majorka"
-        },
-        "ES-IB-MN": {
-            "countryName": "Hiszpania",
-            "zoneName": "Minorka"
-        },
-        "ES-IB-IB": {
-            "countryName": "Hiszpania",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-FM": {
-            "countryName": "Hiszpania",
-            "zoneName": "Formentera"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Hiszpania",
-            "zoneName": "Fuerteventura i Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Hiszpania",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Hiszpania",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Hiszpania",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Hiszpania",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Hiszpania",
-            "zoneName": "Teneryfa"
-        },
-        "ET": {
-            "zoneName": "Etiopia"
-        },
-        "FI": {
-            "zoneName": "Finlandia"
-        },
-        "FO": {
-            "zoneName": "Wyspy Owcze"
-        },
-        "FR": {
-            "zoneName": "Francja"
-        },
-        "FR-COR": {
-            "countryName": "Francja",
-            "zoneName": "Korsyka"
-        },
-        "GB": {
-            "zoneName": "Wielka Brytania"
-        },
-        "GB-NIR": {
-            "zoneName": "Irlandia Północna"
-        },
-        "GE": {
-            "zoneName": "Gruzja"
-        },
-        "GF": {
-            "zoneName": "Gujana Francuska"
-        },
-        "GL": {
-            "zoneName": "Grenlandia"
-        },
-        "GN": {
-            "zoneName": "Gwinea"
-        },
-        "GQ": {
-            "zoneName": "Gwinea Równikowa"
-        },
-        "GR": {
-            "zoneName": "Grecja"
-        },
-        "GR-IS": {
-            "countryName": "Grecja",
-            "zoneName": "Wyspy Egejskie"
-        },
-        "GT": {
-            "zoneName": "Gwatemala"
-        },
-        "GW": {
-            "zoneName": "Gwinea Bissau"
-        },
-        "GY": {
-            "zoneName": "Gujana"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Chorwacja"
-        },
-        "HU": {
-            "zoneName": "Węgry"
-        },
-        "ID": {
-            "zoneName": "Indonezja"
-        },
-        "IE": {
-            "zoneName": "Irlandia"
-        },
-        "IL": {
-            "zoneName": "Izrael"
-        },
-        "IN-AN": {
-            "countryName": "Indie",
-            "zoneName": "Andamany i Nikobary"
-        },
-        "IN-AP": {
-            "countryName": "Indie",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Indie",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Indie",
-            "zoneName": "Asam"
-        },
-        "IN-BR": {
-            "countryName": "Indie",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Indie",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Indie",
-            "zoneName": "Delhi"
-        },
-        "IN-GA": {
-            "countryName": "Indie",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Indie",
-            "zoneName": "Gudźarat"
-        },
-        "IN-HP": {
-            "countryName": "Indie",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Indie",
-            "zoneName": "Hariana"
-        },
-        "IN-JH": {
-            "countryName": "Indie",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Indie",
-            "zoneName": "Dżammu i Kaszmir"
-        },
-        "IN-KA": {
-            "countryName": "Indie",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Indie",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Indie",
-            "zoneName": "Maharasztra"
-        },
-        "IN-ML": {
-            "countryName": "Indie",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Indie",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Indie",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Indie",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Indie",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Indie",
-            "zoneName": "Orisa"
-        },
-        "IN-PB": {
-            "countryName": "Indie",
-            "zoneName": "Pendżab"
-        },
-        "IN-PY": {
-            "countryName": "Indie",
-            "zoneName": "Puducherry"
-        },
-        "IN-RJ": {
-            "countryName": "Indie",
-            "zoneName": "Radżastan"
-        },
-        "IN-SK": {
-            "countryName": "Indie",
-            "zoneName": "Sikkim"
-        },
-        "IN-TL": {
-            "countryName": "Indie",
-            "zoneName": "Tamilnadu"
-        },
-        "IN-TR": {
-            "countryName": "Indie",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Indie",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Indie",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Indie",
-            "zoneName": "Bengal Zachodni"
-        },
-        "IO": {
-            "zoneName": "Brytyjskie Terytorium Oceanu Indyjskiego"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IS": {
-            "zoneName": "Islandia"
-        },
-        "IT": {
-            "zoneName": "Włochy"
-        },
-        "IT-CNO": {
-            "countryName": "Włochy",
-            "zoneName": "Centralna północ"
-        },
-        "IT-CSO": {
-            "countryName": "Włochy",
-            "zoneName": "Centralne południe"
-        },
-        "IT-NO": {
-            "countryName": "Włochy",
-            "zoneName": "Północ"
-        },
-        "IT-SAR": {
-            "countryName": "Włochy",
-            "zoneName": "Sardynia"
-        },
-        "IT-SIC": {
-            "countryName": "Włochy",
-            "zoneName": "Sycylia"
-        },
-        "IT-SO": {
-            "countryName": "Włochy",
-            "zoneName": "Południe"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamajka"
-        },
-        "JO": {
-            "zoneName": "Jordania"
-        },
-        "JP": {
-            "zoneName": "Japonia"
-        },
-        "JP-CB": {
-            "countryName": "Japonia",
-            "zoneName": "Region Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japonia",
-            "zoneName": "Region Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japonia",
-            "zoneName": "Hokkaido"
-        },
-        "JP-HR": {
-            "countryName": "Japonia",
-            "zoneName": "Region Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japonia",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japonia",
-            "zoneName": "Kiusiu"
-        },
-        "JP-ON": {
-            "countryName": "Japonia",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japonia",
-            "zoneName": "Sikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japonia",
-            "zoneName": "Region Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japonia",
-            "zoneName": "Tokio"
-        },
-        "KE": {
-            "zoneName": "Kenia"
-        },
-        "KG": {
-            "zoneName": "Kirgistan"
-        },
-        "KH": {
-            "zoneName": "Kambodża"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Komory"
-        },
-        "KP": {
-            "zoneName": "Korea Północna"
-        },
-        "KR": {
-            "zoneName": "Korea Południowa"
-        },
-        "KW": {
-            "zoneName": "Kuwejt"
-        },
-        "KZ": {
-            "zoneName": "Kazachstan"
-        },
-        "LB": {
-            "zoneName": "Liban"
-        },
-        "LT": {
-            "zoneName": "Litwa"
-        },
-        "LU": {
-            "zoneName": "Luksemburg"
-        },
-        "LV": {
-            "zoneName": "Łotwa"
-        },
-        "LY": {
-            "zoneName": "Libia"
-        },
-        "MA": {
-            "zoneName": "Maroko"
-        },
-        "MD": {
-            "zoneName": "Mołdawia"
-        },
-        "ME": {
-            "zoneName": "Czarnogóra"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Wyspy Marshalla"
-        },
-        "MK": {
-            "zoneName": "Macedonia Północna"
-        },
-        "MM": {
-            "zoneName": "Mjanma"
-        },
-        "MO": {
-            "zoneName": "Makau"
-        },
-        "MP": {
-            "zoneName": "Martynika"
-        },
-        "MR": {
-            "zoneName": "Mauretania"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MV": {
-            "zoneName": "Malediwy"
-        },
-        "MX": {
-            "zoneName": "Meksyk"
-        },
-        "MX-BC": {
-            "countryName": "Meksyk",
-            "zoneName": "Kalifornia Dolna"
-        },
-        "MX-CE": {
-            "countryName": "Meksyk",
-            "zoneName": "Meksyk Centralny"
-        },
-        "MX-NE": {
-            "countryName": "Meksyk",
-            "zoneName": "Meksyk Północno Wschodni"
-        },
-        "MX-NO": {
-            "countryName": "Meksyk",
-            "zoneName": "Meksyk Północny"
-        },
-        "MX-NW": {
-            "countryName": "Meksyk",
-            "zoneName": "Meksyk Północno zachodni"
-        },
-        "MX-OC": {
-            "countryName": "Meksyk",
-            "zoneName": "Meksyk Zachodni"
-        },
-        "MX-OR": {
-            "countryName": "Meksyk",
-            "zoneName": "Meksyk Południowo Zachoni"
-        },
-        "MX-PN": {
-            "countryName": "Meksyk",
-            "zoneName": "Meksyk Południowo Wschodni"
-        },
-        "MY-EM": {
-            "countryName": "Malezja",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malezja",
-            "zoneName": "Malezja zachodnia"
-        },
-        "MZ": {
-            "zoneName": "Mozambik"
-        },
-        "NC": {
-            "zoneName": "Nowa Kaledonia"
-        },
-        "NF": {
-            "zoneName": "Wyspa Norfolk"
-        },
-        "NI": {
-            "zoneName": "Nikaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabakh"
-        },
-        "NL": {
-            "zoneName": "Holandia"
-        },
-        "NO": {
-            "zoneName": "Norwegia"
-        },
-        "NO-NO1": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia południowo-wschodnia"
-        },
-        "NO-NO2": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia południowo-zachodnia"
-        },
-        "NO-NO3": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia środkowa"
-        },
-        "NO-NO4": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia północna"
-        },
-        "NO-NO5": {
-            "countryName": "Norwegia",
-            "zoneName": "Norwegia zachodnia"
-        },
-        "NZ": {
-            "zoneName": "Nowa Zelandia"
-        },
-        "NZ-NZA": {
-            "countryName": "Nowa Zelandia",
-            "zoneName": "Wyspy Auckland"
-        },
-        "NZ-NZC": {
-            "countryName": "Nowa Zelandia",
-            "zoneName": "Wyspy Chatham"
-        },
-        "NZ-NZST": {
-            "countryName": "Nowa Zelandia",
-            "zoneName": "Wyspa Stewart"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PG": {
-            "zoneName": "Papua-Nowa Gwinea"
-        },
-        "PH": {
-            "zoneName": "Filipiny"
-        },
-        "PL": {
-            "zoneName": "Polska"
-        },
-        "PM": {
-            "zoneName": "Saint-Pierre i Miquelon"
-        },
-        "PS": {
-            "zoneName": "Palestyna"
-        },
-        "PT": {
-            "zoneName": "Portugalia"
-        },
-        "PT-AC": {
-            "countryName": "Portugalia",
-            "zoneName": "Azory"
-        },
-        "PT-MA": {
-            "countryName": "Portugalia",
-            "zoneName": "Madera"
-        },
-        "PY": {
-            "zoneName": "Paragwaj"
-        },
-        "QA": {
-            "zoneName": "Katar"
-        },
-        "RO": {
-            "zoneName": "Rumunia"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Rosja"
-        },
-        "RU-EU": {
-            "zoneName": "Rosja"
-        },
-        "RU-AS": {
-            "zoneName": "Rosja"
-        },
-        "RU-FE": {
-            "countryName": "Rosja",
-            "zoneName": "Rosyjski Daleki Wschód"
-        },
-        "RU-1": {
-            "countryName": "Rosja",
-            "zoneName": "Rosja europejska i Ural"
-        },
-        "RU-2": {
-            "countryName": "Rosja",
-            "zoneName": "Syberia"
-        },
-        "RU-KGD": {
-            "countryName": "Rosja",
-            "zoneName": "Kaliningrad"
-        },
-        "SA": {
-            "zoneName": "Arabia Saudyjska"
-        },
-        "SE": {
-            "zoneName": "Szwecja"
-        },
-        "SG": {
-            "zoneName": "Singapur"
-        },
-        "SI": {
-            "zoneName": "Słowenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard i Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Słowacja"
-        },
-        "SR": {
-            "zoneName": "Surinam"
-        },
-        "SS": {
-            "zoneName": "Sudan Południowy"
-        },
-        "ST": {
-            "zoneName": "Wyspy Świętego Tomasza i Książęca"
-        },
-        "SV": {
-            "zoneName": "Salwador"
-        },
-        "SZ": {
-            "zoneName": "Suazi"
-        },
-        "TD": {
-            "zoneName": "Czad"
-        },
-        "TJ": {
-            "zoneName": "Tadżykistan"
-        },
-        "TL": {
-            "zoneName": "Timor Wschodni"
-        },
-        "TH": {
-            "zoneName": "Tajlandia"
-        },
-        "TN": {
-            "zoneName": "Tunezja"
-        },
-        "TR": {
-            "zoneName": "Turcja"
-        },
-        "TT": {
-            "zoneName": "Trynidad i Tobago"
-        },
-        "TW": {
-            "zoneName": "Tajwan"
-        },
-        "UA": {
-            "zoneName": "Ukraina"
-        },
-        "UY": {
-            "zoneName": "Urugwaj"
-        },
-        "VE": {
-            "zoneName": "Wenezuela"
-        },
-        "VN": {
-            "zoneName": "Wietnam"
-        },
-        "YE": {
-            "zoneName": "Jemen"
-        },
-        "ZA": {
-            "zoneName": "Południowa Afryka"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        },
-        "AD": {
-            "zoneName": "Andora"
-        },
-        "AG": {
-            "zoneName": "Antigua i Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AM": {
-            "zoneName": "Armenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarktyka"
-        },
-        "AS": {
-            "zoneName": "Samoa Amerykańskie"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmania"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermudy"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BQ": {
-            "zoneName": "Holandia Karaibska"
-        },
-        "BS": {
-            "zoneName": "Bahamy"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Wyspa Bouveta"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        }
+        "AE": { "zoneName": "Zjednoczone Emiraty Arabskie" },
+        "AL": { "zoneName": "Albania" },
+        "AF": { "zoneName": "Afganistan" },
+        "AR": { "zoneName": "Argentyna" },
+        "AT": { "zoneName": "Austria" },
+        "AUS-NSW": { "countryName": "Australia", "zoneName": "Nowa Południowa Walia" },
+        "AUS-NT": { "countryName": "Australia", "zoneName": "Terytorium Północne" },
+        "AUS-QLD": { "countryName": "Australia", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australia", "zoneName": "Australia Południowa" },
+        "AUS-TAS": { "countryName": "Australia", "zoneName": "Tasmania" },
+        "AUS-VIC": { "countryName": "Australia", "zoneName": "Wiktoria" },
+        "AUS-WA": { "countryName": "Australia", "zoneName": "Australia Zachodnia" },
+        "AX": { "zoneName": "Wyspy Alandzkie" },
+        "AZ": { "zoneName": "Azerbejdżan" },
+        "BA": { "zoneName": "Bośnia i Hercegowina" },
+        "BD": { "zoneName": "Bangladesz" },
+        "BE": { "zoneName": "Belgia" },
+        "BG": { "zoneName": "Bułgaria" },
+        "BH": { "zoneName": "Bahrajn" },
+        "BO": { "zoneName": "Boliwia" },
+        "BR-CS": { "countryName": "Brazylia", "zoneName": "Brazylia centralna" },
+        "BR-N": { "countryName": "Brazylia", "zoneName": "Brazylia północna" },
+        "BR-NE": { "countryName": "Brazylia", "zoneName": "Brazylia północno-wschodnia" },
+        "BR-S": { "countryName": "Brazylia", "zoneName": "Brazylia południowa" },
+        "BY": { "zoneName": "Białoruś" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "Kolumbia Brytyjska" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Nowa Fundlandia i Labrador" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "Nowy Brunszwik" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Terytoria Północno-Zachodnie" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nowa Szkocja" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Wyspa Księcia Edwarda" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Quebec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Jukon" },
+        "CD": { "zoneName": "Demokratyczna Republika Konga" },
+        "CF": { "zoneName": "Republika Środkowoafrykańska" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Szwajcaria" },
+        "CI": { "zoneName": "Wybrzeże Kości Słoniowej" },
+        "CL": { "zoneName": "Chile" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Chiny" },
+        "CO": { "zoneName": "Kolumbia" },
+        "CR": { "zoneName": "Kostaryka" },
+        "CU": { "zoneName": "Kuba" },
+        "CV": { "zoneName": "Republika Zielonego Przylądka" },
+        "CZ": { "zoneName": "Czechy" },
+        "DE": { "zoneName": "Niemcy" },
+        "DJ": { "zoneName": "Dżibuti" },
+        "DK": { "zoneName": "Dania" },
+        "DK-DK1": { "countryName": "Dania", "zoneName": "Dania zachodnia" },
+        "DK-DK2": { "countryName": "Denmark", "zoneName": "Dania wschodnia" },
+        "DK-BHM": { "countryName": "Dania", "zoneName": "Bornholm" },
+        "DO": { "zoneName": "Dominikana" },
+        "DZ": { "zoneName": "Algieria" },
+        "EC": { "zoneName": "Ekwador" },
+        "EE": { "zoneName": "Estonia" },
+        "EG": { "zoneName": "Egipt" },
+        "EH": { "zoneName": "Sahara Zachodnia" },
+        "ER": { "zoneName": "Erytrea" },
+        "ES": { "zoneName": "Hiszpania" },
+        "ES-IB": { "countryName": "Hiszpania", "zoneName": "Baleary" },
+        "ES-IB-ML": { "countryName": "Hiszpania", "zoneName": "Majorka" },
+        "ES-IB-MN": { "countryName": "Hiszpania", "zoneName": "Minorka" },
+        "ES-IB-IB": { "countryName": "Hiszpania", "zoneName": "Ibiza" },
+        "ES-IB-FM": { "countryName": "Hiszpania", "zoneName": "Formentera" },
+        "ES-CN-FVLZ": { "countryName": "Hiszpania", "zoneName": "Fuerteventura i Lanzarote" },
+        "ES-CN-GC": { "countryName": "Hiszpania", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Hiszpania", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Hiszpania", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "Hiszpania", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Hiszpania", "zoneName": "Teneryfa" },
+        "ET": { "zoneName": "Etiopia" },
+        "FI": { "zoneName": "Finlandia" },
+        "FO": { "zoneName": "Wyspy Owcze" },
+        "FR": { "zoneName": "Francja" },
+        "FR-COR": { "countryName": "Francja", "zoneName": "Korsyka" },
+        "GB": { "zoneName": "Wielka Brytania" },
+        "GB-NIR": { "zoneName": "Irlandia Północna" },
+        "GE": { "zoneName": "Gruzja" },
+        "GF": { "zoneName": "Gujana Francuska" },
+        "GL": { "zoneName": "Grenlandia" },
+        "GN": { "zoneName": "Gwinea" },
+        "GQ": { "zoneName": "Gwinea Równikowa" },
+        "GR": { "zoneName": "Grecja" },
+        "GR-IS": { "countryName": "Grecja", "zoneName": "Wyspy Egejskie" },
+        "GT": { "zoneName": "Gwatemala" },
+        "GW": { "zoneName": "Gwinea Bissau" },
+        "GY": { "zoneName": "Gujana" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Chorwacja" },
+        "HU": { "zoneName": "Węgry" },
+        "ID": { "zoneName": "Indonezja" },
+        "IE": { "zoneName": "Irlandia" },
+        "IL": { "zoneName": "Izrael" },
+        "IN-AN": { "countryName": "Indie", "zoneName": "Andamany i Nikobary" },
+        "IN-AP": { "countryName": "Indie", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Indie", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Indie", "zoneName": "Asam" },
+        "IN-BR": { "countryName": "Indie", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Indie", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Indie", "zoneName": "Delhi" },
+        "IN-GA": { "countryName": "Indie", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Indie", "zoneName": "Gudźarat" },
+        "IN-HP": { "countryName": "Indie", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Indie", "zoneName": "Hariana" },
+        "IN-JH": { "countryName": "Indie", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Indie", "zoneName": "Dżammu i Kaszmir" },
+        "IN-KA": { "countryName": "Indie", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Indie", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Indie", "zoneName": "Maharasztra" },
+        "IN-ML": { "countryName": "Indie", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Indie", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Indie", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Indie", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Indie", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Indie", "zoneName": "Orisa" },
+        "IN-PB": { "countryName": "Indie", "zoneName": "Pendżab" },
+        "IN-PY": { "countryName": "Indie", "zoneName": "Puducherry" },
+        "IN-RJ": { "countryName": "Indie", "zoneName": "Radżastan" },
+        "IN-SK": { "countryName": "Indie", "zoneName": "Sikkim" },
+        "IN-TL": { "countryName": "Indie", "zoneName": "Tamilnadu" },
+        "IN-TR": { "countryName": "Indie", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Indie", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Indie", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Indie", "zoneName": "Bengal Zachodni" },
+        "IO": { "zoneName": "Brytyjskie Terytorium Oceanu Indyjskiego" },
+        "IQ": { "zoneName": "Irak" },
+        "IS": { "zoneName": "Islandia" },
+        "IT": { "zoneName": "Włochy" },
+        "IT-CNO": { "countryName": "Włochy", "zoneName": "Centralna północ" },
+        "IT-CSO": { "countryName": "Włochy", "zoneName": "Centralne południe" },
+        "IT-NO": { "countryName": "Włochy", "zoneName": "Północ" },
+        "IT-SAR": { "countryName": "Włochy", "zoneName": "Sardynia" },
+        "IT-SIC": { "countryName": "Włochy", "zoneName": "Sycylia" },
+        "IT-SO": { "countryName": "Włochy", "zoneName": "Południe" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamajka" },
+        "JO": { "zoneName": "Jordania" },
+        "JP": { "zoneName": "Japonia" },
+        "JP-CB": { "countryName": "Japonia", "zoneName": "Region Chūbu" },
+        "JP-CG": { "countryName": "Japonia", "zoneName": "Region Chūgoku" },
+        "JP-HKD": { "countryName": "Japonia", "zoneName": "Hokkaido" },
+        "JP-HR": { "countryName": "Japonia", "zoneName": "Region Hokuriku" },
+        "JP-KN": { "countryName": "Japonia", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japonia", "zoneName": "Kiusiu" },
+        "JP-ON": { "countryName": "Japonia", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japonia", "zoneName": "Sikoku" },
+        "JP-TH": { "countryName": "Japonia", "zoneName": "Region Tōhoku" },
+        "JP-TK": { "countryName": "Japonia", "zoneName": "Tokio" },
+        "KE": { "zoneName": "Kenia" },
+        "KG": { "zoneName": "Kirgistan" },
+        "KH": { "zoneName": "Kambodża" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Komory" },
+        "KP": { "zoneName": "Korea Północna" },
+        "KR": { "zoneName": "Korea Południowa" },
+        "KW": { "zoneName": "Kuwejt" },
+        "KZ": { "zoneName": "Kazachstan" },
+        "LB": { "zoneName": "Liban" },
+        "LT": { "zoneName": "Litwa" },
+        "LU": { "zoneName": "Luksemburg" },
+        "LV": { "zoneName": "Łotwa" },
+        "LY": { "zoneName": "Libia" },
+        "MA": { "zoneName": "Maroko" },
+        "MD": { "zoneName": "Mołdawia" },
+        "ME": { "zoneName": "Czarnogóra" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Wyspy Marshalla" },
+        "MK": { "zoneName": "Macedonia Północna" },
+        "MM": { "zoneName": "Mjanma" },
+        "MO": { "zoneName": "Makau" },
+        "MP": { "zoneName": "Martynika" },
+        "MR": { "zoneName": "Mauretania" },
+        "MT": { "zoneName": "Malta" },
+        "MV": { "zoneName": "Malediwy" },
+        "MX": { "zoneName": "Meksyk" },
+        "MX-BC": { "countryName": "Meksyk", "zoneName": "Kalifornia Dolna" },
+        "MX-CE": { "countryName": "Meksyk", "zoneName": "Meksyk Centralny" },
+        "MX-NE": { "countryName": "Meksyk", "zoneName": "Meksyk Północno Wschodni" },
+        "MX-NO": { "countryName": "Meksyk", "zoneName": "Meksyk Północny" },
+        "MX-NW": { "countryName": "Meksyk", "zoneName": "Meksyk Północno zachodni" },
+        "MX-OC": { "countryName": "Meksyk", "zoneName": "Meksyk Zachodni" },
+        "MX-OR": { "countryName": "Meksyk", "zoneName": "Meksyk Południowo Zachoni" },
+        "MX-PN": { "countryName": "Meksyk", "zoneName": "Meksyk Południowo Wschodni" },
+        "MY-EM": { "countryName": "Malezja", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malezja", "zoneName": "Malezja zachodnia" },
+        "MZ": { "zoneName": "Mozambik" },
+        "NC": { "zoneName": "Nowa Kaledonia" },
+        "NF": { "zoneName": "Wyspa Norfolk" },
+        "NI": { "zoneName": "Nikaragua" },
+        "NKR": { "zoneName": "Nagorno-Karabakh" },
+        "NL": { "zoneName": "Holandia" },
+        "NO": { "zoneName": "Norwegia" },
+        "NO-NO1": { "countryName": "Norwegia", "zoneName": "Norwegia południowo-wschodnia" },
+        "NO-NO2": { "countryName": "Norwegia", "zoneName": "Norwegia południowo-zachodnia" },
+        "NO-NO3": { "countryName": "Norwegia", "zoneName": "Norwegia środkowa" },
+        "NO-NO4": { "countryName": "Norwegia", "zoneName": "Norwegia północna" },
+        "NO-NO5": { "countryName": "Norwegia", "zoneName": "Norwegia zachodnia" },
+        "NZ": { "zoneName": "Nowa Zelandia" },
+        "NZ-NZA": { "countryName": "Nowa Zelandia", "zoneName": "Wyspy Auckland" },
+        "NZ-NZC": { "countryName": "Nowa Zelandia", "zoneName": "Wyspy Chatham" },
+        "NZ-NZST": { "countryName": "Nowa Zelandia", "zoneName": "Wyspa Stewart" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PG": { "zoneName": "Papua-Nowa Gwinea" },
+        "PH": { "zoneName": "Filipiny" },
+        "PL": { "zoneName": "Polska" },
+        "PM": { "zoneName": "Saint-Pierre i Miquelon" },
+        "PS": { "zoneName": "Palestyna" },
+        "PT": { "zoneName": "Portugalia" },
+        "PT-AC": { "countryName": "Portugalia", "zoneName": "Azory" },
+        "PT-MA": { "countryName": "Portugalia", "zoneName": "Madera" },
+        "PY": { "zoneName": "Paragwaj" },
+        "QA": { "zoneName": "Katar" },
+        "RO": { "zoneName": "Rumunia" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Rosja" },
+        "RU-EU": { "zoneName": "Rosja" },
+        "RU-AS": { "zoneName": "Rosja" },
+        "RU-FE": { "countryName": "Rosja", "zoneName": "Rosyjski Daleki Wschód" },
+        "RU-1": { "countryName": "Rosja", "zoneName": "Rosja europejska i Ural" },
+        "RU-2": { "countryName": "Rosja", "zoneName": "Syberia" },
+        "RU-KGD": { "countryName": "Rosja", "zoneName": "Kaliningrad" },
+        "SA": { "zoneName": "Arabia Saudyjska" },
+        "SE": { "zoneName": "Szwecja" },
+        "SG": { "zoneName": "Singapur" },
+        "SI": { "zoneName": "Słowenia" },
+        "SJ": { "zoneName": "Svalbard i Jan Mayen" },
+        "SK": { "zoneName": "Słowacja" },
+        "SR": { "zoneName": "Surinam" },
+        "SS": { "zoneName": "Sudan Południowy" },
+        "ST": { "zoneName": "Wyspy Świętego Tomasza i Książęca" },
+        "SV": { "zoneName": "Salwador" },
+        "SZ": { "zoneName": "Suazi" },
+        "TD": { "zoneName": "Czad" },
+        "TJ": { "zoneName": "Tadżykistan" },
+        "TL": { "zoneName": "Timor Wschodni" },
+        "TH": { "zoneName": "Tajlandia" },
+        "TN": { "zoneName": "Tunezja" },
+        "TR": { "zoneName": "Turcja" },
+        "TT": { "zoneName": "Trynidad i Tobago" },
+        "TW": { "zoneName": "Tajwan" },
+        "UA": { "zoneName": "Ukraina" },
+        "UY": { "zoneName": "Urugwaj" },
+        "VE": { "zoneName": "Wenezuela" },
+        "VN": { "zoneName": "Wietnam" },
+        "YE": { "zoneName": "Jemen" },
+        "ZA": { "zoneName": "Południowa Afryka" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" },
+        "AD": { "zoneName": "Andora" },
+        "AG": { "zoneName": "Antigua i Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AM": { "zoneName": "Armenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarktyka" },
+        "AS": { "zoneName": "Samoa Amerykańskie" },
+        "AUS-TAS-KI": { "countryName": "Tasmania" },
+        "AW": { "zoneName": "Aruba" },
+        "BB": { "zoneName": "Barbados" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermudy" },
+        "BN": { "zoneName": "Brunei" },
+        "BQ": { "zoneName": "Holandia Karaibska" },
+        "BS": { "zoneName": "Bahamy" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Wyspa Bouveta" },
+        "BW": { "zoneName": "Botswana" },
+        "BZ": { "zoneName": "Belize" }
     }
 }

--- a/web/public/locales/pt-BR.json
+++ b/web/public/locales/pt-BR.json
@@ -6,15 +6,9 @@
         "datasources": "fonte de dados",
         "contribute": "Contribua <a href=\"%s\" target=\"_blank\">adicionando seu país ou território</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Áreas",
-        "about": "Sobre"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Áreas", "about": "Sobre" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Mapeando o impacto climático da eletricidade"
-        },
+        "view1": { "subtitle": "Mapeando o impacto climático da eletricidade" },
         "view2": {
             "header": "Veja o quanto de CO₂ é emitido para produzir sua eletricidade em tempo real.",
             "text": "As áreas através do mundo são coloridas pela sua Intensidade de Carbono (incluindo todos os gases de efeito estufa) da eletricidade consumida. Quanto mais verde a cor, mais ecológica é a eletricidade."
@@ -51,14 +45,14 @@
         "search": "Pesquise por país ou área"
     },
     "country-history": {
-        "carbonintensity24h": "Intensidade da emissão de carbono nas últimas 24 horas",
-        "emissions24h": "Emissões de carbono nas últimas 24 horas",
-        "emissionsorigin24h": "Origem da emissão de carbono nas últimas 24 horas",
-        "emissionsproduction24h": "Emissões de carbono produzida nas últimas 24 horas",
-        "electricityorigin24h": "Origem da eletricidade nas últimas 24 horas",
-        "electricityproduction24h": "Produção de eletricidade nas últimas 24 horas",
-        "electricityprices24h": "Preço da eletricidade nas últimas 24 horas",
-        "Getdata": "Obtenha dados históricos, marginais e de previsão da API"
+        "Getdata": "Obtenha dados históricos, marginais e de previsão da API",
+        "carbonintensity": { "hourly": "Intensidade da emissão de carbono nas últimas 24 horas" },
+        "emissionsorigin": { "hourly": "Origem da emissão de carbono nas últimas 24 horas" },
+        "emissionsproduction": { "hourly": "Emissões de carbono produzida nas últimas 24 horas" },
+        "electricityorigin": { "hourly": "Origem da eletricidade nas últimas 24 horas" },
+        "electricityproduction": { "hourly": "Produção de eletricidade nas últimas 24 horas" },
+        "electricityprices": { "hourly": "Preço da eletricidade nas últimas 24 horas" },
+        "emissions": { "hourly": "Emissões de carbono nas últimas 24 horas" }
     },
     "footer": {
         "foundbugs": "Encontrou erros ou tem alguma sugestão? Contate-nos",
@@ -204,1199 +198,360 @@
         "contribute-answer": "Sim! O ElectricityMap é um projeto de código aberto, possibilitado apenas por nossos colaboradores voluntários. Se você quer ajudar a desenvolver o mapa, adicionando fontes de dados para novas áreas, criando novas funcionalidades ou corrigindo bugs, fique à vontade para se juntar a nós no <a href=\"https://github.com/corradio/electricitymap/\" target=\"_blank\">github</a>."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Emirados Árabes Unidos"
-        },
-        "AF": {
-            "zoneName": "Afeganistão"
-        },
-        "AG": {
-            "zoneName": "Antigua e Barbudas"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albânia"
-        },
-        "AM": {
-            "zoneName": "Armênia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antártica"
-        },
-        "AS": {
-            "zoneName": "Samoa Americana"
-        },
-        "AT": {
-            "zoneName": "Áustria"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AUS-NSW": {
-            "countryName": "Austrália",
-            "zoneName": "Nova Gales do Sul"
-        },
-        "AUS-NT": {
-            "countryName": "Austrália",
-            "zoneName": "Território do Norte"
-        },
-        "AUS-QLD": {
-            "countryName": "Austrália",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Austrália",
-            "zoneName": "Austrália do Sul"
-        },
-        "AUS-TAS": {
-            "countryName": "Austrália",
-            "zoneName": "Tasmânia"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmânia",
-            "zoneName": "King Island"
-        },
-        "AUS-VIC": {
-            "countryName": "Austrália",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Austrália",
-            "zoneName": "Austrália Ocidental"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Ilhas de Aland"
-        },
-        "AZ": {
-            "zoneName": "Azerbaijão"
-        },
-        "BA": {
-            "zoneName": "Bósnia e Herzegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Bélgica"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgária"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermudas"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolívia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Santo Eustáquio e Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brasil",
-            "zoneName": "Central"
-        },
-        "BR-I": {
-            "countryName": "Brasil",
-            "zoneName": "Sistemas Isolados"
-        },
-        "BR-N": {
-            "countryName": "Brasil",
-            "zoneName": "Norte"
-        },
-        "BR-NE": {
-            "countryName": "Brasil",
-            "zoneName": "Nordeste"
-        },
-        "BR-S": {
-            "countryName": "Brasil",
-            "zoneName": "Sul"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Butão"
-        },
-        "BV": {
-            "zoneName": "Ilha Bouvet"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Bielorrússia"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Canadá",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Canadá",
-            "zoneName": "Colúmbia Britânica"
-        },
-        "CA-MB": {
-            "countryName": "Canadá",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Canadá",
-            "zoneName": "Terra Nova e Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Canadá",
-            "zoneName": "Nova Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Canadá",
-            "zoneName": "Territórios do Noroeste"
-        },
-        "CA-NS": {
-            "countryName": "Canadá",
-            "zoneName": "Nova Escócia"
-        },
-        "CA-NU": {
-            "countryName": "Canadá",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Canadá",
-            "zoneName": "Ontário"
-        },
-        "CA-PE": {
-            "countryName": "Canadá",
-            "zoneName": "Ilha do Príncipe Eduardo"
-        },
-        "CA-QC": {
-            "countryName": "Canadá",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Canadá",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Canadá",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Ilhas Cocos"
-        },
-        "CD": {
-            "zoneName": "República Democrática do Congo"
-        },
-        "CF": {
-            "zoneName": "República Centro-Africana"
-        },
-        "CG": {
-            "zoneName": "Congo"
-        },
-        "CH": {
-            "zoneName": "Suíça"
-        },
-        "CI": {
-            "zoneName": "Ivory Coast"
-        },
-        "CK": {
-            "zoneName": "Cook Islands"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Aysén"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Magallanes"
-        },
-        "CL-SEN": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico Nacional"
-        },
-        "CM": {
-            "zoneName": "Camarões"
-        },
-        "CN": {
-            "zoneName": "China"
-        },
-        "CO": {
-            "zoneName": "Colômbia"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Cuba"
-        },
-        "CV": {
-            "zoneName": "Cabo Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Ilha do Natal"
-        },
-        "CY": {
-            "zoneName": "Chipre"
-        },
-        "CZ": {
-            "zoneName": "Chéquia"
-        },
-        "DE": {
-            "zoneName": "Alemanha"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Dinamarca"
-        },
-        "DK-DK1": {
-            "countryName": "Dinamarca",
-            "zoneName": "Dinamarca ocidental"
-        },
-        "DK-DK2": {
-            "countryName": "Dinamarca",
-            "zoneName": "Dinamarca oriental"
-        },
-        "DK-BHM": {
-            "countryName": "Dinamarca",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "República Dominicana"
-        },
-        "DZ": {
-            "zoneName": "Argélia"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Estônia"
-        },
-        "EG": {
-            "zoneName": "Egito"
-        },
-        "EH": {
-            "zoneName": "Saara Ocidental"
-        },
-        "ER": {
-            "zoneName": "Eritreia"
-        },
-        "ES": {
-            "zoneName": "Espanha"
-        },
-        "ES-IB-FO": {
-            "countryName": "Espanha",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Espanha",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Espanha",
-            "zoneName": "Maiorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Espanha",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Espanha",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Espanha",
-            "zoneName": "Grã-Canária"
-        },
-        "ES-CN-HI": {
-            "countryName": "Espanha",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Espanha",
-            "zoneName": "Ilha de La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Espanha",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Espanha",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Etiópia"
-        },
-        "FI": {
-            "zoneName": "Finlândia"
-        },
-        "FJ": {
-            "zoneName": "Fiji"
-        },
-        "FK": {
-            "zoneName": "Ilhas Falkland"
-        },
-        "FM": {
-            "zoneName": "Micronésia"
-        },
-        "FO": {
-            "zoneName": "Ilhas Faroé"
-        },
-        "FR": {
-            "zoneName": "França"
-        },
-        "FR-COR": {
-            "countryName": "França",
-            "zoneName": "Corsica"
-        },
-        "GA": {
-            "zoneName": "Gabão"
-        },
-        "GB": {
-            "zoneName": "Grã-Bretanha"
-        },
-        "GB-NIR": {
-            "zoneName": "Irlanda do Norte"
-        },
-        "GB-ORK": {
-            "countryName": "Grã-Bretanha",
-            "zoneName": "Ilhas Orkney"
-        },
-        "GB-SHI": {
-            "countryName": "Grã-Bretanha",
-            "zoneName": "Ilhas Shetland"
-        },
-        "GB-ZET": {
-            "countryName": "Grã-Bretanha",
-            "zoneName": "Ilhas Shetland"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Geórgia"
-        },
-        "GF": {
-            "zoneName": "Guiana Francesa"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Gana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Groenlândia"
-        },
-        "GM": {
-            "zoneName": "Gâmbia"
-        },
-        "GN": {
-            "zoneName": "Guiné"
-        },
-        "GP": {
-            "zoneName": "Guadalupe"
-        },
-        "GQ": {
-            "zoneName": "Guiné Equatorial"
-        },
-        "GR": {
-            "zoneName": "Grécia"
-        },
-        "GR-IS": {
-            "countryName": "Grécia",
-            "zoneName": "Ilhas do mar Egeu"
-        },
-        "GS": {
-            "zoneName": "Geórgia do Sul e Ilhas Sandwich do Sul"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guiné-bissau"
-        },
-        "GY": {
-            "zoneName": "Guiana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Ilha Heard e Ilhas McDonald"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Croácia"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Hungria"
-        },
-        "ID": {
-            "zoneName": "Indonésia"
-        },
-        "IE": {
-            "zoneName": "Irlanda"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Ilha de Man"
-        },
-        "IN-AN": {
-            "countryName": "Índia",
-            "zoneName": "Ilhas Andaman e Nicobar"
-        },
-        "IN-AP": {
-            "countryName": "Índia",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Índia",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Índia",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "Índia",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Índia",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Índia",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "Índia",
-            "zoneName": "Dadra e Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "Índia",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Índia",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "Índia",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Índia",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "Índia",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Índia",
-            "zoneName": "Jammu e Caxemira"
-        },
-        "IN-KA": {
-            "countryName": "Índia",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Índia",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Índia",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "Índia",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Índia",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Índia",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Índia",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Índia",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Índia",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "Índia",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "Índia",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "Índia",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "Índia",
-            "zoneName": "Sikkim"
-        },
-        "IN-TL": {
-            "countryName": "Índia",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "Índia",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Índia",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Índia",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Índia",
-            "zoneName": "Bengala Ocidental"
-        },
-        "IO": {
-            "zoneName": "Território Britânico do Oceano Índico"
-        },
-        "IQ": {
-            "zoneName": "Iraque"
-        },
-        "IQ-KUR": {
-            "countryName": "Iraque",
-            "zoneName": "Curdistão"
-        },
-        "IR": {
-            "zoneName": "Irã"
-        },
-        "IS": {
-            "zoneName": "Islândia"
-        },
-        "IT": {
-            "zoneName": "Itália"
-        },
-        "IT-CNO": {
-            "countryName": "Itália",
-            "zoneName": "Norte Central"
-        },
-        "IT-CSO": {
-            "countryName": "Itália",
-            "zoneName": "Centro sul"
-        },
-        "IT-NO": {
-            "countryName": "Itália",
-            "zoneName": "Norte"
-        },
-        "IT-SAR": {
-            "countryName": "Itália",
-            "zoneName": "Sardenha"
-        },
-        "IT-SIC": {
-            "countryName": "Itália",
-            "zoneName": "Sicilia"
-        },
-        "IT-SO": {
-            "countryName": "Itália",
-            "zoneName": "Sul"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaica"
-        },
-        "JO": {
-            "zoneName": "Jordânia"
-        },
-        "JP-CB": {
-            "countryName": "Japão",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japão",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japão",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Japão",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japão",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japão",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Japão",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japão",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japão",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japão",
-            "zoneName": "Tóquio"
-        },
-        "KE": {
-            "zoneName": "Quênia"
-        },
-        "KG": {
-            "zoneName": "Quirguistão"
-        },
-        "KH": {
-            "zoneName": "Camboja"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comoros"
-        },
-        "KN": {
-            "zoneName": "São Cristóvão e Neves"
-        },
-        "KP": {
-            "zoneName": "Coreia do Norte"
-        },
-        "KR": {
-            "zoneName": "Coreia do Sul"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Ilhas Cayman"
-        },
-        "KZ": {
-            "zoneName": "Cazaquistão"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Líbano"
-        },
-        "LC": {
-            "zoneName": "Santa Lúcia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Libéria"
-        },
-        "LS": {
-            "zoneName": "Lesoto"
-        },
-        "LT": {
-            "zoneName": "Lituânia"
-        },
-        "LU": {
-            "zoneName": "Luxemburgo"
-        },
-        "LV": {
-            "zoneName": "Letônia"
-        },
-        "LY": {
-            "zoneName": "Líbia"
-        },
-        "MA": {
-            "zoneName": "Marrocos"
-        },
-        "MC": {
-            "zoneName": "Mônaco"
-        },
-        "MD": {
-            "zoneName": "Moldávia"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "são Martinho",
-            "zoneName": "Francesa"
-        },
-        "MG": {
-            "zoneName": "Madagáscar"
-        },
-        "MH": {
-            "zoneName": "Ilhas Marshall"
-        },
-        "MK": {
-            "zoneName": "Macedônia do Norte"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Birmânia"
-        },
-        "MN": {
-            "zoneName": "Mongólia"
-        },
-        "MO": {
-            "zoneName": "Macau"
-        },
-        "MP": {
-            "zoneName": "Ilhas Marianas do Norte"
-        },
-        "MQ": {
-            "zoneName": "Martinica"
-        },
-        "MR": {
-            "zoneName": "Mauritânia"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Maurícia"
-        },
-        "MV": {
-            "zoneName": "Maldivas"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "México"
-        },
-        "MX-BC": {
-            "countryName": "México",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "México",
-            "zoneName": "Central"
-        },
-        "MX-NE": {
-            "countryName": "México",
-            "zoneName": "Nordeste"
-        },
-        "MX-NO": {
-            "countryName": "México",
-            "zoneName": "Norte"
-        },
-        "MX-NW": {
-            "countryName": "México",
-            "zoneName": "Noroeste"
-        },
-        "MX-OC": {
-            "countryName": "México",
-            "zoneName": "Ocidental"
-        },
-        "MX-OR": {
-            "countryName": "México",
-            "zoneName": "Oriental"
-        },
-        "MX-PN": {
-            "countryName": "México",
-            "zoneName": "Península"
-        },
-        "MY-EM": {
-            "countryName": "Malaysia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malaysia",
-            "zoneName": "Península"
-        },
-        "MZ": {
-            "zoneName": "Moçambique"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "Nova Caledônia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Ilha Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigéria"
-        },
-        "NI": {
-            "zoneName": "Nicarágua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabakh"
-        },
-        "NL": {
-            "zoneName": "Países Baixos"
-        },
-        "NO-NO1": {
-            "countryName": "Noruega",
-            "zoneName": "Sudeste da Noruega"
-        },
-        "NO-NO2": {
-            "countryName": "Noruega",
-            "zoneName": "Sudeste da Noruega"
-        },
-        "NO-NO3": {
-            "countryName": "Noruega",
-            "zoneName": "Noruega média"
-        },
-        "NO-NO4": {
-            "countryName": "Noruega",
-            "zoneName": "Noruega do Norte"
-        },
-        "NO-NO5": {
-            "countryName": "Noruega",
-            "zoneName": "Noruega Ocidental"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Nova Zelândia"
-        },
-        "NZ-NZA": {
-            "countryName": "Nova Zelândia",
-            "zoneName": "Ilhas de Auckland"
-        },
-        "NZ-NZC": {
-            "countryName": "Nova Zelândia",
-            "zoneName": "Ilhas Chatham"
-        },
-        "OM": {
-            "zoneName": "Omã"
-        },
-        "PA": {
-            "zoneName": "Panamá"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Polinésia Francesa"
-        },
-        "PG": {
-            "zoneName": "Papua Nova Guiné"
-        },
-        "PH": {
-            "zoneName": "Filipinas"
-        },
-        "PK": {
-            "zoneName": "Paquistão"
-        },
-        "PL": {
-            "zoneName": "Polônia"
-        },
-        "PM": {
-            "zoneName": "São Pedro e Miquelão"
-        },
-        "PN": {
-            "zoneName": "Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Estado da Palestina"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Açores"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguai"
-        },
-        "QA": {
-            "zoneName": "Catar"
-        },
-        "RE": {
-            "zoneName": "Reunião"
-        },
-        "RO": {
-            "zoneName": "Romênia"
-        },
-        "RS": {
-            "zoneName": "Sérvia"
-        },
-        "RU": {
-            "zoneName": "Rússia"
-        },
-        "RU-1": {
-            "countryName": "Rússia",
-            "zoneName": "Rússia e Ural europeus"
-        },
-        "RU-2": {
-            "countryName": "Rússia",
-            "zoneName": "Sibéria"
-        },
-        "RU-EU": {
-            "zoneName": "Rússia",
-            "countryName": "Rússia"
-        },
-        "RU-AS": {
-            "zoneName": "Rússia",
-            "countryName": "Rússia"
-        },
-        "RU-KGD": {
-            "countryName": "Rússia",
-            "zoneName": "Kaliningrado"
-        },
-        "RW": {
-            "zoneName": "Ruanda"
-        },
-        "SA": {
-            "zoneName": "Arábia Saudita"
-        },
-        "SB": {
-            "zoneName": "Ilhas Salomão"
-        },
-        "SC": {
-            "zoneName": "Seychelles"
-        },
-        "SD": {
-            "zoneName": "Sudão"
-        },
-        "SE": {
-            "zoneName": "Suécia"
-        },
-        "SG": {
-            "zoneName": "Singapura"
-        },
-        "SH": {
-            "zoneName": "Santa Helena, Ascensão e Tristão da Cunha"
-        },
-        "SI": {
-            "zoneName": "Eslovênia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard and Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Eslováquia"
-        },
-        "SL": {
-            "zoneName": "Serra Leoa"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somália"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Sudão do Sul"
-        },
-        "ST": {
-            "zoneName": "São Tomé e Príncipe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Holandês"
-        },
-        "SY": {
-            "zoneName": "Síria"
-        },
-        "SZ": {
-            "zoneName": "Suazilândia"
-        },
-        "TC": {
-            "zoneName": "Ilhas Turcas e Caicos"
-        },
-        "TD": {
-            "zoneName": "Chade"
-        },
-        "TF": {
-            "zoneName": "Territórios Franceses do Sul"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Tailândia"
-        },
-        "TJ": {
-            "zoneName": "Tajiquistão"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Turcomenistão"
-        },
-        "TN": {
-            "zoneName": "Tunísia"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turquia"
-        },
-        "TT": {
-            "zoneName": "Trinidad e Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tanzânia"
-        },
-        "UA": {
-            "zoneName": "Ucrânia"
-        },
-        "UA-CR": {
-            "countryName": "Crimea",
-            "zoneName": "Ucrânia"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Ilhas Menores Distantes dos Estados Unidos"
-        },
-        "US-HI-HA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Havaí"
-        },
-        "US-HI-KA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Oahu"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Emirados Árabes Unidos" },
+        "AF": { "zoneName": "Afeganistão" },
+        "AG": { "zoneName": "Antigua e Barbudas" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albânia" },
+        "AM": { "zoneName": "Armênia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antártica" },
+        "AS": { "zoneName": "Samoa Americana" },
+        "AT": { "zoneName": "Áustria" },
+        "AR": { "zoneName": "Argentina" },
+        "AUS-NSW": { "countryName": "Austrália", "zoneName": "Nova Gales do Sul" },
+        "AUS-NT": { "countryName": "Austrália", "zoneName": "Território do Norte" },
+        "AUS-QLD": { "countryName": "Austrália", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Austrália", "zoneName": "Austrália do Sul" },
+        "AUS-TAS": { "countryName": "Austrália", "zoneName": "Tasmânia" },
+        "AUS-TAS-KI": { "countryName": "Tasmânia", "zoneName": "King Island" },
+        "AUS-VIC": { "countryName": "Austrália", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Austrália", "zoneName": "Austrália Ocidental" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Ilhas de Aland" },
+        "AZ": { "zoneName": "Azerbaijão" },
+        "BA": { "zoneName": "Bósnia e Herzegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Bélgica" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgária" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermudas" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolívia" },
+        "BQ": { "zoneName": "Bonaire, Santo Eustáquio e Saba" },
+        "BR-CS": { "countryName": "Brasil", "zoneName": "Central" },
+        "BR-I": { "countryName": "Brasil", "zoneName": "Sistemas Isolados" },
+        "BR-N": { "countryName": "Brasil", "zoneName": "Norte" },
+        "BR-NE": { "countryName": "Brasil", "zoneName": "Nordeste" },
+        "BR-S": { "countryName": "Brasil", "zoneName": "Sul" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Butão" },
+        "BV": { "zoneName": "Ilha Bouvet" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Bielorrússia" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Canadá", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Canadá", "zoneName": "Colúmbia Britânica" },
+        "CA-MB": { "countryName": "Canadá", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Canadá", "zoneName": "Terra Nova e Labrador" },
+        "CA-NB": { "countryName": "Canadá", "zoneName": "Nova Brunswick" },
+        "CA-NT": { "countryName": "Canadá", "zoneName": "Territórios do Noroeste" },
+        "CA-NS": { "countryName": "Canadá", "zoneName": "Nova Escócia" },
+        "CA-NU": { "countryName": "Canadá", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Canadá", "zoneName": "Ontário" },
+        "CA-PE": { "countryName": "Canadá", "zoneName": "Ilha do Príncipe Eduardo" },
+        "CA-QC": { "countryName": "Canadá", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Canadá", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Canadá", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Ilhas Cocos" },
+        "CD": { "zoneName": "República Democrática do Congo" },
+        "CF": { "zoneName": "República Centro-Africana" },
+        "CG": { "zoneName": "Congo" },
+        "CH": { "zoneName": "Suíça" },
+        "CI": { "zoneName": "Ivory Coast" },
+        "CK": { "zoneName": "Cook Islands" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Aysén" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Magallanes" },
+        "CL-SEN": { "countryName": "Chile", "zoneName": "Sistema Eléctrico Nacional" },
+        "CM": { "zoneName": "Camarões" },
+        "CN": { "zoneName": "China" },
+        "CO": { "zoneName": "Colômbia" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Cuba" },
+        "CV": { "zoneName": "Cabo Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Ilha do Natal" },
+        "CY": { "zoneName": "Chipre" },
+        "CZ": { "zoneName": "Chéquia" },
+        "DE": { "zoneName": "Alemanha" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Dinamarca" },
+        "DK-DK1": { "countryName": "Dinamarca", "zoneName": "Dinamarca ocidental" },
+        "DK-DK2": { "countryName": "Dinamarca", "zoneName": "Dinamarca oriental" },
+        "DK-BHM": { "countryName": "Dinamarca", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "República Dominicana" },
+        "DZ": { "zoneName": "Argélia" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Estônia" },
+        "EG": { "zoneName": "Egito" },
+        "EH": { "zoneName": "Saara Ocidental" },
+        "ER": { "zoneName": "Eritreia" },
+        "ES": { "zoneName": "Espanha" },
+        "ES-IB-FO": { "countryName": "Espanha", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Espanha", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Espanha", "zoneName": "Maiorca" },
+        "ES-IB-ME": { "countryName": "Espanha", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Espanha", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Espanha", "zoneName": "Grã-Canária" },
+        "ES-CN-HI": { "countryName": "Espanha", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Espanha", "zoneName": "Ilha de La Gomera" },
+        "ES-CN-LP": { "countryName": "Espanha", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Espanha", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Etiópia" },
+        "FI": { "zoneName": "Finlândia" },
+        "FJ": { "zoneName": "Fiji" },
+        "FK": { "zoneName": "Ilhas Falkland" },
+        "FM": { "zoneName": "Micronésia" },
+        "FO": { "zoneName": "Ilhas Faroé" },
+        "FR": { "zoneName": "França" },
+        "FR-COR": { "countryName": "França", "zoneName": "Corsica" },
+        "GA": { "zoneName": "Gabão" },
+        "GB": { "zoneName": "Grã-Bretanha" },
+        "GB-NIR": { "zoneName": "Irlanda do Norte" },
+        "GB-ORK": { "countryName": "Grã-Bretanha", "zoneName": "Ilhas Orkney" },
+        "GB-SHI": { "countryName": "Grã-Bretanha", "zoneName": "Ilhas Shetland" },
+        "GB-ZET": { "countryName": "Grã-Bretanha", "zoneName": "Ilhas Shetland" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Geórgia" },
+        "GF": { "zoneName": "Guiana Francesa" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Gana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Groenlândia" },
+        "GM": { "zoneName": "Gâmbia" },
+        "GN": { "zoneName": "Guiné" },
+        "GP": { "zoneName": "Guadalupe" },
+        "GQ": { "zoneName": "Guiné Equatorial" },
+        "GR": { "zoneName": "Grécia" },
+        "GR-IS": { "countryName": "Grécia", "zoneName": "Ilhas do mar Egeu" },
+        "GS": { "zoneName": "Geórgia do Sul e Ilhas Sandwich do Sul" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guiné-bissau" },
+        "GY": { "zoneName": "Guiana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Ilha Heard e Ilhas McDonald" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Croácia" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Hungria" },
+        "ID": { "zoneName": "Indonésia" },
+        "IE": { "zoneName": "Irlanda" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Ilha de Man" },
+        "IN-AN": { "countryName": "Índia", "zoneName": "Ilhas Andaman e Nicobar" },
+        "IN-AP": { "countryName": "Índia", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Índia", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Índia", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "Índia", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Índia", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Índia", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "Índia", "zoneName": "Dadra e Nagar Haveli" },
+        "IN-GA": { "countryName": "Índia", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Índia", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "Índia", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Índia", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "Índia", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Índia", "zoneName": "Jammu e Caxemira" },
+        "IN-KA": { "countryName": "Índia", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Índia", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Índia", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "Índia", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Índia", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Índia", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Índia", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Índia", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Índia", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "Índia", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "Índia", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "Índia", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "Índia", "zoneName": "Sikkim" },
+        "IN-TL": { "countryName": "Índia", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "Índia", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Índia", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Índia", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Índia", "zoneName": "Bengala Ocidental" },
+        "IO": { "zoneName": "Território Britânico do Oceano Índico" },
+        "IQ": { "zoneName": "Iraque" },
+        "IQ-KUR": { "countryName": "Iraque", "zoneName": "Curdistão" },
+        "IR": { "zoneName": "Irã" },
+        "IS": { "zoneName": "Islândia" },
+        "IT": { "zoneName": "Itália" },
+        "IT-CNO": { "countryName": "Itália", "zoneName": "Norte Central" },
+        "IT-CSO": { "countryName": "Itália", "zoneName": "Centro sul" },
+        "IT-NO": { "countryName": "Itália", "zoneName": "Norte" },
+        "IT-SAR": { "countryName": "Itália", "zoneName": "Sardenha" },
+        "IT-SIC": { "countryName": "Itália", "zoneName": "Sicilia" },
+        "IT-SO": { "countryName": "Itália", "zoneName": "Sul" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaica" },
+        "JO": { "zoneName": "Jordânia" },
+        "JP-CB": { "countryName": "Japão", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Japão", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Japão", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Japão", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japão", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japão", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Japão", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japão", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japão", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Japão", "zoneName": "Tóquio" },
+        "KE": { "zoneName": "Quênia" },
+        "KG": { "zoneName": "Quirguistão" },
+        "KH": { "zoneName": "Camboja" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comoros" },
+        "KN": { "zoneName": "São Cristóvão e Neves" },
+        "KP": { "zoneName": "Coreia do Norte" },
+        "KR": { "zoneName": "Coreia do Sul" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Ilhas Cayman" },
+        "KZ": { "zoneName": "Cazaquistão" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Líbano" },
+        "LC": { "zoneName": "Santa Lúcia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Libéria" },
+        "LS": { "zoneName": "Lesoto" },
+        "LT": { "zoneName": "Lituânia" },
+        "LU": { "zoneName": "Luxemburgo" },
+        "LV": { "zoneName": "Letônia" },
+        "LY": { "zoneName": "Líbia" },
+        "MA": { "zoneName": "Marrocos" },
+        "MC": { "zoneName": "Mônaco" },
+        "MD": { "zoneName": "Moldávia" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "são Martinho", "zoneName": "Francesa" },
+        "MG": { "zoneName": "Madagáscar" },
+        "MH": { "zoneName": "Ilhas Marshall" },
+        "MK": { "zoneName": "Macedônia do Norte" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Birmânia" },
+        "MN": { "zoneName": "Mongólia" },
+        "MO": { "zoneName": "Macau" },
+        "MP": { "zoneName": "Ilhas Marianas do Norte" },
+        "MQ": { "zoneName": "Martinica" },
+        "MR": { "zoneName": "Mauritânia" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Maurícia" },
+        "MV": { "zoneName": "Maldivas" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "México" },
+        "MX-BC": { "countryName": "México", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "México", "zoneName": "Central" },
+        "MX-NE": { "countryName": "México", "zoneName": "Nordeste" },
+        "MX-NO": { "countryName": "México", "zoneName": "Norte" },
+        "MX-NW": { "countryName": "México", "zoneName": "Noroeste" },
+        "MX-OC": { "countryName": "México", "zoneName": "Ocidental" },
+        "MX-OR": { "countryName": "México", "zoneName": "Oriental" },
+        "MX-PN": { "countryName": "México", "zoneName": "Península" },
+        "MY-EM": { "countryName": "Malaysia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malaysia", "zoneName": "Península" },
+        "MZ": { "zoneName": "Moçambique" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "Nova Caledônia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Ilha Norfolk" },
+        "NG": { "zoneName": "Nigéria" },
+        "NI": { "zoneName": "Nicarágua" },
+        "NKR": { "zoneName": "Nagorno-Karabakh" },
+        "NL": { "zoneName": "Países Baixos" },
+        "NO-NO1": { "countryName": "Noruega", "zoneName": "Sudeste da Noruega" },
+        "NO-NO2": { "countryName": "Noruega", "zoneName": "Sudeste da Noruega" },
+        "NO-NO3": { "countryName": "Noruega", "zoneName": "Noruega média" },
+        "NO-NO4": { "countryName": "Noruega", "zoneName": "Noruega do Norte" },
+        "NO-NO5": { "countryName": "Noruega", "zoneName": "Noruega Ocidental" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Nova Zelândia" },
+        "NZ-NZA": { "countryName": "Nova Zelândia", "zoneName": "Ilhas de Auckland" },
+        "NZ-NZC": { "countryName": "Nova Zelândia", "zoneName": "Ilhas Chatham" },
+        "OM": { "zoneName": "Omã" },
+        "PA": { "zoneName": "Panamá" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Polinésia Francesa" },
+        "PG": { "zoneName": "Papua Nova Guiné" },
+        "PH": { "zoneName": "Filipinas" },
+        "PK": { "zoneName": "Paquistão" },
+        "PL": { "zoneName": "Polônia" },
+        "PM": { "zoneName": "São Pedro e Miquelão" },
+        "PN": { "zoneName": "Pitcairn" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Estado da Palestina" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Açores" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguai" },
+        "QA": { "zoneName": "Catar" },
+        "RE": { "zoneName": "Reunião" },
+        "RO": { "zoneName": "Romênia" },
+        "RS": { "zoneName": "Sérvia" },
+        "RU": { "zoneName": "Rússia" },
+        "RU-1": { "countryName": "Rússia", "zoneName": "Rússia e Ural europeus" },
+        "RU-2": { "countryName": "Rússia", "zoneName": "Sibéria" },
+        "RU-EU": { "zoneName": "Rússia", "countryName": "Rússia" },
+        "RU-AS": { "zoneName": "Rússia", "countryName": "Rússia" },
+        "RU-KGD": { "countryName": "Rússia", "zoneName": "Kaliningrado" },
+        "RW": { "zoneName": "Ruanda" },
+        "SA": { "zoneName": "Arábia Saudita" },
+        "SB": { "zoneName": "Ilhas Salomão" },
+        "SC": { "zoneName": "Seychelles" },
+        "SD": { "zoneName": "Sudão" },
+        "SE": { "zoneName": "Suécia" },
+        "SG": { "zoneName": "Singapura" },
+        "SH": { "zoneName": "Santa Helena, Ascensão e Tristão da Cunha" },
+        "SI": { "zoneName": "Eslovênia" },
+        "SJ": { "zoneName": "Svalbard and Jan Mayen" },
+        "SK": { "zoneName": "Eslováquia" },
+        "SL": { "zoneName": "Serra Leoa" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somália" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Sudão do Sul" },
+        "ST": { "zoneName": "São Tomé e Príncipe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Holandês" },
+        "SY": { "zoneName": "Síria" },
+        "SZ": { "zoneName": "Suazilândia" },
+        "TC": { "zoneName": "Ilhas Turcas e Caicos" },
+        "TD": { "zoneName": "Chade" },
+        "TF": { "zoneName": "Territórios Franceses do Sul" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Tailândia" },
+        "TJ": { "zoneName": "Tajiquistão" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Turcomenistão" },
+        "TN": { "zoneName": "Tunísia" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turquia" },
+        "TT": { "zoneName": "Trinidad e Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tanzânia" },
+        "UA": { "zoneName": "Ucrânia" },
+        "UA-CR": { "countryName": "Crimea", "zoneName": "Ucrânia" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Ilhas Menores Distantes dos Estados Unidos" },
+        "US-HI-HA": { "countryName": "Estados Unidos da América", "zoneName": "Havaí" },
+        "US-HI-KA": { "countryName": "Estados Unidos da América", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Estados Unidos da América", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Estados Unidos da América", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Estados Unidos da América", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Estados Unidos da América", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Estados Unidos da América", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Estados Unidos da América", "zoneName": "Oahu" },
         "US-CAL-BANC": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Autoridade de equilíbrio do norte da Califórnia"
@@ -1405,30 +560,15 @@
             "countryName": "Estados Unidos da América",
             "zoneName": "Operador de sistema independente da Califórnia"
         },
-        "US-CAL-IID": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Distrito Imperial de Irrigação"
-        },
+        "US-CAL-IID": { "countryName": "Estados Unidos da América", "zoneName": "Distrito Imperial de Irrigação" },
         "US-CAL-LDWP": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Departamento de Água e Energia de Los Angeles"
         },
-        "US-CAL-TIDC": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Distrito de Irrigação de Turlock"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Duke Energy Progresso Leste"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Duke Energy Progress Oeste"
-        },
-        "US-CAR-DUK": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Duke Energy Carolinas"
-        },
+        "US-CAL-TIDC": { "countryName": "Estados Unidos da América", "zoneName": "Distrito de Irrigação de Turlock" },
+        "US-CAR-CPLE": { "countryName": "Estados Unidos da América", "zoneName": "Duke Energy Progresso Leste" },
+        "US-CAR-CPLW": { "countryName": "Estados Unidos da América", "zoneName": "Duke Energy Progress Oeste" },
+        "US-CAR-DUK": { "countryName": "Estados Unidos da América", "zoneName": "Duke Energy Carolinas" },
         "US-CAR-SC": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Autoridade de serviço público da Carolina do Sul"
@@ -1445,62 +585,26 @@
             "countryName": "Estados Unidos da América",
             "zoneName": "Administração de energia do sudoeste"
         },
-        "US-CENT-SWPP": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Power Pool do sudoeste"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Power Pool do Florida Municipal"
-        },
-        "US-FLA-FPC": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "City Of Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "JEA"
-        },
+        "US-CENT-SWPP": { "countryName": "Estados Unidos da América", "zoneName": "Power Pool do sudoeste" },
+        "US-FLA-FMPP": { "countryName": "Estados Unidos da América", "zoneName": "Power Pool do Florida Municipal" },
+        "US-FLA-FPC": { "countryName": "Estados Unidos da América", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "Estados Unidos da América", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "Estados Unidos da América", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "Estados Unidos da América", "zoneName": "City Of Homestead" },
+        "US-FLA-JEA": { "countryName": "Estados Unidos da América", "zoneName": "JEA" },
         "US-FLA-NSB": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Comissão de serviços públicos de New Smyrna Beach"
         },
-        "US-FLA-SEC": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Cidade de Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Companhia elétrica de Tampa"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "PJM Interconnection, Llc"
-        },
+        "US-FLA-SEC": { "countryName": "Estados Unidos da América", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "Estados Unidos da América", "zoneName": "Cidade de Tallahassee" },
+        "US-FLA-TEC": { "countryName": "Estados Unidos da América", "zoneName": "Companhia elétrica de Tampa" },
+        "US-MIDA-PJM": { "countryName": "Estados Unidos da América", "zoneName": "PJM Interconnection, Llc" },
         "US-MIDW-AECI": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Associated Electric Cooperative, Inc."
         },
-        "US-MIDW-GLHB": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "GridLiance"
-        },
+        "US-MIDW-GLHB": { "countryName": "Estados Unidos da América", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1509,78 +613,33 @@
             "countryName": "Estados Unidos da América",
             "zoneName": "Operador Independente do Sistema de Transmissão Midcontinent, Inc."
         },
-        "US-NE-ISNE": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Cooperativa Avangrid Renewables"
-        },
+        "US-NE-ISNE": { "countryName": "Estados Unidos da América", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "Estados Unidos da América", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "Estados Unidos da América", "zoneName": "Cooperativa Avangrid Renewables" },
         "US-NW-BPAT": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Administração de energia de Bonneville"
         },
-        "US-NW-CHPD": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "PUD No. 1 do Condado de Chelan"
-        },
-        "US-NW-DOPD": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "PUD No. 1 do Condado de Chelan"
-        },
+        "US-NW-CHPD": { "countryName": "Estados Unidos da América", "zoneName": "PUD No. 1 do Condado de Chelan" },
+        "US-NW-DOPD": { "countryName": "Estados Unidos da América", "zoneName": "PUD No. 1 do Condado de Chelan" },
         "US-NW-GCPD": {
             "countryName": "Estados Unidos da América",
             "zoneName": "PUD No. 2 de Grant County, Washington"
         },
-        "US-NW-GRID": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Energia do Noroeste"
-        },
-        "US-NW-PACE": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Portland General Electric Company"
-        },
+        "US-NW-GRID": { "countryName": "Estados Unidos da América", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "Estados Unidos da América", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "Estados Unidos da América", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "Estados Unidos da América", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "Estados Unidos da América", "zoneName": "Energia do Noroeste" },
+        "US-NW-PACE": { "countryName": "Estados Unidos da América", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "Estados Unidos da América", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "Estados Unidos da América", "zoneName": "Portland General Electric Company" },
         "US-NW-PSCO": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Empresa de serviço público do Colorado"
         },
-        "US-NW-PSEI": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NW-PSEI": { "countryName": "Estados Unidos da América", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "Estados Unidos da América", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Cidade de Tacoma, Departamento de Serviços Públicos, Divisão de Iluminação"
@@ -1593,46 +652,22 @@
             "countryName": "Estados Unidos da América",
             "zoneName": "Western Area Power Administration UGP West"
         },
-        "US-NW-WWA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
+        "US-NW-WWA": { "countryName": "Estados Unidos da América", "zoneName": "Naturener Wind Watch, Llc" },
         "US-NY-NYIS": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Operador de sistema independente de Nova York"
         },
-        "US-SE-AEC": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Southeastern Power Administration"
-        },
+        "US-SE-AEC": { "countryName": "Estados Unidos da América", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "Estados Unidos da América", "zoneName": "Southeastern Power Administration" },
         "US-SE-SOCO": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Southern Company Services, Inc. - Trans"
         },
-        "US-SW-AZPS": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Gila River Power, LLC"
-        },
+        "US-SW-AZPS": { "countryName": "Estados Unidos da América", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "Estados Unidos da América", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "Estados Unidos da América", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "Estados Unidos da América", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "Estados Unidos da América", "zoneName": "Gila River Power, LLC" },
         "US-SW-HGMA": {
             "countryName": "Estados Unidos da América",
             "zoneName": "New Harquahala Generating Company, LLC"
@@ -1641,118 +676,44 @@
             "countryName": "Estados Unidos da América",
             "zoneName": "Empresa de serviço público do Novo México"
         },
-        "US-SW-SRP": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Projeto Salt River"
-        },
-        "US-SW-TEPC": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-SW-SRP": { "countryName": "Estados Unidos da América", "zoneName": "Projeto Salt River" },
+        "US-SW-TEPC": { "countryName": "Estados Unidos da América", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Administração de energia da área oeste - Região do deserto do sudoeste"
         },
-        "US-TEN-TVA": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Autoridade do Vale do Tennessee"
-        },
+        "US-TEN-TVA": { "countryName": "Estados Unidos da América", "zoneName": "Autoridade do Vale do Tennessee" },
         "US-TEX-ERCO": {
             "countryName": "Estados Unidos da América",
             "zoneName": "Electric Reliability Council Of Texas, Inc."
         },
-        "UY": {
-            "zoneName": "Uruguai"
-        },
-        "UZ": {
-            "zoneName": "Uzbequistão"
-        },
-        "VA": {
-            "zoneName": "Cidade do Vaticano"
-        },
-        "VC": {
-            "zoneName": "São Vicente e Granadinas"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Ilhas virgens",
-            "zoneName": "Ilhas virgens"
-        },
-        "VI": {
-            "countryName": "Estados Unidos da América",
-            "zoneName": "Ilhas virgens"
-        },
-        "VN": {
-            "zoneName": "Vietnã"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis e Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Norte do Chipre"
-        },
-        "YE": {
-            "zoneName": "Iémen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "África do Sul"
-        },
-        "ZM": {
-            "zoneName": "Zâmbia"
-        },
-        "ZW": {
-            "zoneName": "Zimbábue"
-        },
-        "AUS-TAS-CBI": {
-            "countryName": "Austrália",
-            "zoneName": "Ilha Cape Barren"
-        },
-        "AUS-TAS-FI": {
-            "countryName": "Austrália",
-            "zoneName": "Ilha Flinders"
-        },
-        "AUS-WA-RI": {
-            "countryName": "Austrália",
-            "zoneName": "Ilha Rottnest"
-        },
-        "CA-NL-LB": {
-            "countryName": "Canadá",
-            "zoneName": "Labrador"
-        },
-        "CA-NL-NF": {
-            "countryName": "Canadá",
-            "zoneName": "Newfoundland"
-        },
-        "CL-CHP": {
-            "countryName": "Chile",
-            "zoneName": "Ilha de Páscoa"
-        },
-        "IN-TN": {
-            "countryName": "Índia",
-            "zoneName": "Tamil Nadu"
-        },
-        "NZ-NZST": {
-            "countryName": "Nova Zelândia",
-            "zoneName": "Ilha Stewart"
-        },
-        "RU-FE": {
-            "countryName": "Rússia",
-            "zoneName": "Extremo Oriente"
-        },
-        "XK": {
-            "zoneName": "Kosovo"
-        }
+        "UY": { "zoneName": "Uruguai" },
+        "UZ": { "zoneName": "Uzbequistão" },
+        "VA": { "zoneName": "Cidade do Vaticano" },
+        "VC": { "zoneName": "São Vicente e Granadinas" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Ilhas virgens", "zoneName": "Ilhas virgens" },
+        "VI": { "countryName": "Estados Unidos da América", "zoneName": "Ilhas virgens" },
+        "VN": { "zoneName": "Vietnã" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis e Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Norte do Chipre" },
+        "YE": { "zoneName": "Iémen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "África do Sul" },
+        "ZM": { "zoneName": "Zâmbia" },
+        "ZW": { "zoneName": "Zimbábue" },
+        "AUS-TAS-CBI": { "countryName": "Austrália", "zoneName": "Ilha Cape Barren" },
+        "AUS-TAS-FI": { "countryName": "Austrália", "zoneName": "Ilha Flinders" },
+        "AUS-WA-RI": { "countryName": "Austrália", "zoneName": "Ilha Rottnest" },
+        "CA-NL-LB": { "countryName": "Canadá", "zoneName": "Labrador" },
+        "CA-NL-NF": { "countryName": "Canadá", "zoneName": "Newfoundland" },
+        "CL-CHP": { "countryName": "Chile", "zoneName": "Ilha de Páscoa" },
+        "IN-TN": { "countryName": "Índia", "zoneName": "Tamil Nadu" },
+        "NZ-NZST": { "countryName": "Nova Zelândia", "zoneName": "Ilha Stewart" },
+        "RU-FE": { "countryName": "Rússia", "zoneName": "Extremo Oriente" },
+        "XK": { "zoneName": "Kosovo" }
     },
     "windDataError": "Dados eólicos estão indisponíveis",
     "solarDataError": "Dados solares estão indisponíveis"

--- a/web/public/locales/ro.json
+++ b/web/public/locales/ro.json
@@ -6,15 +6,9 @@
         "datasources": "surse de date",
         "contribute": "Contribuie prin <a href=\"%s\" target=\"_blank\">adăugarea teritoriului tău</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Zone",
-        "about": "Despre"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Zone", "about": "Despre" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Cartografierea impactului electricității asupra climei"
-        },
+        "view1": { "subtitle": "Cartografierea impactului electricității asupra climei" },
         "view2": {
             "header": "Vezi cantitatea de CO₂ emisă pentru a produce electricitate, în timp real.",
             "text": "Colorăm zone de pe glob în funcție de nivelul de gaze cu efect de seră emise pentru producerea electricității consumate în zona respectivă. Cu cât e mai verde zona, cu atât e mai curată electriciatea pentru mediu."
@@ -51,14 +45,14 @@
         "search": "Căutați zone"
     },
     "country-history": {
-        "carbonintensity24h": "Concentrația de dioxid de carbon din ultimele 24 de ore",
-        "emissions24h": "Emisii din ultimele 24 de ore",
-        "emissionsorigin24h": "Originea emisiilor din ultimele 24 de ore",
-        "emissionsproduction24h": "Emisii produse în ultimele 24 de ore",
-        "electricityorigin24h": "Originea electricității din ultimele 24 de ore",
-        "electricityproduction24h": "Electricitatea produsă în ultimele 24 de ore",
-        "electricityprices24h": "Prețul electricității din ultimele 24 de ore",
-        "Getdata": "Acces la date din trecut, la interval de o ora, date în timp real, și predicții cu electricityMap API"
+        "Getdata": "Acces la date din trecut, la interval de o ora, date în timp real, și predicții cu electricityMap API",
+        "carbonintensity": { "hourly": "Concentrația de dioxid de carbon din ultimele 24 de ore" },
+        "emissionsorigin": { "hourly": "Originea emisiilor din ultimele 24 de ore" },
+        "emissionsproduction": { "hourly": "Emisii produse în ultimele 24 de ore" },
+        "electricityorigin": { "hourly": "Originea electricității din ultimele 24 de ore" },
+        "electricityproduction": { "hourly": "Electricitatea produsă în ultimele 24 de ore" },
+        "electricityprices": { "hourly": "Prețul electricității din ultimele 24 de ore" },
+        "emissions": { "hourly": "Emisii din ultimele 24 de ore" }
     },
     "footer": {
         "foundbugs": "Ați găsit defecte sau aveți sugestii? Reportați-le",
@@ -201,1227 +195,367 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publishes data and images on the <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> for information purposes. It makes no claims of correctness nor provides any form of warranties, and reserves the right to change the content at any time or to remove parts without having to inform you of this. electricityMap assumes no responsibility for, and shall not be liable for, any damages or expenses you may incur as a result of any inaccuracy, incompleteness, untimeliness or obsolescence of the electricityMap, or the information derived from them.  It is not allowed to include this webpage, or any of its individual elements, in another webpage, without formal prior written consent.<br><br> All intellectual property rights belong to the rightful owners and its licensors. Copying, distribution and any other use of these materials, in particular the energy data, is not permitted without the written permission of electricityMap, except and only to the extent otherwise provided in regulations of mandatory law (such as the right to quote), unless specified otherwise for specific materials. <br><br>This disclaimer may be updated from time to time."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "United Arab Emirates"
-        },
-        "AF": {
-            "zoneName": "Afghanistan"
-        },
-        "AG": {
-            "zoneName": "Antigua and Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albania"
-        },
-        "AM": {
-            "zoneName": "Armenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarctica"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AS": {
-            "zoneName": "American Samoa"
-        },
-        "AT": {
-            "zoneName": "Austria"
-        },
-        "AUS-NSW": {
-            "countryName": "Australia",
-            "zoneName": "New South Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Australia",
-            "zoneName": "Northern Territory"
-        },
-        "AUS-QLD": {
-            "countryName": "Australia",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australia",
-            "zoneName": "South Australia"
-        },
-        "AUS-TAS": {
-            "countryName": "Australia",
-            "zoneName": "Tasmania"
-        },
-        "AUS-TAS-CBI": {
-            "countryName": "Australia",
-            "zoneName": "Cape Barren Island"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Australia",
-            "zoneName": "King Island"
-        },
-        "AUS-TAS-FI": {
-            "countryName": "Australia",
-            "zoneName": "Flinders Island"
-        },
-        "AUS-VIC": {
-            "countryName": "Australia",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australia",
-            "zoneName": "Western Australia"
-        },
-        "AUS-WA-RI": {
-            "countryName": "Australia",
-            "zoneName": "Rottnest Island"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Åland Islands"
-        },
-        "AZ": {
-            "zoneName": "Azerbaijan"
-        },
-        "BA": {
-            "zoneName": "Bosnia and Herzegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Belgium"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgaria"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius and Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brazil",
-            "zoneName": "Central Brazil"
-        },
-        "BR-N": {
-            "countryName": "Brazil",
-            "zoneName": "North Brazil"
-        },
-        "BR-NE": {
-            "countryName": "Brazil",
-            "zoneName": "North-East Brazil"
-        },
-        "BR-S": {
-            "countryName": "Brazil",
-            "zoneName": "South Brazil"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Bouvet Island"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Belarus"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Canada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Canada",
-            "zoneName": "British Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Canada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NB": {
-            "countryName": "Canada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NL": {
-            "countryName": "Canada",
-            "zoneName": "Newfoundland and Labrador"
-        },
-        "CA-NL-LB": {
-            "countryName": "Canada",
-            "zoneName": "Labrador"
-        },
-        "CA-NL-NF": {
-            "countryName": "Canada",
-            "zoneName": "Newfoundland"
-        },
-        "CA-NS": {
-            "countryName": "Canada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NT": {
-            "countryName": "Canada",
-            "zoneName": "Northwest Territories"
-        },
-        "CA-NU": {
-            "countryName": "Canada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Canada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Canada",
-            "zoneName": "Prince Edward Island"
-        },
-        "CA-QC": {
-            "countryName": "Canada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Canada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Canada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Cocos Islands"
-        },
-        "CD": {
-            "zoneName": "Democratic Republic of the Congo"
-        },
-        "CF": {
-            "zoneName": "Central African Republic"
-        },
-        "CG": {
-            "zoneName": "Congo"
-        },
-        "CH": {
-            "zoneName": "Switzerland"
-        },
-        "CI": {
-            "zoneName": "Ivory Coast"
-        },
-        "CK": {
-            "zoneName": "Cook Islands"
-        },
-        "CL-CHP": {
-            "countryName": "Chile",
-            "zoneName": "Easter Island"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Aysén"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Magallanes"
-        },
-        "CL-SEN": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico Nacional"
-        },
-        "CM": {
-            "zoneName": "Cameroon"
-        },
-        "CN": {
-            "zoneName": "China"
-        },
-        "CO": {
-            "zoneName": "Colombia"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Cuba"
-        },
-        "CV": {
-            "zoneName": "Cabo Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Christmas Island"
-        },
-        "CY": {
-            "zoneName": "Cyprus"
-        },
-        "CZ": {
-            "zoneName": "Czechia"
-        },
-        "DE": {
-            "zoneName": "Germany"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Denmark"
-        },
-        "DK-DK1": {
-            "countryName": "Denmark",
-            "zoneName": "West Denmark"
-        },
-        "DK-DK2": {
-            "countryName": "Denmark",
-            "zoneName": "East Denmark"
-        },
-        "DK-BHM": {
-            "countryName": "Denmark",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "Dominican Republic"
-        },
-        "DZ": {
-            "zoneName": "Algeria"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Estonia"
-        },
-        "EG": {
-            "zoneName": "Egypt"
-        },
-        "EH": {
-            "zoneName": "Western Sahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Spain"
-        },
-        "ES-IB-FO": {
-            "countryName": "Spain",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Spain",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Spain",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Spain",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Spain",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Spain",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Spain",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Spain",
-            "zoneName": "Isla de la Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Spain",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Spain",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Ethiopia"
-        },
-        "FI": {
-            "zoneName": "Finland"
-        },
-        "FJ": {
-            "zoneName": "Fiji"
-        },
-        "FK": {
-            "zoneName": "Falkland Islands"
-        },
-        "FM": {
-            "zoneName": "Micronesia"
-        },
-        "FO": {
-            "zoneName": "Faroe Islands"
-        },
-        "FR": {
-            "zoneName": "France"
-        },
-        "FR-COR": {
-            "countryName": "France",
-            "zoneName": "Corsica"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Great Britain"
-        },
-        "GB-NIR": {
-            "zoneName": "Northern Ireland"
-        },
-        "GB-ORK": {
-            "countryName": "Great Britain",
-            "zoneName": "Orkney Islands"
-        },
-        "GB-SHI": {
-            "countryName": "Great Britain",
-            "zoneName": "Shetland Islands"
-        },
-        "GB-ZET": {
-            "countryName": "Great Britain",
-            "zoneName": "Shetland Islands"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgia"
-        },
-        "GF": {
-            "zoneName": "French Guiana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Greenland"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Equatorial Guinea"
-        },
-        "GR": {
-            "zoneName": "Greece"
-        },
-        "GR-IS": {
-            "countryName": "Greece",
-            "zoneName": "Aegean Islands"
-        },
-        "GS": {
-            "zoneName": "South Georgia and the South Sandwich Islands"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hong Kong"
-        },
-        "HM": {
-            "zoneName": "Heard Island and McDonald Islands"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Croatia"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Hungary"
-        },
-        "ID": {
-            "zoneName": "Indonesia"
-        },
-        "IE": {
-            "zoneName": "Ireland"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Isle of Man"
-        },
-        "IN-AN": {
-            "countryName": "India",
-            "zoneName": "Andaman and Nicobar Islands"
-        },
-        "IN-AP": {
-            "countryName": "India",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "India",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "India",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "India",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "India",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "India",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "India",
-            "zoneName": "Dadra and Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "India",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "India",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "India",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "India",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "India",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "India",
-            "zoneName": "Jammu and Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "India",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "India",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "India",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "India",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "India",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "India",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "India",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "India",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "India",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "India",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "India",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "India",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "India",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "India",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "India",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "India",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "India",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "India",
-            "zoneName": "West Bengal"
-        },
-        "IO": {
-            "zoneName": "British Indian Ocean Territory"
-        },
-        "IQ": {
-            "zoneName": "Iraq"
-        },
-        "IQ-KUR": {
-            "countryName": "Iraq",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Iceland"
-        },
-        "IT": {
-            "zoneName": "Italy"
-        },
-        "IT-CNO": {
-            "countryName": "Italy",
-            "zoneName": "Central North"
-        },
-        "IT-CSO": {
-            "countryName": "Italy",
-            "zoneName": "Central South"
-        },
-        "IT-NO": {
-            "countryName": "Italy",
-            "zoneName": "North"
-        },
-        "IT-SAR": {
-            "countryName": "Italy",
-            "zoneName": "Sardinia"
-        },
-        "IT-SIC": {
-            "countryName": "Italy",
-            "zoneName": "Sicily"
-        },
-        "IT-SO": {
-            "countryName": "Italy",
-            "zoneName": "South"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaica"
-        },
-        "JO": {
-            "zoneName": "Jordan"
-        },
-        "JP-CB": {
-            "countryName": "Japan",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japan",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japan",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Japan",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japan",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japan",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Japan",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japan",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japan",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japan",
-            "zoneName": "Tōkyō"
-        },
-        "KE": {
-            "zoneName": "Kenya"
-        },
-        "KG": {
-            "zoneName": "Kyrgyzstan"
-        },
-        "KH": {
-            "zoneName": "Cambodia"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comoros"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts and Nevis"
-        },
-        "KP": {
-            "zoneName": "North Korea"
-        },
-        "KR": {
-            "zoneName": "South Korea"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Cayman Islands"
-        },
-        "KZ": {
-            "zoneName": "Kazakhstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Lebanon"
-        },
-        "LC": {
-            "zoneName": "Saint Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Lithuania"
-        },
-        "LU": {
-            "zoneName": "Luxembourg"
-        },
-        "LV": {
-            "zoneName": "Latvia"
-        },
-        "LY": {
-            "zoneName": "Libya"
-        },
-        "MA": {
-            "zoneName": "Morocco"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldova"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Saint Martin",
-            "zoneName": "French"
-        },
-        "MG": {
-            "zoneName": "Madagascar"
-        },
-        "MH": {
-            "zoneName": "Marshall Islands"
-        },
-        "MK": {
-            "zoneName": "North Macedonia"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Mongolia"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Northern Mariana Islands"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Maldives"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mexico"
-        },
-        "MX-BC": {
-            "countryName": "Mexico",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mexico",
-            "zoneName": "Central"
-        },
-        "MX-NE": {
-            "countryName": "Mexico",
-            "zoneName": "North East"
-        },
-        "MX-NO": {
-            "countryName": "Mexico",
-            "zoneName": "North"
-        },
-        "MX-NW": {
-            "countryName": "Mexico",
-            "zoneName": "North West"
-        },
-        "MX-OC": {
-            "countryName": "Mexico",
-            "zoneName": "Occidental"
-        },
-        "MX-OR": {
-            "countryName": "Mexico",
-            "zoneName": "Oriental"
-        },
-        "MX-PN": {
-            "countryName": "Mexico",
-            "zoneName": "Peninsula"
-        },
-        "MY-EM": {
-            "countryName": "Malaysia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malaysia",
-            "zoneName": "Peninsula"
-        },
-        "MZ": {
-            "zoneName": "Mozambique"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "New Caledonia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolk Island"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabakh"
-        },
-        "NL": {
-            "zoneName": "Netherlands"
-        },
-        "NO-NO1": {
-            "countryName": "Norway",
-            "zoneName": "Southeast Norway"
-        },
-        "NO-NO2": {
-            "countryName": "Norway",
-            "zoneName": "Southwest Norway"
-        },
-        "NO-NO3": {
-            "countryName": "Norway",
-            "zoneName": "Middle Norway"
-        },
-        "NO-NO4": {
-            "countryName": "Norway",
-            "zoneName": "North Norway"
-        },
-        "NO-NO5": {
-            "countryName": "Norway",
-            "zoneName": "West Norway"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "New Zealand"
-        },
-        "NZ-NZA": {
-            "countryName": "New Zealand",
-            "zoneName": "Auckland Islands"
-        },
-        "NZ-NZC": {
-            "countryName": "New Zealand",
-            "zoneName": "Chatham Islands"
-        },
-        "NZ-NZST": {
-            "countryName": "New Zealand",
-            "zoneName": "Stewart Island"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "French Polynesia"
-        },
-        "PG": {
-            "zoneName": "Papua New Guinea"
-        },
-        "PH": {
-            "zoneName": "Philippines"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Poland"
-        },
-        "PM": {
-            "zoneName": "Saint Pierre and Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "State of Palestine"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Azores"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Qatar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Romania"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Russia"
-        },
-        "RU-1": {
-            "countryName": "Russia",
-            "zoneName": "Europe-Ural"
-        },
-        "RU-2": {
-            "countryName": "Russia",
-            "zoneName": "Siberia"
-        },
-        "RU-AS": {
-            "countryName": "Russia",
-            "zoneName": "East"
-        },
-        "RU-EU": {
-            "countryName": "Russia",
-            "zoneName": "Arctic"
-        },
-        "RU-FE": {
-            "countryName": "Russia",
-            "zoneName": "Far East"
-        },
-        "RU-KGD": {
-            "countryName": "Russia",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Saudi Arabia"
-        },
-        "SB": {
-            "zoneName": "Solomon Islands"
-        },
-        "SC": {
-            "zoneName": "Seychelles"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Sweden"
-        },
-        "SG": {
-            "zoneName": "Singapore"
-        },
-        "SH": {
-            "zoneName": "Saint Helena, Ascension and Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard and Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovakia"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "South Sudan"
-        },
-        "ST": {
-            "zoneName": "Sao Tome and Principe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Dutch"
-        },
-        "SY": {
-            "zoneName": "Syria"
-        },
-        "SZ": {
-            "zoneName": "Swaziland"
-        },
-        "TC": {
-            "zoneName": "Turks and Caicos Islands"
-        },
-        "TD": {
-            "zoneName": "Chad"
-        },
-        "TF": {
-            "zoneName": "French Southern Territories"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thailand"
-        },
-        "TJ": {
-            "zoneName": "Tajikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunisia"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turkey"
-        },
-        "TT": {
-            "zoneName": "Trinidad and Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tanzania"
-        },
-        "UA": {
-            "zoneName": "Ukraine"
-        },
-        "UA-CR": {
-            "countryName": "Ukraine",
-            "zoneName": "Crimea"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "United States Minor Outlying Islands"
-        },
-        "US-HI-HA": {
-            "countryName": "United States of America",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "United States of America",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "United States of America",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "United States of America",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "United States of America",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "United States of America",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "United States of America",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "United States of America",
-            "zoneName": "Oahu"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "United Arab Emirates" },
+        "AF": { "zoneName": "Afghanistan" },
+        "AG": { "zoneName": "Antigua and Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albania" },
+        "AM": { "zoneName": "Armenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarctica" },
+        "AR": { "zoneName": "Argentina" },
+        "AS": { "zoneName": "American Samoa" },
+        "AT": { "zoneName": "Austria" },
+        "AUS-NSW": { "countryName": "Australia", "zoneName": "New South Wales" },
+        "AUS-NT": { "countryName": "Australia", "zoneName": "Northern Territory" },
+        "AUS-QLD": { "countryName": "Australia", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australia", "zoneName": "South Australia" },
+        "AUS-TAS": { "countryName": "Australia", "zoneName": "Tasmania" },
+        "AUS-TAS-CBI": { "countryName": "Australia", "zoneName": "Cape Barren Island" },
+        "AUS-TAS-KI": { "countryName": "Australia", "zoneName": "King Island" },
+        "AUS-TAS-FI": { "countryName": "Australia", "zoneName": "Flinders Island" },
+        "AUS-VIC": { "countryName": "Australia", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australia", "zoneName": "Western Australia" },
+        "AUS-WA-RI": { "countryName": "Australia", "zoneName": "Rottnest Island" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Åland Islands" },
+        "AZ": { "zoneName": "Azerbaijan" },
+        "BA": { "zoneName": "Bosnia and Herzegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Belgium" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgaria" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius and Saba" },
+        "BR-CS": { "countryName": "Brazil", "zoneName": "Central Brazil" },
+        "BR-N": { "countryName": "Brazil", "zoneName": "North Brazil" },
+        "BR-NE": { "countryName": "Brazil", "zoneName": "North-East Brazil" },
+        "BR-S": { "countryName": "Brazil", "zoneName": "South Brazil" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Bouvet Island" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Belarus" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Canada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Canada", "zoneName": "British Columbia" },
+        "CA-MB": { "countryName": "Canada", "zoneName": "Manitoba" },
+        "CA-NB": { "countryName": "Canada", "zoneName": "New Brunswick" },
+        "CA-NL": { "countryName": "Canada", "zoneName": "Newfoundland and Labrador" },
+        "CA-NL-LB": { "countryName": "Canada", "zoneName": "Labrador" },
+        "CA-NL-NF": { "countryName": "Canada", "zoneName": "Newfoundland" },
+        "CA-NS": { "countryName": "Canada", "zoneName": "Nova Scotia" },
+        "CA-NT": { "countryName": "Canada", "zoneName": "Northwest Territories" },
+        "CA-NU": { "countryName": "Canada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Canada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Canada", "zoneName": "Prince Edward Island" },
+        "CA-QC": { "countryName": "Canada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Canada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Canada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Cocos Islands" },
+        "CD": { "zoneName": "Democratic Republic of the Congo" },
+        "CF": { "zoneName": "Central African Republic" },
+        "CG": { "zoneName": "Congo" },
+        "CH": { "zoneName": "Switzerland" },
+        "CI": { "zoneName": "Ivory Coast" },
+        "CK": { "zoneName": "Cook Islands" },
+        "CL-CHP": { "countryName": "Chile", "zoneName": "Easter Island" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Aysén" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Magallanes" },
+        "CL-SEN": { "countryName": "Chile", "zoneName": "Sistema Eléctrico Nacional" },
+        "CM": { "zoneName": "Cameroon" },
+        "CN": { "zoneName": "China" },
+        "CO": { "zoneName": "Colombia" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Cuba" },
+        "CV": { "zoneName": "Cabo Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Christmas Island" },
+        "CY": { "zoneName": "Cyprus" },
+        "CZ": { "zoneName": "Czechia" },
+        "DE": { "zoneName": "Germany" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Denmark" },
+        "DK-DK1": { "countryName": "Denmark", "zoneName": "West Denmark" },
+        "DK-DK2": { "countryName": "Denmark", "zoneName": "East Denmark" },
+        "DK-BHM": { "countryName": "Denmark", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "Dominican Republic" },
+        "DZ": { "zoneName": "Algeria" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Estonia" },
+        "EG": { "zoneName": "Egypt" },
+        "EH": { "zoneName": "Western Sahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Spain" },
+        "ES-IB-FO": { "countryName": "Spain", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Spain", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Spain", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Spain", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Spain", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Spain", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Spain", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Spain", "zoneName": "Isla de la Gomera" },
+        "ES-CN-LP": { "countryName": "Spain", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Spain", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Ethiopia" },
+        "FI": { "zoneName": "Finland" },
+        "FJ": { "zoneName": "Fiji" },
+        "FK": { "zoneName": "Falkland Islands" },
+        "FM": { "zoneName": "Micronesia" },
+        "FO": { "zoneName": "Faroe Islands" },
+        "FR": { "zoneName": "France" },
+        "FR-COR": { "countryName": "France", "zoneName": "Corsica" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Great Britain" },
+        "GB-NIR": { "zoneName": "Northern Ireland" },
+        "GB-ORK": { "countryName": "Great Britain", "zoneName": "Orkney Islands" },
+        "GB-SHI": { "countryName": "Great Britain", "zoneName": "Shetland Islands" },
+        "GB-ZET": { "countryName": "Great Britain", "zoneName": "Shetland Islands" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgia" },
+        "GF": { "zoneName": "French Guiana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Greenland" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Equatorial Guinea" },
+        "GR": { "zoneName": "Greece" },
+        "GR-IS": { "countryName": "Greece", "zoneName": "Aegean Islands" },
+        "GS": { "zoneName": "South Georgia and the South Sandwich Islands" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hong Kong" },
+        "HM": { "zoneName": "Heard Island and McDonald Islands" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Croatia" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Hungary" },
+        "ID": { "zoneName": "Indonesia" },
+        "IE": { "zoneName": "Ireland" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Isle of Man" },
+        "IN-AN": { "countryName": "India", "zoneName": "Andaman and Nicobar Islands" },
+        "IN-AP": { "countryName": "India", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "India", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "India", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "India", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "India", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "India", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "India", "zoneName": "Dadra and Nagar Haveli" },
+        "IN-GA": { "countryName": "India", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "India", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "India", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "India", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "India", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "India", "zoneName": "Jammu and Kashmir" },
+        "IN-KA": { "countryName": "India", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "India", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "India", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "India", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "India", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "India", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "India", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "India", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "India", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "India", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "India", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "India", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "India", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "India", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "India", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "India", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "India", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "India", "zoneName": "West Bengal" },
+        "IO": { "zoneName": "British Indian Ocean Territory" },
+        "IQ": { "zoneName": "Iraq" },
+        "IQ-KUR": { "countryName": "Iraq", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Iceland" },
+        "IT": { "zoneName": "Italy" },
+        "IT-CNO": { "countryName": "Italy", "zoneName": "Central North" },
+        "IT-CSO": { "countryName": "Italy", "zoneName": "Central South" },
+        "IT-NO": { "countryName": "Italy", "zoneName": "North" },
+        "IT-SAR": { "countryName": "Italy", "zoneName": "Sardinia" },
+        "IT-SIC": { "countryName": "Italy", "zoneName": "Sicily" },
+        "IT-SO": { "countryName": "Italy", "zoneName": "South" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaica" },
+        "JO": { "zoneName": "Jordan" },
+        "JP-CB": { "countryName": "Japan", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Japan", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Japan", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Japan", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japan", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japan", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Japan", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japan", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japan", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Japan", "zoneName": "Tōkyō" },
+        "KE": { "zoneName": "Kenya" },
+        "KG": { "zoneName": "Kyrgyzstan" },
+        "KH": { "zoneName": "Cambodia" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comoros" },
+        "KN": { "zoneName": "Saint Kitts and Nevis" },
+        "KP": { "zoneName": "North Korea" },
+        "KR": { "zoneName": "South Korea" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Cayman Islands" },
+        "KZ": { "zoneName": "Kazakhstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Lebanon" },
+        "LC": { "zoneName": "Saint Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Lithuania" },
+        "LU": { "zoneName": "Luxembourg" },
+        "LV": { "zoneName": "Latvia" },
+        "LY": { "zoneName": "Libya" },
+        "MA": { "zoneName": "Morocco" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldova" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Saint Martin", "zoneName": "French" },
+        "MG": { "zoneName": "Madagascar" },
+        "MH": { "zoneName": "Marshall Islands" },
+        "MK": { "zoneName": "North Macedonia" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Mongolia" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Northern Mariana Islands" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Maldives" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mexico" },
+        "MX-BC": { "countryName": "Mexico", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mexico", "zoneName": "Central" },
+        "MX-NE": { "countryName": "Mexico", "zoneName": "North East" },
+        "MX-NO": { "countryName": "Mexico", "zoneName": "North" },
+        "MX-NW": { "countryName": "Mexico", "zoneName": "North West" },
+        "MX-OC": { "countryName": "Mexico", "zoneName": "Occidental" },
+        "MX-OR": { "countryName": "Mexico", "zoneName": "Oriental" },
+        "MX-PN": { "countryName": "Mexico", "zoneName": "Peninsula" },
+        "MY-EM": { "countryName": "Malaysia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malaysia", "zoneName": "Peninsula" },
+        "MZ": { "zoneName": "Mozambique" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "New Caledonia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolk Island" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Nagorno-Karabakh" },
+        "NL": { "zoneName": "Netherlands" },
+        "NO-NO1": { "countryName": "Norway", "zoneName": "Southeast Norway" },
+        "NO-NO2": { "countryName": "Norway", "zoneName": "Southwest Norway" },
+        "NO-NO3": { "countryName": "Norway", "zoneName": "Middle Norway" },
+        "NO-NO4": { "countryName": "Norway", "zoneName": "North Norway" },
+        "NO-NO5": { "countryName": "Norway", "zoneName": "West Norway" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "New Zealand" },
+        "NZ-NZA": { "countryName": "New Zealand", "zoneName": "Auckland Islands" },
+        "NZ-NZC": { "countryName": "New Zealand", "zoneName": "Chatham Islands" },
+        "NZ-NZST": { "countryName": "New Zealand", "zoneName": "Stewart Island" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "French Polynesia" },
+        "PG": { "zoneName": "Papua New Guinea" },
+        "PH": { "zoneName": "Philippines" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Poland" },
+        "PM": { "zoneName": "Saint Pierre and Miquelon" },
+        "PN": { "zoneName": "Pitcairn" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "State of Palestine" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Azores" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Qatar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Romania" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Russia" },
+        "RU-1": { "countryName": "Russia", "zoneName": "Europe-Ural" },
+        "RU-2": { "countryName": "Russia", "zoneName": "Siberia" },
+        "RU-AS": { "countryName": "Russia", "zoneName": "East" },
+        "RU-EU": { "countryName": "Russia", "zoneName": "Arctic" },
+        "RU-FE": { "countryName": "Russia", "zoneName": "Far East" },
+        "RU-KGD": { "countryName": "Russia", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Saudi Arabia" },
+        "SB": { "zoneName": "Solomon Islands" },
+        "SC": { "zoneName": "Seychelles" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Sweden" },
+        "SG": { "zoneName": "Singapore" },
+        "SH": { "zoneName": "Saint Helena, Ascension and Tristan da Cunha" },
+        "SI": { "zoneName": "Slovenia" },
+        "SJ": { "zoneName": "Svalbard and Jan Mayen" },
+        "SK": { "zoneName": "Slovakia" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "South Sudan" },
+        "ST": { "zoneName": "Sao Tome and Principe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Dutch" },
+        "SY": { "zoneName": "Syria" },
+        "SZ": { "zoneName": "Swaziland" },
+        "TC": { "zoneName": "Turks and Caicos Islands" },
+        "TD": { "zoneName": "Chad" },
+        "TF": { "zoneName": "French Southern Territories" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thailand" },
+        "TJ": { "zoneName": "Tajikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunisia" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turkey" },
+        "TT": { "zoneName": "Trinidad and Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tanzania" },
+        "UA": { "zoneName": "Ukraine" },
+        "UA-CR": { "countryName": "Ukraine", "zoneName": "Crimea" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "United States Minor Outlying Islands" },
+        "US-HI-HA": { "countryName": "United States of America", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "United States of America", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "United States of America", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "United States of America", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "United States of America", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "United States of America", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "United States of America", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "United States of America", "zoneName": "Oahu" },
         "US-CAL-BANC": {
             "countryName": "United States of America",
             "zoneName": "Balancing Authority Of Northern California"
@@ -1430,30 +564,15 @@
             "countryName": "United States of America",
             "zoneName": "California Independent System Operator"
         },
-        "US-CAL-IID": {
-            "countryName": "United States of America",
-            "zoneName": "Imperial Irrigation District"
-        },
+        "US-CAL-IID": { "countryName": "United States of America", "zoneName": "Imperial Irrigation District" },
         "US-CAL-LDWP": {
             "countryName": "United States of America",
             "zoneName": "Los Angeles Department Of Water And Power"
         },
-        "US-CAL-TIDC": {
-            "countryName": "United States of America",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "United States of America",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "United States of America",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "United States of America",
-            "zoneName": "Duke Energy Carolinas"
-        },
+        "US-CAL-TIDC": { "countryName": "United States of America", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "United States of America", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "United States of America", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "United States of America", "zoneName": "Duke Energy Carolinas" },
         "US-CAR-SC": {
             "countryName": "United States of America",
             "zoneName": "South Carolina Public Service Authority"
@@ -1466,66 +585,27 @@
             "countryName": "United States of America",
             "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
         },
-        "US-CENT-SPA": {
-            "countryName": "United States of America",
-            "zoneName": "Southwestern Power Administration"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "United States of America",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "United States of America",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "United States of America",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "United States of America",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "United States of America",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "United States of America",
-            "zoneName": "City Of Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "United States of America",
-            "zoneName": "Jacksonville Electric Authority"
-        },
+        "US-CENT-SPA": { "countryName": "United States of America", "zoneName": "Southwestern Power Administration" },
+        "US-CENT-SWPP": { "countryName": "United States of America", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "United States of America", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "United States of America", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "United States of America", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "United States of America", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "United States of America", "zoneName": "City Of Homestead" },
+        "US-FLA-JEA": { "countryName": "United States of America", "zoneName": "Jacksonville Electric Authority" },
         "US-FLA-NSB": {
             "countryName": "United States of America",
             "zoneName": "Utilities Commission Of New Smyrna Beach"
         },
-        "US-FLA-SEC": {
-            "countryName": "United States of America",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "United States of America",
-            "zoneName": "City Of Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "United States of America",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "United States of America",
-            "zoneName": "PJM Interconnection, Llc"
-        },
+        "US-FLA-SEC": { "countryName": "United States of America", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "United States of America", "zoneName": "City Of Tallahassee" },
+        "US-FLA-TEC": { "countryName": "United States of America", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "United States of America", "zoneName": "PJM Interconnection, Llc" },
         "US-MIDW-AECI": {
             "countryName": "United States of America",
             "zoneName": "Associated Electric Cooperative, Inc."
         },
-        "US-MIDW-GLHB": {
-            "countryName": "United States of America",
-            "zoneName": "GridLiance"
-        },
+        "US-MIDW-GLHB": { "countryName": "United States of America", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "United States of America",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1534,78 +614,27 @@
             "countryName": "United States of America",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc.."
         },
-        "US-NE-ISNE": {
-            "countryName": "United States of America",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "United States of America",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "United States of America",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "United States of America",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "United States of America",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "United States of America",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
+        "US-NE-ISNE": { "countryName": "United States of America", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "United States of America", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "United States of America", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "United States of America", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "United States of America", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "United States of America", "zoneName": "PUD No. 1 Of Douglas County" },
         "US-NW-GCPD": {
             "countryName": "United States of America",
             "zoneName": "PUD No. 2 Of Grant County, Washington"
         },
-        "US-NW-GRID": {
-            "countryName": "United States of America",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "United States of America",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "United States of America",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "United States of America",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "United States of America",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "United States of America",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "United States of America",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "United States of America",
-            "zoneName": "Portland General Electric Company"
-        },
-        "US-NW-PSCO": {
-            "countryName": "United States of America",
-            "zoneName": "Public Service Company Of Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "United States of America",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "United States of America",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NW-GRID": { "countryName": "United States of America", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "United States of America", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "United States of America", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "United States of America", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "United States of America", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "United States of America", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "United States of America", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "United States of America", "zoneName": "Portland General Electric Company" },
+        "US-NW-PSCO": { "countryName": "United States of America", "zoneName": "Public Service Company Of Colorado" },
+        "US-NW-PSEI": { "countryName": "United States of America", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "United States of America", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "United States of America",
             "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
@@ -1618,129 +647,52 @@
             "countryName": "United States of America",
             "zoneName": "Western Area Power Administration UGP West"
         },
-        "US-NW-WWA": {
-            "countryName": "United States of America",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "United States of America",
-            "zoneName": "New York Independent System Operator"
-        },
-        "US-SE-AEC": {
-            "countryName": "United States of America",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "United States of America",
-            "zoneName": "Southeastern Power Administration"
-        },
+        "US-NW-WWA": { "countryName": "United States of America", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "United States of America", "zoneName": "New York Independent System Operator" },
+        "US-SE-AEC": { "countryName": "United States of America", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "United States of America", "zoneName": "Southeastern Power Administration" },
         "US-SE-SOCO": {
             "countryName": "United States of America",
             "zoneName": "Southern Company Services, Inc. - Trans"
         },
-        "US-SW-AZPS": {
-            "countryName": "United States of America",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "United States of America",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "United States of America",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "United States of America",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "United States of America",
-            "zoneName": "Gila River Power, LLC"
-        },
+        "US-SW-AZPS": { "countryName": "United States of America", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "United States of America", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "United States of America", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "United States of America", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "United States of America", "zoneName": "Gila River Power, LLC" },
         "US-SW-HGMA": {
             "countryName": "United States of America",
             "zoneName": "New Harquahala Generating Company, LLC"
         },
-        "US-SW-PNM": {
-            "countryName": "United States of America",
-            "zoneName": "Public Service Company Of New Mexico"
-        },
-        "US-SW-SRP": {
-            "countryName": "United States of America",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "United States of America",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-SW-PNM": { "countryName": "United States of America", "zoneName": "Public Service Company Of New Mexico" },
+        "US-SW-SRP": { "countryName": "United States of America", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "United States of America", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "United States of America",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "United States of America",
-            "zoneName": "Tennessee Valley Authority"
-        },
+        "US-TEN-TVA": { "countryName": "United States of America", "zoneName": "Tennessee Valley Authority" },
         "US-TEX-ERCO": {
             "countryName": "United States of America",
             "zoneName": "Electric Reliability Council Of Texas, Inc."
         },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatican City"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent and the Grenadines"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Virgin Islands",
-            "zoneName": "Virgin Islands"
-        },
-        "VI": {
-            "countryName": "United States of America",
-            "zoneName": "Virgin Islands"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis and Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XK": {
-            "zoneName": "Kosovo"
-        },
-        "XX": {
-            "zoneName": "Northern Cyprus"
-        },
-        "YE": {
-            "zoneName": "Yemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "South Africa"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Vatican City" },
+        "VC": { "zoneName": "Saint Vincent and the Grenadines" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Virgin Islands", "zoneName": "Virgin Islands" },
+        "VI": { "countryName": "United States of America", "zoneName": "Virgin Islands" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis and Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XK": { "zoneName": "Kosovo" },
+        "XX": { "zoneName": "Northern Cyprus" },
+        "YE": { "zoneName": "Yemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "South Africa" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/ru.json
+++ b/web/public/locales/ru.json
@@ -36,13 +36,13 @@
         "search": "Найти зону"
     },
     "country-history": {
-        "carbonintensity24h": "Интенсивность выбросов CO₂ за последние 24 часа",
-        "electricityorigin24h": "Источники электричества за последние 24 часа",
-        "electricityprices24h": "Цена электричества за последние 24 часа",
         "Getdata": "Доступ к историческим данным и к API для прогноза",
-        "emissionsorigin24h": "Источники выбросов за последние 24 часа",
-        "emissionsproduction24h": "Объем выбросов за последние 24 часа",
-        "electricityproduction24h": "Объем производства электричества за последние 24 часа"
+        "carbonintensity": { "hourly": "Интенсивность выбросов CO₂ за последние 24 часа" },
+        "emissionsorigin": { "hourly": "Источники выбросов за последние 24 часа" },
+        "emissionsproduction": { "hourly": "Объем выбросов за последние 24 часа" },
+        "electricityorigin": { "hourly": "Источники электричества за последние 24 часа" },
+        "electricityproduction": { "hourly": "Объем производства электричества за последние 24 часа" },
+        "electricityprices": { "hourly": "Цена электричества за последние 24 часа" }
     },
     "footer": {
         "foundbugs": "Вы обнаружили ошибку или у Вас есть идея? Сообщите нам о них",
@@ -110,1274 +110,385 @@
     "emissionsImportedFrom": "<b>%1$s %%</b> эмисии CO₂ зоны <img id=\"country-flag\"></img> <b>%2$s</b> импортируются из зоны <img id=\"country-exchange-flag\"></img> <b>%3$s</b>",
     "ofCO2eqPerMinute": "CO₂эк в минуту",
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Андорра"
-        },
-        "AE": {
-            "zoneName": "Объединенные Арабские Эмираты"
-        },
-        "AF": {
-            "zoneName": "Афганистан"
-        },
-        "AG": {
-            "zoneName": "Антигуа и Барбуда"
-        },
-        "AI": {
-            "zoneName": "Ангилья"
-        },
-        "AL": {
-            "zoneName": "Албания"
-        },
-        "AM": {
-            "zoneName": "Армения"
-        },
-        "AO": {
-            "zoneName": "Ангола"
-        },
-        "AQ": {
-            "zoneName": "Антарктида"
-        },
-        "AR": {
-            "zoneName": "Аргентина"
-        },
-        "AS": {
-            "zoneName": "Американское Самоа"
-        },
-        "AT": {
-            "zoneName": "Австрия"
-        },
-        "AUS-NSW": {
-            "countryName": "Австралия",
-            "zoneName": "Новый Южный Уэльс"
-        },
-        "AUS-NT": {
-            "countryName": "Австралия",
-            "zoneName": "Северная территория"
-        },
-        "AUS-QLD": {
-            "countryName": "Австралия",
-            "zoneName": "Квинсленд"
-        },
-        "AUS-SA": {
-            "countryName": "Австралия",
-            "zoneName": "Южная Австралия"
-        },
-        "AUS-TAS": {
-            "countryName": "Австралия",
-            "zoneName": "Тасмания"
-        },
-        "AUS-VIC": {
-            "countryName": "Австралия",
-            "zoneName": "Виктория"
-        },
-        "AUS-WA": {
-            "countryName": "Австралия",
-            "zoneName": "Западная Австралия"
-        },
-        "AW": {
-            "zoneName": "Аруба"
-        },
-        "AX": {
-            "zoneName": "Аландские острова"
-        },
-        "AZ": {
-            "zoneName": "Азербайджан"
-        },
-        "BA": {
-            "zoneName": "Босния и Герцеговина"
-        },
-        "BB": {
-            "zoneName": "Барбадос"
-        },
-        "BD": {
-            "zoneName": "Бангладеш"
-        },
-        "BE": {
-            "zoneName": "Бельгия"
-        },
-        "BF": {
-            "zoneName": "Буркина-Фасо"
-        },
-        "BG": {
-            "zoneName": "Болгария"
-        },
-        "BH": {
-            "zoneName": "Бахрейн"
-        },
-        "BI": {
-            "zoneName": "Бурунди"
-        },
-        "BJ": {
-            "zoneName": "Бенин"
-        },
-        "BM": {
-            "zoneName": "Бермудские острова"
-        },
-        "BN": {
-            "zoneName": "Бруней"
-        },
-        "BO": {
-            "zoneName": "Боливия"
-        },
-        "BQ": {
-            "zoneName": "Бонайр, Синт Эстатиус и Саба"
-        },
-        "BR-CS": {
-            "countryName": "Бразилия",
-            "zoneName": "Центральная"
-        },
-        "BR-N": {
-            "countryName": "Бразилия",
-            "zoneName": "Северная"
-        },
-        "BR-NE": {
-            "countryName": "Бразилия",
-            "zoneName": "Cеверо-Восточная"
-        },
-        "BR-S": {
-            "countryName": "Бразилия",
-            "zoneName": "Южная"
-        },
-        "BS": {
-            "zoneName": "Багамские Острова"
-        },
-        "BT": {
-            "zoneName": "Бутан"
-        },
-        "BV": {
-            "zoneName": "Остров Буве"
-        },
-        "BW": {
-            "zoneName": "Ботсвана"
-        },
-        "BY": {
-            "zoneName": "Беларусь"
-        },
-        "BZ": {
-            "zoneName": "Белиз"
-        },
-        "CA-AB": {
-            "countryName": "Канада",
-            "zoneName": "Альберта"
-        },
-        "CA-BC": {
-            "countryName": "Канада",
-            "zoneName": "Британская Колумбия"
-        },
-        "CA-MB": {
-            "countryName": "Канада",
-            "zoneName": "Манитоба"
-        },
-        "CA-NB": {
-            "countryName": "Канада",
-            "zoneName": "Нью-Брансуик"
-        },
-        "CA-NL": {
-            "countryName": "Канада",
-            "zoneName": "Ньюфаундленд и Лабрадор"
-        },
-        "CA-NS": {
-            "countryName": "Канада",
-            "zoneName": "Новая Шотландия"
-        },
-        "CA-NT": {
-            "countryName": "Канада",
-            "zoneName": "Северо-Западные территории"
-        },
-        "CA-NU": {
-            "countryName": "Канада",
-            "zoneName": "Нунавут"
-        },
-        "CA-ON": {
-            "countryName": "Канада",
-            "zoneName": "Онтарио"
-        },
-        "CA-PE": {
-            "countryName": "Канада",
-            "zoneName": "Остров Принца Эдуарда"
-        },
-        "CA-QC": {
-            "countryName": "Канада",
-            "zoneName": "Квебек"
-        },
-        "CA-SK": {
-            "countryName": "Канада",
-            "zoneName": "Саскачеван"
-        },
-        "CA-YT": {
-            "countryName": "Канада",
-            "zoneName": "Юкон"
-        },
-        "CC": {
-            "zoneName": "Кокосовые острова"
-        },
-        "CD": {
-            "zoneName": "Демократическая Республика Конго"
-        },
-        "CF": {
-            "zoneName": "Центральноафриканская Республика"
-        },
-        "CG": {
-            "zoneName": "Конго"
-        },
-        "CH": {
-            "zoneName": "Швейцария"
-        },
-        "CI": {
-            "zoneName": "Кот-д'Ивуар"
-        },
-        "CK": {
-            "zoneName": "Острова Кука"
-        },
-        "CL-SEA": {
-            "countryName": "Чили",
-            "zoneName": "SEA"
-        },
-        "CL-SEM": {
-            "countryName": "Чили",
-            "zoneName": "SEM"
-        },
-        "CL-SING": {
-            "countryName": "Чили",
-            "zoneName": "SING"
-        },
-        "CM": {
-            "zoneName": "Камерун"
-        },
-        "CN": {
-            "zoneName": "Китай"
-        },
-        "CO": {
-            "zoneName": "Колумбия"
-        },
-        "CR": {
-            "zoneName": "Коста-Рика"
-        },
-        "CU": {
-            "zoneName": "Куба"
-        },
-        "CV": {
-            "zoneName": "Кабо Верде"
-        },
-        "CW": {
-            "zoneName": "Кюрасао"
-        },
-        "CX": {
-            "zoneName": "Остров Рождества"
-        },
-        "CY": {
-            "zoneName": "Кипр"
-        },
-        "CZ": {
-            "zoneName": "Чехия"
-        },
-        "DE": {
-            "zoneName": "Германия"
-        },
-        "DJ": {
-            "zoneName": "Джибути"
-        },
-        "DK": {
-            "zoneName": "Дания"
-        },
-        "DK-BHM": {
-            "countryName": "Дания",
-            "zoneName": "Борнхольм"
-        },
-        "DK-DK1": {
-            "countryName": "Дания",
-            "zoneName": "Запад"
-        },
-        "DK-DK2": {
-            "countryName": "Дания",
-            "zoneName": "Восток"
-        },
-        "DM": {
-            "zoneName": "Доминика"
-        },
-        "DO": {
-            "zoneName": "Доминиканская Республика"
-        },
-        "DZ": {
-            "zoneName": "Алжир"
-        },
-        "EC": {
-            "zoneName": "Эквадор"
-        },
-        "EE": {
-            "zoneName": "Эстония"
-        },
-        "EG": {
-            "zoneName": "Египет"
-        },
-        "EH": {
-            "zoneName": "Западная Сахара"
-        },
-        "ER": {
-            "zoneName": "Эритрея"
-        },
-        "ES": {
-            "zoneName": "Испания"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Испания",
-            "zoneName": "Фуэртевентура / Лансароте"
-        },
-        "ES-CN-GC": {
-            "countryName": "Испания",
-            "zoneName": "Гран-Канария"
-        },
-        "ES-CN-HI": {
-            "countryName": "Испания",
-            "zoneName": "Эль Йерро"
-        },
-        "ES-CN-IG": {
-            "countryName": "Испания",
-            "zoneName": "Исла-де-ла-Гомера"
-        },
-        "ES-CN-LP": {
-            "countryName": "Испания",
-            "zoneName": "Ла-Пальма"
-        },
-        "ES-CN-TE": {
-            "countryName": "Испания",
-            "zoneName": "Тенерифе"
-        },
-        "ES-IB": {
-            "countryName": "Испания",
-            "zoneName": "Балеарские острова"
-        },
-        "ET": {
-            "zoneName": "Эфиопия"
-        },
-        "FI": {
-            "zoneName": "Финляндия"
-        },
-        "FJ": {
-            "zoneName": "Фиджи"
-        },
-        "FK": {
-            "zoneName": "Фолклендские острова"
-        },
-        "FM": {
-            "zoneName": "Микронезия"
-        },
-        "FO": {
-            "zoneName": "Фарерские острова"
-        },
-        "FR": {
-            "zoneName": "Франция"
-        },
-        "FR-COR": {
-            "countryName": "Франция",
-            "zoneName": "Корсика"
-        },
-        "GA": {
-            "zoneName": "Габон"
-        },
-        "GB": {
-            "zoneName": "Великобритания"
-        },
-        "GB-NIR": {
-            "zoneName": "Северная Ирландия"
-        },
-        "GD": {
-            "zoneName": "Гренада"
-        },
-        "GE": {
-            "zoneName": "Грузия"
-        },
-        "GF": {
-            "zoneName": "Французская Гвиана"
-        },
-        "GG": {
-            "zoneName": "Гернси"
-        },
-        "GH": {
-            "zoneName": "Гана"
-        },
-        "GI": {
-            "zoneName": "Гибралтар"
-        },
-        "GL": {
-            "zoneName": "Гренландия"
-        },
-        "GM": {
-            "zoneName": "Гамбия"
-        },
-        "GN": {
-            "zoneName": "Гвинея"
-        },
-        "GP": {
-            "zoneName": "Гваделупа"
-        },
-        "GQ": {
-            "zoneName": "Экваториальная Гвинея"
-        },
-        "GR": {
-            "zoneName": "Греция"
-        },
-        "GS": {
-            "zoneName": "Южная Георгия и Южные Сандвичевы острова"
-        },
-        "GT": {
-            "zoneName": "Гватемала"
-        },
-        "GU": {
-            "zoneName": "Гуам"
-        },
-        "GW": {
-            "zoneName": "Гвинея-Бисау"
-        },
-        "GY": {
-            "zoneName": "Гайана"
-        },
-        "HK": {
-            "zoneName": "Гонконг"
-        },
-        "HM": {
-            "zoneName": "Остров Херд и Острова Макдональд"
-        },
-        "HN": {
-            "zoneName": "Гондурас"
-        },
-        "HR": {
-            "zoneName": "Хорватия"
-        },
-        "HT": {
-            "zoneName": "Гаити"
-        },
-        "HU": {
-            "zoneName": "Венгрия"
-        },
-        "ID": {
-            "zoneName": "Индонезия"
-        },
-        "IE": {
-            "zoneName": "Ирландия"
-        },
-        "IL": {
-            "zoneName": "Израиль"
-        },
-        "IM": {
-            "zoneName": "Остров Мэн"
-        },
-        "IN-AN": {
-            "countryName": "Индия",
-            "zoneName": "Острова Андаман и Никобар"
-        },
-        "IN-AP": {
-            "countryName": "Индия",
-            "zoneName": "Андхра-Прадеш"
-        },
-        "IN-AR": {
-            "countryName": "Индия",
-            "zoneName": "Аруначал-Прадеш"
-        },
-        "IN-AS": {
-            "countryName": "Индия",
-            "zoneName": "Ассам"
-        },
-        "IN-BR": {
-            "countryName": "Индия",
-            "zoneName": "Бихар"
-        },
-        "IN-CT": {
-            "countryName": "Индия",
-            "zoneName": "Чхаттисгарха"
-        },
-        "IN-DL": {
-            "countryName": "Индия",
-            "zoneName": "Дели"
-        },
-        "IN-GA": {
-            "countryName": "Индия",
-            "zoneName": "Гоа"
-        },
-        "IN-GJ": {
-            "countryName": "Индия",
-            "zoneName": "Гуджарат"
-        },
-        "IN-HP": {
-            "countryName": "Индия",
-            "zoneName": "Химачал-Прадеш"
-        },
-        "IN-HR": {
-            "countryName": "Индия",
-            "zoneName": "Харьяна"
-        },
-        "IN-JH": {
-            "countryName": "Индия",
-            "zoneName": "Джаркханд"
-        },
-        "IN-JK": {
-            "countryName": "Индия",
-            "zoneName": "Джамму и Кашмир"
-        },
-        "IN-KA": {
-            "countryName": "Индия",
-            "zoneName": "Карнатака"
-        },
-        "IN-KL": {
-            "countryName": "Индия",
-            "zoneName": "Керала"
-        },
-        "IN-MH": {
-            "countryName": "Индия",
-            "zoneName": "Махараштра"
-        },
-        "IN-ML": {
-            "countryName": "Индия",
-            "zoneName": "Мегалая"
-        },
-        "IN-MN": {
-            "countryName": "Индия",
-            "zoneName": "Манипур"
-        },
-        "IN-MP": {
-            "countryName": "Индия",
-            "zoneName": "Мадхья-Прадеш"
-        },
-        "IN-MZ": {
-            "countryName": "Индия",
-            "zoneName": "Мизорам"
-        },
-        "IN-NL": {
-            "countryName": "Индия",
-            "zoneName": "Нагаленд"
-        },
-        "IN-OR": {
-            "countryName": "Индия",
-            "zoneName": "Орисса"
-        },
-        "IN-PB": {
-            "countryName": "Индия",
-            "zoneName": "Пенджаб"
-        },
-        "IN-PY": {
-            "countryName": "Индия",
-            "zoneName": "Пондишерри"
-        },
-        "IN-RJ": {
-            "countryName": "Индия",
-            "zoneName": "Раджастхан"
-        },
-        "IN-SK": {
-            "countryName": "Индия",
-            "zoneName": "Сикким"
-        },
-        "IN-TL": {
-            "countryName": "Индия",
-            "zoneName": "Тамил Наду"
-        },
-        "IN-TR": {
-            "countryName": "Индия",
-            "zoneName": "Трипура"
-        },
-        "IN-UP": {
-            "countryName": "Индия",
-            "zoneName": "Уттар-Прадеш"
-        },
-        "IN-UT": {
-            "countryName": "Индия",
-            "zoneName": "Уттаракханд"
-        },
-        "IN-WB": {
-            "countryName": "Индия",
-            "zoneName": "Западная Бенгалия"
-        },
-        "IO": {
-            "zoneName": "Британская территория в Индийском океане"
-        },
-        "IQ": {
-            "zoneName": "Ирак"
-        },
-        "IR": {
-            "zoneName": "Иран"
-        },
-        "IS": {
-            "zoneName": "Исландия"
-        },
-        "IT": {
-            "zoneName": "Италия"
-        },
-        "JE": {
-            "zoneName": "Джерси"
-        },
-        "JM": {
-            "zoneName": "Ямайка"
-        },
-        "JO": {
-            "zoneName": "Иордания"
-        },
-        "JP": {
-            "zoneName": "Япония"
-        },
-        "KE": {
-            "zoneName": "Кения"
-        },
-        "KG": {
-            "zoneName": "Кыргызстан"
-        },
-        "KH": {
-            "zoneName": "Камбоджа"
-        },
-        "KI": {
-            "zoneName": "Кирибати"
-        },
-        "KM": {
-            "zoneName": "Коморские острова"
-        },
-        "KN": {
-            "zoneName": "Сент-Китс и Невис"
-        },
-        "KP": {
-            "zoneName": "Северная Корея"
-        },
-        "KR": {
-            "zoneName": "Южная Корея"
-        },
-        "KW": {
-            "zoneName": "Кувейт"
-        },
-        "KY": {
-            "zoneName": "Каймановы острова"
-        },
-        "KZ": {
-            "zoneName": "Казахстан"
-        },
-        "LA": {
-            "zoneName": "Лаос"
-        },
-        "LB": {
-            "zoneName": "Ливан"
-        },
-        "LC": {
-            "zoneName": "Сент-Люсия"
-        },
-        "LI": {
-            "zoneName": "Лихтенштейн"
-        },
-        "LK": {
-            "zoneName": "Шри-Ланка"
-        },
-        "LR": {
-            "zoneName": "Либерия"
-        },
-        "LS": {
-            "zoneName": "Лесото"
-        },
-        "LT": {
-            "zoneName": "Литва"
-        },
-        "LU": {
-            "zoneName": "Люксембург"
-        },
-        "LV": {
-            "zoneName": "Латвия"
-        },
-        "LY": {
-            "zoneName": "Ливия"
-        },
-        "MA": {
-            "zoneName": "Марокко"
-        },
-        "MC": {
-            "zoneName": "Монако"
-        },
-        "MD": {
-            "zoneName": "Молдова"
-        },
-        "ME": {
-            "zoneName": "Черногория"
-        },
-        "MF": {
-            "countryName": "Святой Мартин",
-            "zoneName": "Франция"
-        },
-        "MG": {
-            "zoneName": "Мадагаскар"
-        },
-        "MH": {
-            "zoneName": "Маршалловы Острова"
-        },
-        "MK": {
-            "zoneName": "Северная Македония"
-        },
-        "ML": {
-            "zoneName": "Мали"
-        },
-        "MM": {
-            "zoneName": "Мьянма"
-        },
-        "MN": {
-            "zoneName": "Монголия"
-        },
-        "MO": {
-            "zoneName": "Макао"
-        },
-        "MP": {
-            "zoneName": "Северные Марианские острова"
-        },
-        "MQ": {
-            "zoneName": "Мартиника"
-        },
-        "MR": {
-            "zoneName": "Мавритания"
-        },
-        "MS": {
-            "zoneName": "Монтсеррат"
-        },
-        "MT": {
-            "zoneName": "Мальта"
-        },
-        "MU": {
-            "zoneName": "Маврикий"
-        },
-        "MV": {
-            "zoneName": "Мальдивы"
-        },
-        "MW": {
-            "zoneName": "Малави"
-        },
-        "MX": {
-            "zoneName": "Мексика"
-        },
-        "MY-EM": {
-            "countryName": "Малайзия",
-            "zoneName": "Борнео"
-        },
-        "MY-WM": {
-            "countryName": "Малайзия",
-            "zoneName": "полуостров"
-        },
-        "MZ": {
-            "zoneName": "Мозамбик"
-        },
-        "NA": {
-            "zoneName": "Намибия"
-        },
-        "NC": {
-            "zoneName": "Новая Каледония"
-        },
-        "NE": {
-            "zoneName": "Нигер"
-        },
-        "NF": {
-            "zoneName": "Остров Норфолк"
-        },
-        "NG": {
-            "zoneName": "Нигерия"
-        },
-        "NI": {
-            "zoneName": "Никарагуа"
-        },
-        "NKR": {
-            "zoneName": "Нагорный Карабах"
-        },
-        "NL": {
-            "zoneName": "Нидерланды"
-        },
-        "NO": {
-            "zoneName": "Норвегия"
-        },
-        "NP": {
-            "zoneName": "Непал"
-        },
-        "NR": {
-            "zoneName": "Науру"
-        },
-        "NU": {
-            "zoneName": "Ниуэ"
-        },
-        "NZ": {
-            "zoneName": "Новая Зеландия"
-        },
-        "NZ-NZA": {
-            "countryName": "Новая Зеландия",
-            "zoneName": "Оклендские острова"
-        },
-        "NZ-NZC": {
-            "countryName": "Новая Зеландия",
-            "zoneName": "Острова Чатем"
-        },
-        "OM": {
-            "zoneName": "Оман"
-        },
-        "PA": {
-            "zoneName": "Панама"
-        },
-        "PE": {
-            "zoneName": "Перу"
-        },
-        "PF": {
-            "zoneName": "Французская Полинезия"
-        },
-        "PG": {
-            "zoneName": "Папуа-Новая Гвинея"
-        },
-        "PH": {
-            "zoneName": "Филиппины"
-        },
-        "PK": {
-            "zoneName": "Пакистан"
-        },
-        "PL": {
-            "zoneName": "Польша"
-        },
-        "PM": {
-            "zoneName": "Сен-Пьер и Микелон"
-        },
-        "PN": {
-            "zoneName": "Питкэрн"
-        },
-        "PR": {
-            "zoneName": "Пуэрто-Рико"
-        },
-        "PS": {
-            "zoneName": "Государство Палестина"
-        },
-        "PT": {
-            "zoneName": "Португалия"
-        },
-        "PT-AC": {
-            "countryName": "Португалия",
-            "zoneName": "Азорские острова"
-        },
-        "PT-MA": {
-            "countryName": "Португалия",
-            "zoneName": "Мадейра"
-        },
-        "PW": {
-            "zoneName": "Палау"
-        },
-        "PY": {
-            "zoneName": "Парагвай"
-        },
-        "QA": {
-            "zoneName": "Катар"
-        },
-        "RE": {
-            "zoneName": "Реюньон"
-        },
-        "RO": {
-            "zoneName": "Румыния"
-        },
-        "RS": {
-            "zoneName": "Сербия"
-        },
-        "RU": {
-            "zoneName": "Россия"
-        },
-        "RU-AS": {
-            "zoneName": "Россия"
-        },
-        "RU-EU": {
-            "zoneName": "Россия"
-        },
-        "RU-1": {
-            "countryName": "Россия",
-            "zoneName": "Европейская часть и Урал"
-        },
-        "RU-2": {
-            "countryName": "Россия",
-            "zoneName": "Сибирь"
-        },
-        "RU-KGD": {
-            "countryName": "Россия",
-            "zoneName": "Калининград"
-        },
-        "RW": {
-            "zoneName": "Руанда"
-        },
-        "SA": {
-            "zoneName": "Саудовская Аравия"
-        },
-        "SB": {
-            "zoneName": "Соломоновы Острова"
-        },
-        "SC": {
-            "zoneName": "Сейшельские острова"
-        },
-        "SD": {
-            "zoneName": "Судан"
-        },
-        "SE": {
-            "zoneName": "Швеция"
-        },
-        "SG": {
-            "zoneName": "Сингапур"
-        },
-        "SH": {
-            "zoneName": "Острова Святой Елены, Вознесения и Тристан-да-Кунья"
-        },
-        "SI": {
-            "zoneName": "Словения"
-        },
-        "SJ": {
-            "zoneName": "Свальбард и Ян Майен"
-        },
-        "SK": {
-            "zoneName": "Словакия"
-        },
-        "SL": {
-            "zoneName": "Сьерра-Леоне"
-        },
-        "SM": {
-            "zoneName": "Сан-Марино"
-        },
-        "SN": {
-            "zoneName": "Сенегал"
-        },
-        "SO": {
-            "zoneName": "Сомали"
-        },
-        "SR": {
-            "zoneName": "Суринам"
-        },
-        "SS": {
-            "zoneName": "Южный Судан"
-        },
-        "ST": {
-            "zoneName": "Сан-Томе и Принсипи"
-        },
-        "SV": {
-            "zoneName": "Сальвадор"
-        },
-        "SX": {
-            "countryName": "Синт-Мартен",
-            "zoneName": "Нидерланды"
-        },
-        "SY": {
-            "zoneName": "Сирия"
-        },
-        "SZ": {
-            "zoneName": "Свазиленд"
-        },
-        "TC": {
-            "zoneName": "Острова Теркс и Кайкос"
-        },
-        "TD": {
-            "zoneName": "Чад"
-        },
-        "TF": {
-            "zoneName": "Французские Южные Территории"
-        },
-        "TG": {
-            "zoneName": "Того"
-        },
-        "TH": {
-            "zoneName": "Таиланд"
-        },
-        "TJ": {
-            "zoneName": "Таджикистан"
-        },
-        "TK": {
-            "zoneName": "Токелау"
-        },
-        "TL": {
-            "zoneName": "Тимор-Лешти"
-        },
-        "TM": {
-            "zoneName": "Туркменистан"
-        },
-        "TN": {
-            "zoneName": "Тунис"
-        },
-        "TO": {
-            "zoneName": "Тонга"
-        },
-        "TR": {
-            "zoneName": "Турция"
-        },
-        "TT": {
-            "zoneName": "Тринидад и Тобаго"
-        },
-        "TV": {
-            "zoneName": "Тувалу"
-        },
-        "TW": {
-            "zoneName": "Тайвань"
-        },
-        "TZ": {
-            "zoneName": "Танзания"
-        },
-        "UA": {
-            "zoneName": "Украина"
-        },
-        "UA-CR": {
-            "countryName": "Крым",
-            "zoneName": "Украина"
-        },
-        "UG": {
-            "zoneName": "Уганда"
-        },
-        "UM": {
-            "zoneName": "Малые отдаленные острова Соединенных Штатов"
-        },
-        "UY": {
-            "zoneName": "Уругвай"
-        },
-        "UZ": {
-            "zoneName": "Узбекистан"
-        },
-        "VA": {
-            "zoneName": "Ватикан"
-        },
-        "VC": {
-            "zoneName": "Сент-Винсент и Гренадины"
-        },
-        "VE": {
-            "zoneName": "Венесуэла"
-        },
-        "VG": {
-            "countryName": "Виргинские острова",
-            "zoneName": "Великобритания"
-        },
-        "VI": {
-            "countryName": "Виргинские острова",
-            "zoneName": "США"
-        },
-        "VN": {
-            "zoneName": "Вьетнам"
-        },
-        "VU": {
-            "zoneName": "Вануату"
-        },
-        "WF": {
-            "zoneName": "Уоллис и Футуна"
-        },
-        "WS": {
-            "zoneName": "Самоа"
-        },
-        "XX": {
-            "zoneName": "Северный Кипр"
-        },
-        "YE": {
-            "zoneName": "Йемен"
-        },
-        "YT": {
-            "zoneName": "Майотта"
-        },
-        "ZA": {
-            "zoneName": "Южная Африка"
-        },
-        "ZM": {
-            "zoneName": "Замбия"
-        },
-        "ZW": {
-            "zoneName": "Зимбабве"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Тасмания",
-            "zoneName": "Кинг"
-        },
-        "CL-SING-SIC": {
-            "countryName": "Чили",
-            "zoneName": "SING/SIC"
-        },
-        "ES-IB-FO": {
-            "countryName": "Испания",
-            "zoneName": "Форментера"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Испания",
-            "zoneName": "Ибица"
-        },
-        "ES-IB-MA": {
-            "countryName": "Испания",
-            "zoneName": "Майорка"
-        },
-        "ES-IB-ME": {
-            "countryName": "Испания",
-            "zoneName": "Менорка"
-        },
-        "GB-ORK": {
-            "countryName": "Великобритания",
-            "zoneName": "Оркнейские острова"
-        },
-        "GB-SHI": {
-            "countryName": "Великобритания",
-            "zoneName": "Шетландские острова"
-        },
-        "GB-ZET": {
-            "countryName": "Великобритания",
-            "zoneName": "Шетландские острова"
-        },
-        "GR-IS": {
-            "countryName": "Греция",
-            "zoneName": "Эгейские острова"
-        },
-        "IN-DN": {
-            "countryName": "Индия",
-            "zoneName": "Дадра и Нагар-Хавели"
-        },
-        "IN-TN": {
-            "countryName": "Индия",
-            "zoneName": "Тамил Наду"
-        },
-        "IQ-KUR": {
-            "countryName": "Ирак",
-            "zoneName": "Курдистан"
-        },
-        "IT-CNO": {
-            "countryName": "Италия",
-            "zoneName": "Северный центр"
-        },
-        "IT-CSO": {
-            "countryName": "Италия",
-            "zoneName": "Южный центр"
-        },
-        "IT-NO": {
-            "countryName": "Италия",
-            "zoneName": "Север"
-        },
-        "IT-SAR": {
-            "countryName": "Италия",
-            "zoneName": "Сардиния"
-        },
-        "IT-SIC": {
-            "countryName": "Италия",
-            "zoneName": "Сицилия"
-        },
-        "IT-SO": {
-            "countryName": "Италия",
-            "zoneName": "Юг"
-        },
-        "JP-CB": {
-            "countryName": "Япония",
-            "zoneName": "Тюбу"
-        },
-        "JP-CG": {
-            "countryName": "Япония",
-            "zoneName": "Тюгоку"
-        },
-        "JP-HKD": {
-            "countryName": "Япония",
-            "zoneName": "Хоккайдо"
-        },
-        "JP-HR": {
-            "countryName": "Япония",
-            "zoneName": "Хокурику"
-        },
-        "JP-KN": {
-            "countryName": "Япония",
-            "zoneName": "Кансай"
-        },
-        "JP-KY": {
-            "countryName": "Япония",
-            "zoneName": "Кюсю"
-        },
-        "JP-ON": {
-            "countryName": "Япония",
-            "zoneName": "Окинава"
-        },
-        "JP-SK": {
-            "countryName": "Япония",
-            "zoneName": "Шикоку"
-        },
-        "JP-TH": {
-            "countryName": "Япония",
-            "zoneName": "Тохоку"
-        },
-        "JP-TK": {
-            "countryName": "Япония",
-            "zoneName": "Токио"
-        },
-        "MX-BC": {
-            "countryName": "Мексика",
-            "zoneName": "Нижняя Калифорния"
-        },
-        "MX-CE": {
-            "countryName": "Мексика",
-            "zoneName": "Центр"
-        },
-        "MX-NE": {
-            "countryName": "Мексика",
-            "zoneName": "Северо-Восток"
-        },
-        "MX-NO": {
-            "countryName": "Мексика",
-            "zoneName": "Север"
-        },
-        "MX-NW": {
-            "countryName": "Мексика",
-            "zoneName": "Северо-Запад"
-        },
-        "MX-OC": {
-            "countryName": "Мексика",
-            "zoneName": "Occidental"
-        },
-        "MX-OR": {
-            "countryName": "Мексика",
-            "zoneName": "Орьенталь"
-        },
-        "MX-PN": {
-            "countryName": "Мексика",
-            "zoneName": "Пенинсула"
-        },
-        "NO-NO1": {
-            "countryName": "Норвегия",
-            "zoneName": "Юго-Восточная Норвегия"
-        },
-        "NO-NO2": {
-            "countryName": "Норвегия",
-            "zoneName": "Юго-Западная Норвегия"
-        },
-        "NO-NO3": {
-            "countryName": "Норвегия",
-            "zoneName": "Центральная Норвегия"
-        },
-        "NO-NO4": {
-            "countryName": "Норвегия",
-            "zoneName": "Северная Норвегия"
-        },
-        "NO-NO5": {
-            "countryName": "Норвегия",
-            "zoneName": "Западная Норвегия"
-        },
-        "US-HI-HA": {
-            "countryName": "США",
-            "zoneName": "Гаваи"
-        },
-        "US-HI-KA": {
-            "countryName": "США",
-            "zoneName": "Кауаи"
-        },
-        "US-HI-KH": {
-            "countryName": "США",
-            "zoneName": "Кахулаве"
-        },
-        "US-HI-LA": {
-            "countryName": "США",
-            "zoneName": "Ланаи"
-        },
-        "US-HI-MA": {
-            "countryName": "США",
-            "zoneName": "Мауи"
-        },
-        "US-HI-MO": {
-            "countryName": "США",
-            "zoneName": "Молокаи"
-        },
-        "US-HI-NI": {
-            "countryName": "США",
-            "zoneName": "Ниихау"
-        },
-        "US-HI-OA": {
-            "countryName": "США",
-            "zoneName": "Оаху"
-        }
+        "AD": { "zoneName": "Андорра" },
+        "AE": { "zoneName": "Объединенные Арабские Эмираты" },
+        "AF": { "zoneName": "Афганистан" },
+        "AG": { "zoneName": "Антигуа и Барбуда" },
+        "AI": { "zoneName": "Ангилья" },
+        "AL": { "zoneName": "Албания" },
+        "AM": { "zoneName": "Армения" },
+        "AO": { "zoneName": "Ангола" },
+        "AQ": { "zoneName": "Антарктида" },
+        "AR": { "zoneName": "Аргентина" },
+        "AS": { "zoneName": "Американское Самоа" },
+        "AT": { "zoneName": "Австрия" },
+        "AUS-NSW": { "countryName": "Австралия", "zoneName": "Новый Южный Уэльс" },
+        "AUS-NT": { "countryName": "Австралия", "zoneName": "Северная территория" },
+        "AUS-QLD": { "countryName": "Австралия", "zoneName": "Квинсленд" },
+        "AUS-SA": { "countryName": "Австралия", "zoneName": "Южная Австралия" },
+        "AUS-TAS": { "countryName": "Австралия", "zoneName": "Тасмания" },
+        "AUS-VIC": { "countryName": "Австралия", "zoneName": "Виктория" },
+        "AUS-WA": { "countryName": "Австралия", "zoneName": "Западная Австралия" },
+        "AW": { "zoneName": "Аруба" },
+        "AX": { "zoneName": "Аландские острова" },
+        "AZ": { "zoneName": "Азербайджан" },
+        "BA": { "zoneName": "Босния и Герцеговина" },
+        "BB": { "zoneName": "Барбадос" },
+        "BD": { "zoneName": "Бангладеш" },
+        "BE": { "zoneName": "Бельгия" },
+        "BF": { "zoneName": "Буркина-Фасо" },
+        "BG": { "zoneName": "Болгария" },
+        "BH": { "zoneName": "Бахрейн" },
+        "BI": { "zoneName": "Бурунди" },
+        "BJ": { "zoneName": "Бенин" },
+        "BM": { "zoneName": "Бермудские острова" },
+        "BN": { "zoneName": "Бруней" },
+        "BO": { "zoneName": "Боливия" },
+        "BQ": { "zoneName": "Бонайр, Синт Эстатиус и Саба" },
+        "BR-CS": { "countryName": "Бразилия", "zoneName": "Центральная" },
+        "BR-N": { "countryName": "Бразилия", "zoneName": "Северная" },
+        "BR-NE": { "countryName": "Бразилия", "zoneName": "Cеверо-Восточная" },
+        "BR-S": { "countryName": "Бразилия", "zoneName": "Южная" },
+        "BS": { "zoneName": "Багамские Острова" },
+        "BT": { "zoneName": "Бутан" },
+        "BV": { "zoneName": "Остров Буве" },
+        "BW": { "zoneName": "Ботсвана" },
+        "BY": { "zoneName": "Беларусь" },
+        "BZ": { "zoneName": "Белиз" },
+        "CA-AB": { "countryName": "Канада", "zoneName": "Альберта" },
+        "CA-BC": { "countryName": "Канада", "zoneName": "Британская Колумбия" },
+        "CA-MB": { "countryName": "Канада", "zoneName": "Манитоба" },
+        "CA-NB": { "countryName": "Канада", "zoneName": "Нью-Брансуик" },
+        "CA-NL": { "countryName": "Канада", "zoneName": "Ньюфаундленд и Лабрадор" },
+        "CA-NS": { "countryName": "Канада", "zoneName": "Новая Шотландия" },
+        "CA-NT": { "countryName": "Канада", "zoneName": "Северо-Западные территории" },
+        "CA-NU": { "countryName": "Канада", "zoneName": "Нунавут" },
+        "CA-ON": { "countryName": "Канада", "zoneName": "Онтарио" },
+        "CA-PE": { "countryName": "Канада", "zoneName": "Остров Принца Эдуарда" },
+        "CA-QC": { "countryName": "Канада", "zoneName": "Квебек" },
+        "CA-SK": { "countryName": "Канада", "zoneName": "Саскачеван" },
+        "CA-YT": { "countryName": "Канада", "zoneName": "Юкон" },
+        "CC": { "zoneName": "Кокосовые острова" },
+        "CD": { "zoneName": "Демократическая Республика Конго" },
+        "CF": { "zoneName": "Центральноафриканская Республика" },
+        "CG": { "zoneName": "Конго" },
+        "CH": { "zoneName": "Швейцария" },
+        "CI": { "zoneName": "Кот-д'Ивуар" },
+        "CK": { "zoneName": "Острова Кука" },
+        "CL-SEA": { "countryName": "Чили", "zoneName": "SEA" },
+        "CL-SEM": { "countryName": "Чили", "zoneName": "SEM" },
+        "CL-SING": { "countryName": "Чили", "zoneName": "SING" },
+        "CM": { "zoneName": "Камерун" },
+        "CN": { "zoneName": "Китай" },
+        "CO": { "zoneName": "Колумбия" },
+        "CR": { "zoneName": "Коста-Рика" },
+        "CU": { "zoneName": "Куба" },
+        "CV": { "zoneName": "Кабо Верде" },
+        "CW": { "zoneName": "Кюрасао" },
+        "CX": { "zoneName": "Остров Рождества" },
+        "CY": { "zoneName": "Кипр" },
+        "CZ": { "zoneName": "Чехия" },
+        "DE": { "zoneName": "Германия" },
+        "DJ": { "zoneName": "Джибути" },
+        "DK": { "zoneName": "Дания" },
+        "DK-BHM": { "countryName": "Дания", "zoneName": "Борнхольм" },
+        "DK-DK1": { "countryName": "Дания", "zoneName": "Запад" },
+        "DK-DK2": { "countryName": "Дания", "zoneName": "Восток" },
+        "DM": { "zoneName": "Доминика" },
+        "DO": { "zoneName": "Доминиканская Республика" },
+        "DZ": { "zoneName": "Алжир" },
+        "EC": { "zoneName": "Эквадор" },
+        "EE": { "zoneName": "Эстония" },
+        "EG": { "zoneName": "Египет" },
+        "EH": { "zoneName": "Западная Сахара" },
+        "ER": { "zoneName": "Эритрея" },
+        "ES": { "zoneName": "Испания" },
+        "ES-CN-FVLZ": { "countryName": "Испания", "zoneName": "Фуэртевентура / Лансароте" },
+        "ES-CN-GC": { "countryName": "Испания", "zoneName": "Гран-Канария" },
+        "ES-CN-HI": { "countryName": "Испания", "zoneName": "Эль Йерро" },
+        "ES-CN-IG": { "countryName": "Испания", "zoneName": "Исла-де-ла-Гомера" },
+        "ES-CN-LP": { "countryName": "Испания", "zoneName": "Ла-Пальма" },
+        "ES-CN-TE": { "countryName": "Испания", "zoneName": "Тенерифе" },
+        "ES-IB": { "countryName": "Испания", "zoneName": "Балеарские острова" },
+        "ET": { "zoneName": "Эфиопия" },
+        "FI": { "zoneName": "Финляндия" },
+        "FJ": { "zoneName": "Фиджи" },
+        "FK": { "zoneName": "Фолклендские острова" },
+        "FM": { "zoneName": "Микронезия" },
+        "FO": { "zoneName": "Фарерские острова" },
+        "FR": { "zoneName": "Франция" },
+        "FR-COR": { "countryName": "Франция", "zoneName": "Корсика" },
+        "GA": { "zoneName": "Габон" },
+        "GB": { "zoneName": "Великобритания" },
+        "GB-NIR": { "zoneName": "Северная Ирландия" },
+        "GD": { "zoneName": "Гренада" },
+        "GE": { "zoneName": "Грузия" },
+        "GF": { "zoneName": "Французская Гвиана" },
+        "GG": { "zoneName": "Гернси" },
+        "GH": { "zoneName": "Гана" },
+        "GI": { "zoneName": "Гибралтар" },
+        "GL": { "zoneName": "Гренландия" },
+        "GM": { "zoneName": "Гамбия" },
+        "GN": { "zoneName": "Гвинея" },
+        "GP": { "zoneName": "Гваделупа" },
+        "GQ": { "zoneName": "Экваториальная Гвинея" },
+        "GR": { "zoneName": "Греция" },
+        "GS": { "zoneName": "Южная Георгия и Южные Сандвичевы острова" },
+        "GT": { "zoneName": "Гватемала" },
+        "GU": { "zoneName": "Гуам" },
+        "GW": { "zoneName": "Гвинея-Бисау" },
+        "GY": { "zoneName": "Гайана" },
+        "HK": { "zoneName": "Гонконг" },
+        "HM": { "zoneName": "Остров Херд и Острова Макдональд" },
+        "HN": { "zoneName": "Гондурас" },
+        "HR": { "zoneName": "Хорватия" },
+        "HT": { "zoneName": "Гаити" },
+        "HU": { "zoneName": "Венгрия" },
+        "ID": { "zoneName": "Индонезия" },
+        "IE": { "zoneName": "Ирландия" },
+        "IL": { "zoneName": "Израиль" },
+        "IM": { "zoneName": "Остров Мэн" },
+        "IN-AN": { "countryName": "Индия", "zoneName": "Острова Андаман и Никобар" },
+        "IN-AP": { "countryName": "Индия", "zoneName": "Андхра-Прадеш" },
+        "IN-AR": { "countryName": "Индия", "zoneName": "Аруначал-Прадеш" },
+        "IN-AS": { "countryName": "Индия", "zoneName": "Ассам" },
+        "IN-BR": { "countryName": "Индия", "zoneName": "Бихар" },
+        "IN-CT": { "countryName": "Индия", "zoneName": "Чхаттисгарха" },
+        "IN-DL": { "countryName": "Индия", "zoneName": "Дели" },
+        "IN-GA": { "countryName": "Индия", "zoneName": "Гоа" },
+        "IN-GJ": { "countryName": "Индия", "zoneName": "Гуджарат" },
+        "IN-HP": { "countryName": "Индия", "zoneName": "Химачал-Прадеш" },
+        "IN-HR": { "countryName": "Индия", "zoneName": "Харьяна" },
+        "IN-JH": { "countryName": "Индия", "zoneName": "Джаркханд" },
+        "IN-JK": { "countryName": "Индия", "zoneName": "Джамму и Кашмир" },
+        "IN-KA": { "countryName": "Индия", "zoneName": "Карнатака" },
+        "IN-KL": { "countryName": "Индия", "zoneName": "Керала" },
+        "IN-MH": { "countryName": "Индия", "zoneName": "Махараштра" },
+        "IN-ML": { "countryName": "Индия", "zoneName": "Мегалая" },
+        "IN-MN": { "countryName": "Индия", "zoneName": "Манипур" },
+        "IN-MP": { "countryName": "Индия", "zoneName": "Мадхья-Прадеш" },
+        "IN-MZ": { "countryName": "Индия", "zoneName": "Мизорам" },
+        "IN-NL": { "countryName": "Индия", "zoneName": "Нагаленд" },
+        "IN-OR": { "countryName": "Индия", "zoneName": "Орисса" },
+        "IN-PB": { "countryName": "Индия", "zoneName": "Пенджаб" },
+        "IN-PY": { "countryName": "Индия", "zoneName": "Пондишерри" },
+        "IN-RJ": { "countryName": "Индия", "zoneName": "Раджастхан" },
+        "IN-SK": { "countryName": "Индия", "zoneName": "Сикким" },
+        "IN-TL": { "countryName": "Индия", "zoneName": "Тамил Наду" },
+        "IN-TR": { "countryName": "Индия", "zoneName": "Трипура" },
+        "IN-UP": { "countryName": "Индия", "zoneName": "Уттар-Прадеш" },
+        "IN-UT": { "countryName": "Индия", "zoneName": "Уттаракханд" },
+        "IN-WB": { "countryName": "Индия", "zoneName": "Западная Бенгалия" },
+        "IO": { "zoneName": "Британская территория в Индийском океане" },
+        "IQ": { "zoneName": "Ирак" },
+        "IR": { "zoneName": "Иран" },
+        "IS": { "zoneName": "Исландия" },
+        "IT": { "zoneName": "Италия" },
+        "JE": { "zoneName": "Джерси" },
+        "JM": { "zoneName": "Ямайка" },
+        "JO": { "zoneName": "Иордания" },
+        "JP": { "zoneName": "Япония" },
+        "KE": { "zoneName": "Кения" },
+        "KG": { "zoneName": "Кыргызстан" },
+        "KH": { "zoneName": "Камбоджа" },
+        "KI": { "zoneName": "Кирибати" },
+        "KM": { "zoneName": "Коморские острова" },
+        "KN": { "zoneName": "Сент-Китс и Невис" },
+        "KP": { "zoneName": "Северная Корея" },
+        "KR": { "zoneName": "Южная Корея" },
+        "KW": { "zoneName": "Кувейт" },
+        "KY": { "zoneName": "Каймановы острова" },
+        "KZ": { "zoneName": "Казахстан" },
+        "LA": { "zoneName": "Лаос" },
+        "LB": { "zoneName": "Ливан" },
+        "LC": { "zoneName": "Сент-Люсия" },
+        "LI": { "zoneName": "Лихтенштейн" },
+        "LK": { "zoneName": "Шри-Ланка" },
+        "LR": { "zoneName": "Либерия" },
+        "LS": { "zoneName": "Лесото" },
+        "LT": { "zoneName": "Литва" },
+        "LU": { "zoneName": "Люксембург" },
+        "LV": { "zoneName": "Латвия" },
+        "LY": { "zoneName": "Ливия" },
+        "MA": { "zoneName": "Марокко" },
+        "MC": { "zoneName": "Монако" },
+        "MD": { "zoneName": "Молдова" },
+        "ME": { "zoneName": "Черногория" },
+        "MF": { "countryName": "Святой Мартин", "zoneName": "Франция" },
+        "MG": { "zoneName": "Мадагаскар" },
+        "MH": { "zoneName": "Маршалловы Острова" },
+        "MK": { "zoneName": "Северная Македония" },
+        "ML": { "zoneName": "Мали" },
+        "MM": { "zoneName": "Мьянма" },
+        "MN": { "zoneName": "Монголия" },
+        "MO": { "zoneName": "Макао" },
+        "MP": { "zoneName": "Северные Марианские острова" },
+        "MQ": { "zoneName": "Мартиника" },
+        "MR": { "zoneName": "Мавритания" },
+        "MS": { "zoneName": "Монтсеррат" },
+        "MT": { "zoneName": "Мальта" },
+        "MU": { "zoneName": "Маврикий" },
+        "MV": { "zoneName": "Мальдивы" },
+        "MW": { "zoneName": "Малави" },
+        "MX": { "zoneName": "Мексика" },
+        "MY-EM": { "countryName": "Малайзия", "zoneName": "Борнео" },
+        "MY-WM": { "countryName": "Малайзия", "zoneName": "полуостров" },
+        "MZ": { "zoneName": "Мозамбик" },
+        "NA": { "zoneName": "Намибия" },
+        "NC": { "zoneName": "Новая Каледония" },
+        "NE": { "zoneName": "Нигер" },
+        "NF": { "zoneName": "Остров Норфолк" },
+        "NG": { "zoneName": "Нигерия" },
+        "NI": { "zoneName": "Никарагуа" },
+        "NKR": { "zoneName": "Нагорный Карабах" },
+        "NL": { "zoneName": "Нидерланды" },
+        "NO": { "zoneName": "Норвегия" },
+        "NP": { "zoneName": "Непал" },
+        "NR": { "zoneName": "Науру" },
+        "NU": { "zoneName": "Ниуэ" },
+        "NZ": { "zoneName": "Новая Зеландия" },
+        "NZ-NZA": { "countryName": "Новая Зеландия", "zoneName": "Оклендские острова" },
+        "NZ-NZC": { "countryName": "Новая Зеландия", "zoneName": "Острова Чатем" },
+        "OM": { "zoneName": "Оман" },
+        "PA": { "zoneName": "Панама" },
+        "PE": { "zoneName": "Перу" },
+        "PF": { "zoneName": "Французская Полинезия" },
+        "PG": { "zoneName": "Папуа-Новая Гвинея" },
+        "PH": { "zoneName": "Филиппины" },
+        "PK": { "zoneName": "Пакистан" },
+        "PL": { "zoneName": "Польша" },
+        "PM": { "zoneName": "Сен-Пьер и Микелон" },
+        "PN": { "zoneName": "Питкэрн" },
+        "PR": { "zoneName": "Пуэрто-Рико" },
+        "PS": { "zoneName": "Государство Палестина" },
+        "PT": { "zoneName": "Португалия" },
+        "PT-AC": { "countryName": "Португалия", "zoneName": "Азорские острова" },
+        "PT-MA": { "countryName": "Португалия", "zoneName": "Мадейра" },
+        "PW": { "zoneName": "Палау" },
+        "PY": { "zoneName": "Парагвай" },
+        "QA": { "zoneName": "Катар" },
+        "RE": { "zoneName": "Реюньон" },
+        "RO": { "zoneName": "Румыния" },
+        "RS": { "zoneName": "Сербия" },
+        "RU": { "zoneName": "Россия" },
+        "RU-AS": { "zoneName": "Россия" },
+        "RU-EU": { "zoneName": "Россия" },
+        "RU-1": { "countryName": "Россия", "zoneName": "Европейская часть и Урал" },
+        "RU-2": { "countryName": "Россия", "zoneName": "Сибирь" },
+        "RU-KGD": { "countryName": "Россия", "zoneName": "Калининград" },
+        "RW": { "zoneName": "Руанда" },
+        "SA": { "zoneName": "Саудовская Аравия" },
+        "SB": { "zoneName": "Соломоновы Острова" },
+        "SC": { "zoneName": "Сейшельские острова" },
+        "SD": { "zoneName": "Судан" },
+        "SE": { "zoneName": "Швеция" },
+        "SG": { "zoneName": "Сингапур" },
+        "SH": { "zoneName": "Острова Святой Елены, Вознесения и Тристан-да-Кунья" },
+        "SI": { "zoneName": "Словения" },
+        "SJ": { "zoneName": "Свальбард и Ян Майен" },
+        "SK": { "zoneName": "Словакия" },
+        "SL": { "zoneName": "Сьерра-Леоне" },
+        "SM": { "zoneName": "Сан-Марино" },
+        "SN": { "zoneName": "Сенегал" },
+        "SO": { "zoneName": "Сомали" },
+        "SR": { "zoneName": "Суринам" },
+        "SS": { "zoneName": "Южный Судан" },
+        "ST": { "zoneName": "Сан-Томе и Принсипи" },
+        "SV": { "zoneName": "Сальвадор" },
+        "SX": { "countryName": "Синт-Мартен", "zoneName": "Нидерланды" },
+        "SY": { "zoneName": "Сирия" },
+        "SZ": { "zoneName": "Свазиленд" },
+        "TC": { "zoneName": "Острова Теркс и Кайкос" },
+        "TD": { "zoneName": "Чад" },
+        "TF": { "zoneName": "Французские Южные Территории" },
+        "TG": { "zoneName": "Того" },
+        "TH": { "zoneName": "Таиланд" },
+        "TJ": { "zoneName": "Таджикистан" },
+        "TK": { "zoneName": "Токелау" },
+        "TL": { "zoneName": "Тимор-Лешти" },
+        "TM": { "zoneName": "Туркменистан" },
+        "TN": { "zoneName": "Тунис" },
+        "TO": { "zoneName": "Тонга" },
+        "TR": { "zoneName": "Турция" },
+        "TT": { "zoneName": "Тринидад и Тобаго" },
+        "TV": { "zoneName": "Тувалу" },
+        "TW": { "zoneName": "Тайвань" },
+        "TZ": { "zoneName": "Танзания" },
+        "UA": { "zoneName": "Украина" },
+        "UA-CR": { "countryName": "Крым", "zoneName": "Украина" },
+        "UG": { "zoneName": "Уганда" },
+        "UM": { "zoneName": "Малые отдаленные острова Соединенных Штатов" },
+        "UY": { "zoneName": "Уругвай" },
+        "UZ": { "zoneName": "Узбекистан" },
+        "VA": { "zoneName": "Ватикан" },
+        "VC": { "zoneName": "Сент-Винсент и Гренадины" },
+        "VE": { "zoneName": "Венесуэла" },
+        "VG": { "countryName": "Виргинские острова", "zoneName": "Великобритания" },
+        "VI": { "countryName": "Виргинские острова", "zoneName": "США" },
+        "VN": { "zoneName": "Вьетнам" },
+        "VU": { "zoneName": "Вануату" },
+        "WF": { "zoneName": "Уоллис и Футуна" },
+        "WS": { "zoneName": "Самоа" },
+        "XX": { "zoneName": "Северный Кипр" },
+        "YE": { "zoneName": "Йемен" },
+        "YT": { "zoneName": "Майотта" },
+        "ZA": { "zoneName": "Южная Африка" },
+        "ZM": { "zoneName": "Замбия" },
+        "ZW": { "zoneName": "Зимбабве" },
+        "AUS-TAS-KI": { "countryName": "Тасмания", "zoneName": "Кинг" },
+        "CL-SING-SIC": { "countryName": "Чили", "zoneName": "SING/SIC" },
+        "ES-IB-FO": { "countryName": "Испания", "zoneName": "Форментера" },
+        "ES-IB-IZ": { "countryName": "Испания", "zoneName": "Ибица" },
+        "ES-IB-MA": { "countryName": "Испания", "zoneName": "Майорка" },
+        "ES-IB-ME": { "countryName": "Испания", "zoneName": "Менорка" },
+        "GB-ORK": { "countryName": "Великобритания", "zoneName": "Оркнейские острова" },
+        "GB-SHI": { "countryName": "Великобритания", "zoneName": "Шетландские острова" },
+        "GB-ZET": { "countryName": "Великобритания", "zoneName": "Шетландские острова" },
+        "GR-IS": { "countryName": "Греция", "zoneName": "Эгейские острова" },
+        "IN-DN": { "countryName": "Индия", "zoneName": "Дадра и Нагар-Хавели" },
+        "IN-TN": { "countryName": "Индия", "zoneName": "Тамил Наду" },
+        "IQ-KUR": { "countryName": "Ирак", "zoneName": "Курдистан" },
+        "IT-CNO": { "countryName": "Италия", "zoneName": "Северный центр" },
+        "IT-CSO": { "countryName": "Италия", "zoneName": "Южный центр" },
+        "IT-NO": { "countryName": "Италия", "zoneName": "Север" },
+        "IT-SAR": { "countryName": "Италия", "zoneName": "Сардиния" },
+        "IT-SIC": { "countryName": "Италия", "zoneName": "Сицилия" },
+        "IT-SO": { "countryName": "Италия", "zoneName": "Юг" },
+        "JP-CB": { "countryName": "Япония", "zoneName": "Тюбу" },
+        "JP-CG": { "countryName": "Япония", "zoneName": "Тюгоку" },
+        "JP-HKD": { "countryName": "Япония", "zoneName": "Хоккайдо" },
+        "JP-HR": { "countryName": "Япония", "zoneName": "Хокурику" },
+        "JP-KN": { "countryName": "Япония", "zoneName": "Кансай" },
+        "JP-KY": { "countryName": "Япония", "zoneName": "Кюсю" },
+        "JP-ON": { "countryName": "Япония", "zoneName": "Окинава" },
+        "JP-SK": { "countryName": "Япония", "zoneName": "Шикоку" },
+        "JP-TH": { "countryName": "Япония", "zoneName": "Тохоку" },
+        "JP-TK": { "countryName": "Япония", "zoneName": "Токио" },
+        "MX-BC": { "countryName": "Мексика", "zoneName": "Нижняя Калифорния" },
+        "MX-CE": { "countryName": "Мексика", "zoneName": "Центр" },
+        "MX-NE": { "countryName": "Мексика", "zoneName": "Северо-Восток" },
+        "MX-NO": { "countryName": "Мексика", "zoneName": "Север" },
+        "MX-NW": { "countryName": "Мексика", "zoneName": "Северо-Запад" },
+        "MX-OC": { "countryName": "Мексика", "zoneName": "Occidental" },
+        "MX-OR": { "countryName": "Мексика", "zoneName": "Орьенталь" },
+        "MX-PN": { "countryName": "Мексика", "zoneName": "Пенинсула" },
+        "NO-NO1": { "countryName": "Норвегия", "zoneName": "Юго-Восточная Норвегия" },
+        "NO-NO2": { "countryName": "Норвегия", "zoneName": "Юго-Западная Норвегия" },
+        "NO-NO3": { "countryName": "Норвегия", "zoneName": "Центральная Норвегия" },
+        "NO-NO4": { "countryName": "Норвегия", "zoneName": "Северная Норвегия" },
+        "NO-NO5": { "countryName": "Норвегия", "zoneName": "Западная Норвегия" },
+        "US-HI-HA": { "countryName": "США", "zoneName": "Гаваи" },
+        "US-HI-KA": { "countryName": "США", "zoneName": "Кауаи" },
+        "US-HI-KH": { "countryName": "США", "zoneName": "Кахулаве" },
+        "US-HI-LA": { "countryName": "США", "zoneName": "Ланаи" },
+        "US-HI-MA": { "countryName": "США", "zoneName": "Мауи" },
+        "US-HI-MO": { "countryName": "США", "zoneName": "Молокаи" },
+        "US-HI-NI": { "countryName": "США", "zoneName": "Ниихау" },
+        "US-HI-OA": { "countryName": "США", "zoneName": "Оаху" }
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Зоны",
-        "about": "О нас"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Зоны", "about": "О нас" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Разметка влияния выработки электричества на климат"
-        },
+        "view1": { "subtitle": "Разметка влияния выработки электричества на климат" },
         "view2": {
             "header": "Посмотреть как много CO₂ выброшено для производства вашего электричества, в режиме реального времени",
             "text": "Мы подкрашиваем мировые зоны в зависимости от интенсивности выбросов (включая парниковые газы) при производстве и подтреблении электричества. Более зеленые зоны - означают более экологичное электричество."

--- a/web/public/locales/sk.json
+++ b/web/public/locales/sk.json
@@ -6,15 +6,9 @@
         "datasources": "zdroje dát",
         "contribute": "Zapojte sa <a href=\"%s\" target=\"_blank\">pridaním svojej oblasti</a>"
     },
-    "mobile-main-menu": {
-        "map": "electricityMap",
-        "areas": "Oblasti",
-        "about": "Info"
-    },
+    "mobile-main-menu": { "map": "electricityMap", "areas": "Oblasti", "about": "Info" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Mapovanie dopadu spotreby elektriny na klímu"
-        },
+        "view1": { "subtitle": "Mapovanie dopadu spotreby elektriny na klímu" },
         "view2": {
             "header": "Sledujte koľko CO₂ je vyprodukovaného tvojou spotrebou elektriny v reálnom čase",
             "text": "Farebne zobrazujeme oblasti po celom svete na základe ich intenzity emisií"
@@ -50,13 +44,13 @@
         "search": "Hľadaj oblasti"
     },
     "country-history": {
-        "carbonintensity24h": "Intenzita uhlíka za posledných 24 hodín",
-        "emissionsorigin24h": "Pôvod emisií za posledných 24 hodín",
-        "emissionsproduction24h": "Emisie vyprodukované za posledných 24 hodín",
-        "electricityorigin24h": "Pôvod elektriny za posledných 24 hodín",
-        "electricityproduction24h": "Produkcia elektriny za posledných 24 hodín",
-        "electricityprices24h": "Ceny elektriny za posledných 24 hodín",
-        "Getdata": "Získajte historické dáta, menšinové a predpoveď API"
+        "Getdata": "Získajte historické dáta, menšinové a predpoveď API",
+        "carbonintensity": { "hourly": "Intenzita uhlíka za posledných 24 hodín" },
+        "emissionsorigin": { "hourly": "Pôvod emisií za posledných 24 hodín" },
+        "emissionsproduction": { "hourly": "Emisie vyprodukované za posledných 24 hodín" },
+        "electricityorigin": { "hourly": "Pôvod elektriny za posledných 24 hodín" },
+        "electricityproduction": { "hourly": "Produkcia elektriny za posledných 24 hodín" },
+        "electricityprices": { "hourly": "Ceny elektriny za posledných 24 hodín" }
     },
     "footer": {
         "foundbugs": "Našli ste nedostatky alebo máte nápad? Povedzte nám o nich",
@@ -186,1206 +180,365 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publikuje dáta a obrázky na <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> pre informačné účely. Nezaručuje správnosť ani žiadnu formu záruky a vyhradzuje si právo kedykoľvek zmeniť obsah alebo odstrániť časti bez toho, že by o tom musel informovať. electricityMap nepreberá žiadnu zodpovednosť za akékoľvek škody alebo výdavky, ktoré by mohli vzniknúť v dôsledku nepresnosti, neúplnosti, neopatrnosti alebo zastaranosti electricityMap alebo informácií ziskýnych z nej. Nie je dovolené zahrnúť túto webovú stránku alebo jej jednotlivé prvky do inej webovej stránky bez formálneho predchádzajúceho písomného súhlasu.<br><br> Všetky práva duševného vlastníctva patria oprávneným majiteľom a poskytovateľom licencií. Kopírovanie, distribúcia a akýkoľvek iné použitie týchto materiálov, najmä energetických údajov, nie je povolené bez písomného súhlasu electricityMap, s výnimkou prípadov, ktoré sú ustanovené inak v predpisoch povinného práva (ako je právo citovať), pokiaľ nie je pre konkrétne materiály uvedené inak. <br><br> Toto vylúčenie zodpovednosti môže byť z času na čas aktualizované."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Spojené Arabské Emiráty"
-        },
-        "AF": {
-            "zoneName": "Afganistan"
-        },
-        "AG": {
-            "zoneName": "Antigua a Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albánsko"
-        },
-        "AM": {
-            "zoneName": "Arménsko"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarktída"
-        },
-        "AS": {
-            "zoneName": "Americká Samoa"
-        },
-        "AT": {
-            "zoneName": "Rakúsko"
-        },
-        "AR": {
-            "zoneName": "Argentína"
-        },
-        "AUS-NSW": {
-            "countryName": "Austrália",
-            "zoneName": "Nový Južný Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Austrália",
-            "zoneName": "Severné teritórium"
-        },
-        "AUS-QLD": {
-            "countryName": "Austrália",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Austrália",
-            "zoneName": "Juzná Austrália"
-        },
-        "AUS-TAS": {
-            "countryName": "Austrália",
-            "zoneName": "Tasmánia"
-        },
-        "AUS-VIC": {
-            "countryName": "Austrália",
-            "zoneName": "Viktória"
-        },
-        "AUS-WA": {
-            "countryName": "Austrália",
-            "zoneName": "Západná Austrália"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Ålandy"
-        },
-        "AZ": {
-            "zoneName": "Azerbajdžan"
-        },
-        "BA": {
-            "zoneName": "Bosna a Hercegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladéš"
-        },
-        "BE": {
-            "zoneName": "Belgicko"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulharsko"
-        },
-        "BH": {
-            "zoneName": "Bahrajn"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermudy"
-        },
-        "BN": {
-            "zoneName": "Brunej"
-        },
-        "BO": {
-            "zoneName": "Bolívia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius and Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brazília",
-            "zoneName": "Centrálna Brazília"
-        },
-        "BR-N": {
-            "countryName": "Brazília",
-            "zoneName": "Severná Brazília"
-        },
-        "BR-NE": {
-            "countryName": "Brazília",
-            "zoneName": "Severovychodná Brazília"
-        },
-        "BR-S": {
-            "countryName": "Brazília",
-            "zoneName": "Južná Brazília"
-        },
-        "BS": {
-            "zoneName": "Bahamy"
-        },
-        "BT": {
-            "zoneName": "Bhután"
-        },
-        "BV": {
-            "zoneName": "Bouvetov ostrov"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Bielorusko"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "Britská Kolumbia"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland a Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Severozápadné teritóriá"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nové Škótsko"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontário"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Ostrov princa Eduarda"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Quebec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Kokosové ostrovy"
-        },
-        "CD": {
-            "zoneName": "Konžská emokratická republika"
-        },
-        "CF": {
-            "zoneName": "Stredoafrická Republika"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Švajčiarsko"
-        },
-        "CI": {
-            "zoneName": "Pobrežie Slonoviny"
-        },
-        "CK": {
-            "zoneName": "Cookove ostrovy"
-        },
-        "CL-SING": {
-            "countryName": "Čile",
-            "zoneName": "SING"
-        },
-        "CL-SEM": {
-            "countryName": "Čile",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "Čile",
-            "zoneName": "SEA"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Čína"
-        },
-        "CO": {
-            "zoneName": "Kolumbia"
-        },
-        "CR": {
-            "zoneName": "Kostarika"
-        },
-        "CU": {
-            "zoneName": "Kuba"
-        },
-        "CV": {
-            "zoneName": "Kapverdy"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Vianočný ostrov"
-        },
-        "CY": {
-            "zoneName": "Cyprus"
-        },
-        "CZ": {
-            "zoneName": "Česko"
-        },
-        "DE": {
-            "zoneName": "Nemecko"
-        },
-        "DJ": {
-            "zoneName": "Džibutsko"
-        },
-        "DK": {
-            "zoneName": "Dánsko"
-        },
-        "DK-DK1": {
-            "countryName": "Dánsko",
-            "zoneName": "Západné Dánsko"
-        },
-        "DK-DK2": {
-            "countryName": "Dásko",
-            "zoneName": "Vychodné Dánsko"
-        },
-        "DK-BHM": {
-            "countryName": "Dánsko",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominika"
-        },
-        "DO": {
-            "zoneName": "Dominikánska republika"
-        },
-        "DZ": {
-            "zoneName": "Alžírsko"
-        },
-        "EC": {
-            "zoneName": "Ekvádor"
-        },
-        "EE": {
-            "zoneName": "Estónsko"
-        },
-        "EG": {
-            "zoneName": "Egypt"
-        },
-        "EH": {
-            "zoneName": "Západná Sahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Španielsko"
-        },
-        "ES-IB-FO": {
-            "countryName": "Španielsko",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Španielsko",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Španielsko",
-            "zoneName": "Malorka"
-        },
-        "ES-IB-ME": {
-            "countryName": "Španielsko",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Španielsko",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Španielsko",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Španielsko",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Španielsko",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Španielsko",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Španielsko",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Etiópia"
-        },
-        "FI": {
-            "zoneName": "Fínsko"
-        },
-        "FJ": {
-            "zoneName": "Fidži"
-        },
-        "FK": {
-            "zoneName": "Falklandy"
-        },
-        "FM": {
-            "zoneName": "Mikronézia"
-        },
-        "FO": {
-            "zoneName": "Faerské ostrovy"
-        },
-        "FR": {
-            "zoneName": "Francúzsko"
-        },
-        "FR-COR": {
-            "countryName": "Francúzsko",
-            "zoneName": "Korzika"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Veľká Británia"
-        },
-        "GB-NIR": {
-            "zoneName": "Severné Irsko"
-        },
-        "GB-ORK": {
-            "countryName": "Veľká Británia",
-            "zoneName": "Orkneje"
-        },
-        "GB-SHI": {
-            "countryName": "Veľká Británia",
-            "zoneName": "Shetlandy"
-        },
-        "GB-ZET": {
-            "countryName": "Velká Británia",
-            "zoneName": "Shetlandy"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Gruzínsko"
-        },
-        "GF": {
-            "zoneName": "Francúzska Guyana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltár"
-        },
-        "GL": {
-            "zoneName": "Grónsko"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Rovníková Guinea"
-        },
-        "GR": {
-            "zoneName": "Grécko"
-        },
-        "GR-IS": {
-            "countryName": "Grécko",
-            "zoneName": "Egejské ostrovy"
-        },
-        "GS": {
-            "zoneName": "Južná Georgia a Sandwichove ostrovy"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hongkong"
-        },
-        "HM": {
-            "zoneName": "Teritórium Heardovho ostrova a Macdonaldových ostrovov"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Chorvátsko"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Maďarsko"
-        },
-        "ID": {
-            "zoneName": "Indonézia"
-        },
-        "IE": {
-            "zoneName": "Írsko"
-        },
-        "IL": {
-            "zoneName": "Izrael"
-        },
-        "IM": {
-            "zoneName": "Ostrov Man"
-        },
-        "IN-AN": {
-            "countryName": "India",
-            "zoneName": "Andmany a Nikobary"
-        },
-        "IN-AP": {
-            "countryName": "India",
-            "zoneName": "Andhrapradáš"
-        },
-        "IN-AR": {
-            "countryName": "India",
-            "zoneName": "Arunáčalpraéš"
-        },
-        "IN-AS": {
-            "countryName": "India",
-            "zoneName": "Ásam"
-        },
-        "IN-BR": {
-            "countryName": "India",
-            "zoneName": "Bihár"
-        },
-        "IN-CT": {
-            "countryName": "India",
-            "zoneName": "Čhattásgarh"
-        },
-        "IN-DL": {
-            "countryName": "India",
-            "zoneName": "Dillí"
-        },
-        "IN-DN": {
-            "countryName": "India",
-            "zoneName": "Dádra a Nagar Havelí"
-        },
-        "IN-GA": {
-            "countryName": "India",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "India",
-            "zoneName": "Gudžarát"
-        },
-        "IN-HP": {
-            "countryName": "India",
-            "zoneName": "Himáčalpradéš"
-        },
-        "IN-HR": {
-            "countryName": "india",
-            "zoneName": "Harijána"
-        },
-        "IN-JH": {
-            "countryName": "India",
-            "zoneName": "Džhárkhand"
-        },
-        "IN-JK": {
-            "countryName": "India",
-            "zoneName": "Džammú a Kašmír"
-        },
-        "IN-KA": {
-            "countryName": "India",
-            "zoneName": "Karnátaka"
-        },
-        "IN-KL": {
-            "countryName": "India",
-            "zoneName": "Kérala"
-        },
-        "IN-MH": {
-            "countryName": "India",
-            "zoneName": "Maháraštra"
-        },
-        "IN-ML": {
-            "countryName": "India",
-            "zoneName": "Meghálaj"
-        },
-        "IN-MN": {
-            "countryName": "India",
-            "zoneName": "Manípur"
-        },
-        "IN-MP": {
-            "countryName": "India",
-            "zoneName": "Madhjapradéš"
-        },
-        "IN-MZ": {
-            "countryName": "India",
-            "zoneName": "Mizorám"
-        },
-        "IN-NL": {
-            "countryName": "India",
-            "zoneName": "Nágsko"
-        },
-        "IN-OR": {
-            "countryName": "India",
-            "zoneName": "Urísa"
-        },
-        "IN-PB": {
-            "countryName": "India",
-            "zoneName": "Pandžáb"
-        },
-        "IN-PY": {
-            "countryName": "India",
-            "zoneName": "Puttučéri"
-        },
-        "IN-RJ": {
-            "countryName": "India",
-            "zoneName": "Radžastan"
-        },
-        "IN-SK": {
-            "countryName": "India",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "India",
-            "zoneName": "Tamilnádu"
-        },
-        "IN-TR": {
-            "countryName": "India",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "India",
-            "zoneName": "Uttarpradáš"
-        },
-        "IN-UT": {
-            "countryName": "India",
-            "zoneName": "Uttarákhand"
-        },
-        "IN-WB": {
-            "countryName": "India",
-            "zoneName": "Západné Bengálsko"
-        },
-        "IO": {
-            "zoneName": "Britské indickooceánske územie"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Irán"
-        },
-        "IS": {
-            "zoneName": "Island"
-        },
-        "IT": {
-            "zoneName": "Taliansko"
-        },
-        "IT-CNO": {
-            "countryName": "Taliansko",
-            "zoneName": "Centrálne Severné"
-        },
-        "IT-CSO": {
-            "countryName": "Taliansko",
-            "zoneName": "Centrálne Južné"
-        },
-        "IT-NO": {
-            "countryName": "Taliansko",
-            "zoneName": "Severné Taliansko"
-        },
-        "IT-SAR": {
-            "countryName": "Taliansko",
-            "zoneName": "Sardínia"
-        },
-        "IT-SIC": {
-            "countryName": "Taliansko",
-            "zoneName": "Sicília"
-        },
-        "IT-SO": {
-            "countryName": "Taliansko",
-            "zoneName": "Južné Taliansko"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamajka"
-        },
-        "JO": {
-            "zoneName": "Jordánsko"
-        },
-        "JP-CB": {
-            "countryName": "Japonsko",
-            "zoneName": "Čobú"
-        },
-        "JP-CG": {
-            "countryName": "Japan",
-            "zoneName": "Čugokú"
-        },
-        "JP-HKD": {
-            "countryName": "Japonsko",
-            "zoneName": "Hokkaidó"
-        },
-        "JP-HR": {
-            "countryName": "Japonsko",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japonsko",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japonsko",
-            "zoneName": "Kjušú"
-        },
-        "JP-ON": {
-            "countryName": "Japonsko",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japonsko",
-            "zoneName": "Šikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japonsko",
-            "zoneName": "Tóhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japonsko",
-            "zoneName": "Tokio"
-        },
-        "KE": {
-            "zoneName": "Keňa"
-        },
-        "KG": {
-            "zoneName": "Kirgizsko"
-        },
-        "KH": {
-            "zoneName": "Kambodža"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Komory"
-        },
-        "KN": {
-            "zoneName": "Svätý Krištof a Nevis"
-        },
-        "KP": {
-            "zoneName": "Kórejská ľudovodemokratická republika"
-        },
-        "KR": {
-            "zoneName": "Kórejská republika"
-        },
-        "KW": {
-            "zoneName": "Kuvajt"
-        },
-        "KY": {
-            "zoneName": "Kajmanie ostrovy"
-        },
-        "KZ": {
-            "zoneName": "Kazachstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Libanon"
-        },
-        "LC": {
-            "zoneName": "Svätá Lucia"
-        },
-        "LI": {
-            "zoneName": "Lichtenštajnsko"
-        },
-        "LK": {
-            "zoneName": "Srí Lanka"
-        },
-        "LR": {
-            "zoneName": "Libéria"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Litva"
-        },
-        "LU": {
-            "zoneName": "Luxembursko"
-        },
-        "LV": {
-            "zoneName": "Lotyšsko"
-        },
-        "LY": {
-            "zoneName": "Líbya"
-        },
-        "MA": {
-            "zoneName": "Maroko"
-        },
-        "MC": {
-            "zoneName": "Monako"
-        },
-        "MD": {
-            "zoneName": "Moldavsko"
-        },
-        "ME": {
-            "zoneName": "Čierna Hora"
-        },
-        "MF": {
-            "countryName": "Sväty Martin",
-            "zoneName": "French"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Marshallove ostrovy"
-        },
-        "MK": {
-            "zoneName": "Severné Macedónsko"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Mjanmarsko"
-        },
-        "MN": {
-            "zoneName": "Mongolsko"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Severné Mariány"
-        },
-        "MQ": {
-            "zoneName": "Martinik"
-        },
-        "MR": {
-            "zoneName": "Mauritánia"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Maurícius"
-        },
-        "MV": {
-            "zoneName": "Maldivy"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mexiko"
-        },
-        "MX-BC": {
-            "countryName": "Mexiko",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mexiko",
-            "zoneName": "Centrálne Mexiko"
-        },
-        "MX-NE": {
-            "countryName": "Mexiko",
-            "zoneName": "Severovychodné Mexiko"
-        },
-        "MX-NO": {
-            "countryName": "Mexiko",
-            "zoneName": "Severné Mexiko"
-        },
-        "MX-NW": {
-            "countryName": "Mexiko",
-            "zoneName": "Severzápadné Mexiko"
-        },
-        "MX-OC": {
-            "countryName": "Mexiko",
-            "zoneName": "Západné Mexiko"
-        },
-        "MX-OR": {
-            "countryName": "Mexiko",
-            "zoneName": "Orientálne Mexiko"
-        },
-        "MX-PN": {
-            "countryName": "Mexiko",
-            "zoneName": "Poloostrov"
-        },
-        "MY-EM": {
-            "countryName": "Malajzia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malajyia",
-            "zoneName": "Poloostrov"
-        },
-        "MZ": {
-            "zoneName": "Mozambik"
-        },
-        "NA": {
-            "zoneName": "Namíbia"
-        },
-        "NC": {
-            "zoneName": "Nová Kaledónia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigéria"
-        },
-        "NI": {
-            "zoneName": "Nikaragua"
-        },
-        "NL": {
-            "zoneName": "Holandsko"
-        },
-        "NO-NO1": {
-            "countryName": "Nórsko",
-            "zoneName": "Juhovychodné Nórsko"
-        },
-        "NO-NO2": {
-            "countryName": "Nórsko",
-            "zoneName": "Juhozápadné Nórsko"
-        },
-        "NO-NO3": {
-            "countryName": "Nórsko",
-            "zoneName": "Stredné Nórsko"
-        },
-        "NO-NO4": {
-            "countryName": "Nórsko",
-            "zoneName": "Severné Nórsko"
-        },
-        "NO-NO5": {
-            "countryName": "Nórsko",
-            "zoneName": "Západné Nórsko"
-        },
-        "NP": {
-            "zoneName": "Nepál"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Novy Zéland"
-        },
-        "NZ-NZA": {
-            "countryName": "Novy Zéland",
-            "zoneName": "Aucklandove ostrovy"
-        },
-        "NZ-NZC": {
-            "countryName": "Novy Zéland",
-            "zoneName": "Chathamské ostrovy"
-        },
-        "OM": {
-            "zoneName": "Omán"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Francúzska Polynézia"
-        },
-        "PG": {
-            "zoneName": "Papua-Nová Guinea"
-        },
-        "PH": {
-            "zoneName": "Filipíny"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Poľsko"
-        },
-        "PM": {
-            "zoneName": "Saint Pierre a Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairnove ostrovy"
-        },
-        "PR": {
-            "zoneName": "Portoriko"
-        },
-        "PS": {
-            "zoneName": "Palestína"
-        },
-        "PT": {
-            "zoneName": "Portugalsko"
-        },
-        "PT-AC": {
-            "countryName": "Portugalsko",
-            "zoneName": "Azory"
-        },
-        "PT-MA": {
-            "countryName": "Portugalsko",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguaj"
-        },
-        "QA": {
-            "zoneName": "Katar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Rumunsko"
-        },
-        "RS": {
-            "zoneName": "Srbsko"
-        },
-        "RU": {
-            "zoneName": "Rusko"
-        },
-        "RU-1": {
-            "countryName": "Rusko",
-            "zoneName": "Európske Rusko a Ural"
-        },
-        "RU-2": {
-            "countryName": "Rusko",
-            "zoneName": "Sibír"
-        },
-        "RU-EU": {
-            "zoneName": "Rusko"
-        },
-        "RU-AS": {
-            "zoneName": "Rusko"
-        },
-        "RU-KGD": {
-            "countryName": "Rusko",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Saudská Arábia"
-        },
-        "SB": {
-            "zoneName": "Šalamúnové ostrovy"
-        },
-        "SC": {
-            "zoneName": "Seychely"
-        },
-        "SD": {
-            "zoneName": "Sudán"
-        },
-        "SE": {
-            "zoneName": "Švédsko"
-        },
-        "SG": {
-            "zoneName": "Singapur"
-        },
-        "SH": {
-            "zoneName": "Svätá Helena, Ascension a Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovinsko"
-        },
-        "SJ": {
-            "zoneName": "Svalbard a Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovensko"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Maríno"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somálsko"
-        },
-        "SR": {
-            "zoneName": "Surinam"
-        },
-        "SS": {
-            "zoneName": "Južný Sudán"
-        },
-        "ST": {
-            "zoneName": "Svätý Tomáš a Princov ostrov"
-        },
-        "SV": {
-            "zoneName": "Salvádor"
-        },
-        "SX": {
-            "countryName": "San Maarten",
-            "zoneName": "Dutch"
-        },
-        "SY": {
-            "zoneName": "Sýria"
-        },
-        "SZ": {
-            "zoneName": "Svazijsko"
-        },
-        "TC": {
-            "zoneName": "Turks a Caicos"
-        },
-        "TD": {
-            "zoneName": "Čad"
-        },
-        "TF": {
-            "zoneName": "Francúzske južné a antarktické teritória"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thajsko"
-        },
-        "TJ": {
-            "zoneName": "Tadžikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Vychodnź Timor"
-        },
-        "TM": {
-            "zoneName": "Turkménsko"
-        },
-        "TN": {
-            "zoneName": "Tunisko"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turecko"
-        },
-        "TT": {
-            "zoneName": "Trinidad a Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tanzánia"
-        },
-        "UA": {
-            "zoneName": "Ukrajina"
-        },
-        "UA-CR": {
-            "countryName": "Ukrajina",
-            "zoneName": "Krym"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Menšie ohľahlé ostrovy USA"
-        },
-        "UY": {
-            "zoneName": "Uruguaj"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatikán"
-        },
-        "VC": {
-            "zoneName": "Svätý Vincent a Grenadíny"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Britské Panenské ostrovy",
-            "zoneName": "Britské Panenské ostrovy"
-        },
-        "VI": {
-            "countryName": "Spojené štáty americké",
-            "zoneName": "Americké Panenské ostrovy"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis a Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Severocyperská turecká republika"
-        },
-        "YE": {
-            "zoneName": "Jemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Južná Afrika"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Spojené Arabské Emiráty" },
+        "AF": { "zoneName": "Afganistan" },
+        "AG": { "zoneName": "Antigua a Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albánsko" },
+        "AM": { "zoneName": "Arménsko" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarktída" },
+        "AS": { "zoneName": "Americká Samoa" },
+        "AT": { "zoneName": "Rakúsko" },
+        "AR": { "zoneName": "Argentína" },
+        "AUS-NSW": { "countryName": "Austrália", "zoneName": "Nový Južný Wales" },
+        "AUS-NT": { "countryName": "Austrália", "zoneName": "Severné teritórium" },
+        "AUS-QLD": { "countryName": "Austrália", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Austrália", "zoneName": "Juzná Austrália" },
+        "AUS-TAS": { "countryName": "Austrália", "zoneName": "Tasmánia" },
+        "AUS-VIC": { "countryName": "Austrália", "zoneName": "Viktória" },
+        "AUS-WA": { "countryName": "Austrália", "zoneName": "Západná Austrália" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Ålandy" },
+        "AZ": { "zoneName": "Azerbajdžan" },
+        "BA": { "zoneName": "Bosna a Hercegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladéš" },
+        "BE": { "zoneName": "Belgicko" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulharsko" },
+        "BH": { "zoneName": "Bahrajn" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermudy" },
+        "BN": { "zoneName": "Brunej" },
+        "BO": { "zoneName": "Bolívia" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius and Saba" },
+        "BR-CS": { "countryName": "Brazília", "zoneName": "Centrálna Brazília" },
+        "BR-N": { "countryName": "Brazília", "zoneName": "Severná Brazília" },
+        "BR-NE": { "countryName": "Brazília", "zoneName": "Severovychodná Brazília" },
+        "BR-S": { "countryName": "Brazília", "zoneName": "Južná Brazília" },
+        "BS": { "zoneName": "Bahamy" },
+        "BT": { "zoneName": "Bhután" },
+        "BV": { "zoneName": "Bouvetov ostrov" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Bielorusko" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "Britská Kolumbia" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland a Labrador" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "New Brunswick" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Severozápadné teritóriá" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nové Škótsko" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontário" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Ostrov princa Eduarda" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Quebec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Kokosové ostrovy" },
+        "CD": { "zoneName": "Konžská emokratická republika" },
+        "CF": { "zoneName": "Stredoafrická Republika" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Švajčiarsko" },
+        "CI": { "zoneName": "Pobrežie Slonoviny" },
+        "CK": { "zoneName": "Cookove ostrovy" },
+        "CL-SING": { "countryName": "Čile", "zoneName": "SING" },
+        "CL-SEM": { "countryName": "Čile", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "Čile", "zoneName": "SEA" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Čína" },
+        "CO": { "zoneName": "Kolumbia" },
+        "CR": { "zoneName": "Kostarika" },
+        "CU": { "zoneName": "Kuba" },
+        "CV": { "zoneName": "Kapverdy" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Vianočný ostrov" },
+        "CY": { "zoneName": "Cyprus" },
+        "CZ": { "zoneName": "Česko" },
+        "DE": { "zoneName": "Nemecko" },
+        "DJ": { "zoneName": "Džibutsko" },
+        "DK": { "zoneName": "Dánsko" },
+        "DK-DK1": { "countryName": "Dánsko", "zoneName": "Západné Dánsko" },
+        "DK-DK2": { "countryName": "Dásko", "zoneName": "Vychodné Dánsko" },
+        "DK-BHM": { "countryName": "Dánsko", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominika" },
+        "DO": { "zoneName": "Dominikánska republika" },
+        "DZ": { "zoneName": "Alžírsko" },
+        "EC": { "zoneName": "Ekvádor" },
+        "EE": { "zoneName": "Estónsko" },
+        "EG": { "zoneName": "Egypt" },
+        "EH": { "zoneName": "Západná Sahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Španielsko" },
+        "ES-IB-FO": { "countryName": "Španielsko", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Španielsko", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Španielsko", "zoneName": "Malorka" },
+        "ES-IB-ME": { "countryName": "Španielsko", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Španielsko", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Španielsko", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Španielsko", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Španielsko", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "Španielsko", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Španielsko", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Etiópia" },
+        "FI": { "zoneName": "Fínsko" },
+        "FJ": { "zoneName": "Fidži" },
+        "FK": { "zoneName": "Falklandy" },
+        "FM": { "zoneName": "Mikronézia" },
+        "FO": { "zoneName": "Faerské ostrovy" },
+        "FR": { "zoneName": "Francúzsko" },
+        "FR-COR": { "countryName": "Francúzsko", "zoneName": "Korzika" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Veľká Británia" },
+        "GB-NIR": { "zoneName": "Severné Irsko" },
+        "GB-ORK": { "countryName": "Veľká Británia", "zoneName": "Orkneje" },
+        "GB-SHI": { "countryName": "Veľká Británia", "zoneName": "Shetlandy" },
+        "GB-ZET": { "countryName": "Velká Británia", "zoneName": "Shetlandy" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Gruzínsko" },
+        "GF": { "zoneName": "Francúzska Guyana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltár" },
+        "GL": { "zoneName": "Grónsko" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Rovníková Guinea" },
+        "GR": { "zoneName": "Grécko" },
+        "GR-IS": { "countryName": "Grécko", "zoneName": "Egejské ostrovy" },
+        "GS": { "zoneName": "Južná Georgia a Sandwichove ostrovy" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hongkong" },
+        "HM": { "zoneName": "Teritórium Heardovho ostrova a Macdonaldových ostrovov" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Chorvátsko" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Maďarsko" },
+        "ID": { "zoneName": "Indonézia" },
+        "IE": { "zoneName": "Írsko" },
+        "IL": { "zoneName": "Izrael" },
+        "IM": { "zoneName": "Ostrov Man" },
+        "IN-AN": { "countryName": "India", "zoneName": "Andmany a Nikobary" },
+        "IN-AP": { "countryName": "India", "zoneName": "Andhrapradáš" },
+        "IN-AR": { "countryName": "India", "zoneName": "Arunáčalpraéš" },
+        "IN-AS": { "countryName": "India", "zoneName": "Ásam" },
+        "IN-BR": { "countryName": "India", "zoneName": "Bihár" },
+        "IN-CT": { "countryName": "India", "zoneName": "Čhattásgarh" },
+        "IN-DL": { "countryName": "India", "zoneName": "Dillí" },
+        "IN-DN": { "countryName": "India", "zoneName": "Dádra a Nagar Havelí" },
+        "IN-GA": { "countryName": "India", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "India", "zoneName": "Gudžarát" },
+        "IN-HP": { "countryName": "India", "zoneName": "Himáčalpradéš" },
+        "IN-HR": { "countryName": "india", "zoneName": "Harijána" },
+        "IN-JH": { "countryName": "India", "zoneName": "Džhárkhand" },
+        "IN-JK": { "countryName": "India", "zoneName": "Džammú a Kašmír" },
+        "IN-KA": { "countryName": "India", "zoneName": "Karnátaka" },
+        "IN-KL": { "countryName": "India", "zoneName": "Kérala" },
+        "IN-MH": { "countryName": "India", "zoneName": "Maháraštra" },
+        "IN-ML": { "countryName": "India", "zoneName": "Meghálaj" },
+        "IN-MN": { "countryName": "India", "zoneName": "Manípur" },
+        "IN-MP": { "countryName": "India", "zoneName": "Madhjapradéš" },
+        "IN-MZ": { "countryName": "India", "zoneName": "Mizorám" },
+        "IN-NL": { "countryName": "India", "zoneName": "Nágsko" },
+        "IN-OR": { "countryName": "India", "zoneName": "Urísa" },
+        "IN-PB": { "countryName": "India", "zoneName": "Pandžáb" },
+        "IN-PY": { "countryName": "India", "zoneName": "Puttučéri" },
+        "IN-RJ": { "countryName": "India", "zoneName": "Radžastan" },
+        "IN-SK": { "countryName": "India", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "India", "zoneName": "Tamilnádu" },
+        "IN-TR": { "countryName": "India", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "India", "zoneName": "Uttarpradáš" },
+        "IN-UT": { "countryName": "India", "zoneName": "Uttarákhand" },
+        "IN-WB": { "countryName": "India", "zoneName": "Západné Bengálsko" },
+        "IO": { "zoneName": "Britské indickooceánske územie" },
+        "IQ": { "zoneName": "Irak" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Irán" },
+        "IS": { "zoneName": "Island" },
+        "IT": { "zoneName": "Taliansko" },
+        "IT-CNO": { "countryName": "Taliansko", "zoneName": "Centrálne Severné" },
+        "IT-CSO": { "countryName": "Taliansko", "zoneName": "Centrálne Južné" },
+        "IT-NO": { "countryName": "Taliansko", "zoneName": "Severné Taliansko" },
+        "IT-SAR": { "countryName": "Taliansko", "zoneName": "Sardínia" },
+        "IT-SIC": { "countryName": "Taliansko", "zoneName": "Sicília" },
+        "IT-SO": { "countryName": "Taliansko", "zoneName": "Južné Taliansko" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamajka" },
+        "JO": { "zoneName": "Jordánsko" },
+        "JP-CB": { "countryName": "Japonsko", "zoneName": "Čobú" },
+        "JP-CG": { "countryName": "Japan", "zoneName": "Čugokú" },
+        "JP-HKD": { "countryName": "Japonsko", "zoneName": "Hokkaidó" },
+        "JP-HR": { "countryName": "Japonsko", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japonsko", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japonsko", "zoneName": "Kjušú" },
+        "JP-ON": { "countryName": "Japonsko", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japonsko", "zoneName": "Šikoku" },
+        "JP-TH": { "countryName": "Japonsko", "zoneName": "Tóhoku" },
+        "JP-TK": { "countryName": "Japonsko", "zoneName": "Tokio" },
+        "KE": { "zoneName": "Keňa" },
+        "KG": { "zoneName": "Kirgizsko" },
+        "KH": { "zoneName": "Kambodža" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Komory" },
+        "KN": { "zoneName": "Svätý Krištof a Nevis" },
+        "KP": { "zoneName": "Kórejská ľudovodemokratická republika" },
+        "KR": { "zoneName": "Kórejská republika" },
+        "KW": { "zoneName": "Kuvajt" },
+        "KY": { "zoneName": "Kajmanie ostrovy" },
+        "KZ": { "zoneName": "Kazachstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Libanon" },
+        "LC": { "zoneName": "Svätá Lucia" },
+        "LI": { "zoneName": "Lichtenštajnsko" },
+        "LK": { "zoneName": "Srí Lanka" },
+        "LR": { "zoneName": "Libéria" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Litva" },
+        "LU": { "zoneName": "Luxembursko" },
+        "LV": { "zoneName": "Lotyšsko" },
+        "LY": { "zoneName": "Líbya" },
+        "MA": { "zoneName": "Maroko" },
+        "MC": { "zoneName": "Monako" },
+        "MD": { "zoneName": "Moldavsko" },
+        "ME": { "zoneName": "Čierna Hora" },
+        "MF": { "countryName": "Sväty Martin", "zoneName": "French" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Marshallove ostrovy" },
+        "MK": { "zoneName": "Severné Macedónsko" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Mjanmarsko" },
+        "MN": { "zoneName": "Mongolsko" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Severné Mariány" },
+        "MQ": { "zoneName": "Martinik" },
+        "MR": { "zoneName": "Mauritánia" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Maurícius" },
+        "MV": { "zoneName": "Maldivy" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mexiko" },
+        "MX-BC": { "countryName": "Mexiko", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mexiko", "zoneName": "Centrálne Mexiko" },
+        "MX-NE": { "countryName": "Mexiko", "zoneName": "Severovychodné Mexiko" },
+        "MX-NO": { "countryName": "Mexiko", "zoneName": "Severné Mexiko" },
+        "MX-NW": { "countryName": "Mexiko", "zoneName": "Severzápadné Mexiko" },
+        "MX-OC": { "countryName": "Mexiko", "zoneName": "Západné Mexiko" },
+        "MX-OR": { "countryName": "Mexiko", "zoneName": "Orientálne Mexiko" },
+        "MX-PN": { "countryName": "Mexiko", "zoneName": "Poloostrov" },
+        "MY-EM": { "countryName": "Malajzia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malajyia", "zoneName": "Poloostrov" },
+        "MZ": { "zoneName": "Mozambik" },
+        "NA": { "zoneName": "Namíbia" },
+        "NC": { "zoneName": "Nová Kaledónia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolk" },
+        "NG": { "zoneName": "Nigéria" },
+        "NI": { "zoneName": "Nikaragua" },
+        "NL": { "zoneName": "Holandsko" },
+        "NO-NO1": { "countryName": "Nórsko", "zoneName": "Juhovychodné Nórsko" },
+        "NO-NO2": { "countryName": "Nórsko", "zoneName": "Juhozápadné Nórsko" },
+        "NO-NO3": { "countryName": "Nórsko", "zoneName": "Stredné Nórsko" },
+        "NO-NO4": { "countryName": "Nórsko", "zoneName": "Severné Nórsko" },
+        "NO-NO5": { "countryName": "Nórsko", "zoneName": "Západné Nórsko" },
+        "NP": { "zoneName": "Nepál" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Novy Zéland" },
+        "NZ-NZA": { "countryName": "Novy Zéland", "zoneName": "Aucklandove ostrovy" },
+        "NZ-NZC": { "countryName": "Novy Zéland", "zoneName": "Chathamské ostrovy" },
+        "OM": { "zoneName": "Omán" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Francúzska Polynézia" },
+        "PG": { "zoneName": "Papua-Nová Guinea" },
+        "PH": { "zoneName": "Filipíny" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Poľsko" },
+        "PM": { "zoneName": "Saint Pierre a Miquelon" },
+        "PN": { "zoneName": "Pitcairnove ostrovy" },
+        "PR": { "zoneName": "Portoriko" },
+        "PS": { "zoneName": "Palestína" },
+        "PT": { "zoneName": "Portugalsko" },
+        "PT-AC": { "countryName": "Portugalsko", "zoneName": "Azory" },
+        "PT-MA": { "countryName": "Portugalsko", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguaj" },
+        "QA": { "zoneName": "Katar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Rumunsko" },
+        "RS": { "zoneName": "Srbsko" },
+        "RU": { "zoneName": "Rusko" },
+        "RU-1": { "countryName": "Rusko", "zoneName": "Európske Rusko a Ural" },
+        "RU-2": { "countryName": "Rusko", "zoneName": "Sibír" },
+        "RU-EU": { "zoneName": "Rusko" },
+        "RU-AS": { "zoneName": "Rusko" },
+        "RU-KGD": { "countryName": "Rusko", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Saudská Arábia" },
+        "SB": { "zoneName": "Šalamúnové ostrovy" },
+        "SC": { "zoneName": "Seychely" },
+        "SD": { "zoneName": "Sudán" },
+        "SE": { "zoneName": "Švédsko" },
+        "SG": { "zoneName": "Singapur" },
+        "SH": { "zoneName": "Svätá Helena, Ascension a Tristan da Cunha" },
+        "SI": { "zoneName": "Slovinsko" },
+        "SJ": { "zoneName": "Svalbard a Jan Mayen" },
+        "SK": { "zoneName": "Slovensko" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Maríno" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somálsko" },
+        "SR": { "zoneName": "Surinam" },
+        "SS": { "zoneName": "Južný Sudán" },
+        "ST": { "zoneName": "Svätý Tomáš a Princov ostrov" },
+        "SV": { "zoneName": "Salvádor" },
+        "SX": { "countryName": "San Maarten", "zoneName": "Dutch" },
+        "SY": { "zoneName": "Sýria" },
+        "SZ": { "zoneName": "Svazijsko" },
+        "TC": { "zoneName": "Turks a Caicos" },
+        "TD": { "zoneName": "Čad" },
+        "TF": { "zoneName": "Francúzske južné a antarktické teritória" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thajsko" },
+        "TJ": { "zoneName": "Tadžikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Vychodnź Timor" },
+        "TM": { "zoneName": "Turkménsko" },
+        "TN": { "zoneName": "Tunisko" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turecko" },
+        "TT": { "zoneName": "Trinidad a Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tanzánia" },
+        "UA": { "zoneName": "Ukrajina" },
+        "UA-CR": { "countryName": "Ukrajina", "zoneName": "Krym" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Menšie ohľahlé ostrovy USA" },
+        "UY": { "zoneName": "Uruguaj" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Vatikán" },
+        "VC": { "zoneName": "Svätý Vincent a Grenadíny" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Britské Panenské ostrovy", "zoneName": "Britské Panenské ostrovy" },
+        "VI": { "countryName": "Spojené štáty americké", "zoneName": "Americké Panenské ostrovy" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis a Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Severocyperská turecká republika" },
+        "YE": { "zoneName": "Jemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Južná Afrika" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/sv.json
+++ b/web/public/locales/sv.json
@@ -6,15 +6,9 @@
         "datasources": "datakällor",
         "contribute": "Bidra genom att <a href=\"%s\" target=\"_blank\">lägga till din region</a>"
     },
-    "mobile-main-menu": {
-        "map": "Elkarta",
-        "areas": "Regioner",
-        "about": "Om"
-    },
+    "mobile-main-menu": { "map": "Elkarta", "areas": "Regioner", "about": "Om" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Kartlägger klimatpåverkan från elkonsumtion"
-        },
+        "view1": { "subtitle": "Kartlägger klimatpåverkan från elkonsumtion" },
         "view2": {
             "header": "Se hur mycket CO₂ som släpps ut när din el produceras, i realtid.",
             "text": "Vi färglägger regioner runt om i världen baserat på dess kolintensitet (inklusive alla växthusgaser) från el konsumerad där. Ju grönare färg, desto mer klimatvänlig el."
@@ -55,14 +49,14 @@
         "search": "Sök efter region"
     },
     "country-history": {
-        "carbonintensity24h": "Kolintensitet under de senaste 24 timmarna",
-        "emissions24h": "Utsläpp de senaste 24 timmarna",
-        "emissionsorigin24h": "Källa för utsläpp de senaste 24 timmarna",
-        "emissionsproduction24h": "Utsläpp producerad de senaste 24 timmarna",
-        "electricityorigin24h": "Källa för el under de senaste 24 timmarna",
-        "electricityproduction24h": "El producerad de senaste 24 timmarna",
-        "electricityprices24h": "Elpriser under de senaste 24 timmarna",
-        "Getdata": "API från electricityMap för att hämta timvis historisk data, aktuell data och prognos"
+        "Getdata": "API från electricityMap för att hämta timvis historisk data, aktuell data och prognos",
+        "carbonintensity": { "hourly": "Kolintensitet under de senaste 24 timmarna" },
+        "emissionsorigin": { "hourly": "Källa för utsläpp de senaste 24 timmarna" },
+        "emissionsproduction": { "hourly": "Utsläpp producerad de senaste 24 timmarna" },
+        "electricityorigin": { "hourly": "Källa för el under de senaste 24 timmarna" },
+        "electricityproduction": { "hourly": "El producerad de senaste 24 timmarna" },
+        "electricityprices": { "hourly": "Elpriser under de senaste 24 timmarna" },
+        "emissions": { "hourly": "Utsläpp de senaste 24 timmarna" }
     },
     "footer": {
         "foundbugs": "Hittat buggar eller har idéer? Rapportera dem",
@@ -207,1325 +201,392 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publicerar data och bilder på The <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> för informationsändamål. Det görs inga påståenden om korrekthet och inte heller lämnas några garantier, och vi förbehåller oss rätten att ändra innehållet när som helst eller ta bort delar utan att behöva informera dig om detta. electricityMap påtar sig inget ansvar för några skador eller kostnader som kan förorsakas till följd av felaktigheter, ofullständigheter, otydligheter eller inaktuell data på electricityMap, eller information som härrör från den. Det är inte tillåtet att använda denna hemsida, eller dess individuella element, på andra hemsidor, utan formellt skriftligt förhandsgodkännande.<br><br>Alla immateriella rättigheter tillhör de berättigade ägarna och dess licensgivare. Kopiering, distribution och annan användning av dessa material, i synnerhet energidata, är otillåtet utan skriftligt tillstånd från electricityMap, utom och endast i den utsträckning som anges i bestämmelser i obligatorisk lagstiftning (så som rätten att citera), om inget annat anges för specifikt material.<br><br>Denna ansvarsfriskrivning kan uppdateras då och då"
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Förenade Arabemiraten"
-        },
-        "AF": {
-            "zoneName": "Afghanistan"
-        },
-        "AG": {
-            "zoneName": "Antigua och Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albanien"
-        },
-        "AM": {
-            "zoneName": "Armenien"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Antarktis"
-        },
-        "AS": {
-            "zoneName": "Amerikanska Samoa"
-        },
-        "AT": {
-            "zoneName": "Österrike"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AUS-NSW": {
-            "countryName": "Australien",
-            "zoneName": "New South Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Australien",
-            "zoneName": "Northern Territory"
-        },
-        "AUS-QLD": {
-            "countryName": "Australien",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Australien",
-            "zoneName": "South Australia"
-        },
-        "AUS-TAS": {
-            "countryName": "Australien",
-            "zoneName": "Tasmanien"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Australien",
-            "zoneName": "King Island"
-        },
-        "AUS-TAS-FI": {
-            "countryName": "Australien",
-            "zoneName": "Flinders Island"
-        },
-        "AUS-TAS-CBI": {
-            "countryName": "Australien",
-            "zoneName": "Cape Barren Island"
-        },
-        "AUS-VIC": {
-            "countryName": "Australien",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Australien",
-            "zoneName": "Western Australia"
-        },
-        "AUS-WA-RI": {
-            "countryName": "Australien",
-            "zoneName": "Rottnest Island"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Åland"
-        },
-        "AZ": {
-            "zoneName": "Azerbajdzjan"
-        },
-        "BA": {
-            "zoneName": "Bosnien och Hercegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Belgien"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgarien"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius och Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brasilien",
-            "zoneName": "Centrala Brasilien"
-        },
-        "BR-N": {
-            "countryName": "Brasilien",
-            "zoneName": "Norra Brasilien"
-        },
-        "BR-NE": {
-            "countryName": "Brasilien",
-            "zoneName": "Nordöstra Brasilien"
-        },
-        "BR-S": {
-            "countryName": "Brasilien",
-            "zoneName": "Södra Brasilien"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Bouvetön"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Belarus"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Kanada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Kanada",
-            "zoneName": "British Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Kanada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland och Labrador"
-        },
-        "CA-NL-LB": {
-            "countryName": "Kanada",
-            "zoneName": "Labrador"
-        },
-        "CA-NL-NF": {
-            "countryName": "Kanada",
-            "zoneName": "Newfoundland"
-        },
-        "CA-NB": {
-            "countryName": "Kanada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Kanada",
-            "zoneName": "Northwest Territories"
-        },
-        "CA-NS": {
-            "countryName": "Kanada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NU": {
-            "countryName": "Kanada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Kanada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Kanada",
-            "zoneName": "Prince Edward Island"
-        },
-        "CA-QC": {
-            "countryName": "Kanada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Kanada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Kanada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Kokosöarna"
-        },
-        "CD": {
-            "zoneName": "Demokratiska republiken Kongo"
-        },
-        "CF": {
-            "zoneName": "Centralafrikanska republiken"
-        },
-        "CG": {
-            "zoneName": "Kongo"
-        },
-        "CH": {
-            "zoneName": "Schweiz"
-        },
-        "CI": {
-            "zoneName": "Elfenbenskusten"
-        },
-        "CK": {
-            "zoneName": "Cooköarna"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Aysén"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico de Magallanes"
-        },
-        "CL-SEN": {
-            "countryName": "Chile",
-            "zoneName": "Sistema Eléctrico Nacional"
-        },
-        "CL-CHP": {
-            "countryName": "Chile",
-            "zoneName": "Påskön"
-        },
-        "CM": {
-            "zoneName": "Kamerun"
-        },
-        "CN": {
-            "zoneName": "Kina"
-        },
-        "CO": {
-            "zoneName": "Colombia"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Kuba"
-        },
-        "CV": {
-            "zoneName": "Kap Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Julön"
-        },
-        "CY": {
-            "zoneName": "Cypern"
-        },
-        "CZ": {
-            "zoneName": "Tjeckien"
-        },
-        "DE": {
-            "zoneName": "Tyskland"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Danmark"
-        },
-        "DK-DK1": {
-            "countryName": "Danmark",
-            "zoneName": "Västra Danmark"
-        },
-        "DK-DK2": {
-            "countryName": "Danmark",
-            "zoneName": "Östra Danmark"
-        },
-        "DK-BHM": {
-            "countryName": "Danmark",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "Dominikanska republiken"
-        },
-        "DZ": {
-            "zoneName": "Algeriet"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Estland"
-        },
-        "EG": {
-            "zoneName": "Egypten"
-        },
-        "EH": {
-            "zoneName": "Västsahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Spanien"
-        },
-        "ES-IB-FO": {
-            "countryName": "Spanien",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Spanien",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Spanien",
-            "zoneName": "Mallorca "
-        },
-        "ES-IB-ME": {
-            "countryName": "Spanien",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Spanien",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Spanien",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Spanien",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Spanien",
-            "zoneName": "La Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Spanien",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Spanien",
-            "zoneName": "Teneriffa"
-        },
-        "ET": {
-            "zoneName": "Etiopien"
-        },
-        "FI": {
-            "zoneName": "Finland"
-        },
-        "FJ": {
-            "zoneName": "Fiji"
-        },
-        "FK": {
-            "zoneName": "Falklandsöarna"
-        },
-        "FM": {
-            "zoneName": "Mikronesien"
-        },
-        "FO": {
-            "zoneName": "Färöarna"
-        },
-        "FR": {
-            "zoneName": "Frankrike"
-        },
-        "FR-COR": {
-            "countryName": "Frankrike",
-            "zoneName": "Korsika"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Storbritannien"
-        },
-        "GB-NIR": {
-            "zoneName": "Nordirland"
-        },
-        "GB-ORK": {
-            "countryName": "Storbritannien",
-            "zoneName": "Orkneyöarna"
-        },
-        "GB-SHI": {
-            "countryName": "Storbritannien",
-            "zoneName": "Shetlandsöarna"
-        },
-        "GB-ZET": {
-            "countryName": "Storbritannien",
-            "zoneName": "Shetlandsöarna"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgien"
-        },
-        "GF": {
-            "zoneName": "Franska Guyana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Grönland"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Ekvatorialguinea"
-        },
-        "GR": {
-            "zoneName": "Grekland"
-        },
-        "GR-IS": {
-            "countryName": "Grekland",
-            "zoneName": "Egeiska öarna"
-        },
-        "GS": {
-            "zoneName": "Sydgeorgien och Sydsandwichöarna"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hongkong"
-        },
-        "HM": {
-            "zoneName": "Heard- och McDonaldöarna"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Kroatien"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Ungern"
-        },
-        "ID": {
-            "zoneName": "Indonesien"
-        },
-        "IE": {
-            "zoneName": "Irland"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Isle of Man"
-        },
-        "IN-AN": {
-            "countryName": "Indien",
-            "zoneName": "Andamanerna och Nikobarerna"
-        },
-        "IN-AP": {
-            "countryName": "Indien",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Indien",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Indien",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "Indien",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Indien",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Indien",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "Indien",
-            "zoneName": "Dadra och Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "Indien",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Indien",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "Indien",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Indien",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "Indien",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Indien",
-            "zoneName": "Jammu och Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "Indien",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Indien",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Indien",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "Indien",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Indien",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Indien",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Indien",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Indien",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Indien",
-            "zoneName": "Odisha"
-        },
-        "IN-PB": {
-            "countryName": "Indien",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "Indien",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "Indien",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "Indien",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "Indien",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "Indien",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Indien",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Indien",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Indien",
-            "zoneName": "Västbengalen"
-        },
-        "IO": {
-            "zoneName": "Brittiska territoriet i Indiska oceanen"
-        },
-        "IQ": {
-            "zoneName": "Irak"
-        },
-        "IQ-KUR": {
-            "countryName": "Irak",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Island"
-        },
-        "IT": {
-            "zoneName": "Italien"
-        },
-        "IT-CNO": {
-            "countryName": "Italien",
-            "zoneName": "Centrala norra"
-        },
-        "IT-CSO": {
-            "countryName": "Italien",
-            "zoneName": "Centrala södra"
-        },
-        "IT-NO": {
-            "countryName": "Italien",
-            "zoneName": "Norra"
-        },
-        "IT-SAR": {
-            "countryName": "Italien",
-            "zoneName": "Sardinien"
-        },
-        "IT-SIC": {
-            "countryName": "Italien",
-            "zoneName": "Sicilien"
-        },
-        "IT-SO": {
-            "countryName": "Italien",
-            "zoneName": "Södra"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaica"
-        },
-        "JO": {
-            "zoneName": "Jordanien"
-        },
-        "JP-CB": {
-            "countryName": "Japan",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Japan",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Japan",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Japan",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Japan",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Japan",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Japan",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Japan",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Japan",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Japan",
-            "zoneName": "Tōkyō"
-        },
-        "KE": {
-            "zoneName": "Kenya"
-        },
-        "KG": {
-            "zoneName": "Kirgizistan"
-        },
-        "KH": {
-            "zoneName": "Kambodja"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Komorerna"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts och Nevis"
-        },
-        "KP": {
-            "zoneName": "Nordkorea"
-        },
-        "KR": {
-            "zoneName": "Sydkorea"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Caymanöarna"
-        },
-        "KZ": {
-            "zoneName": "Kazakstan"
-        },
-        "LA": {
-            "zoneName": "Laos"
-        },
-        "LB": {
-            "zoneName": "Libanon"
-        },
-        "LC": {
-            "zoneName": "Saint Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Litauen"
-        },
-        "LU": {
-            "zoneName": "Luxemburg"
-        },
-        "LV": {
-            "zoneName": "Lettland"
-        },
-        "LY": {
-            "zoneName": "Libyen"
-        },
-        "MA": {
-            "zoneName": "Marocko"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldavien"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Saint-Martin",
-            "zoneName": "Franska"
-        },
-        "MG": {
-            "zoneName": "Madagaskar"
-        },
-        "MH": {
-            "zoneName": "Marshallöarna"
-        },
-        "MK": {
-            "zoneName": "Nordmakedonien"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Burma"
-        },
-        "MN": {
-            "zoneName": "Mongoliet"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Nordmarianerna"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauretanien"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Maldiverna"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mexiko"
-        },
-        "MX-BC": {
-            "countryName": "Mexiko",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mexiko",
-            "zoneName": "Centrala"
-        },
-        "MX-NE": {
-            "countryName": "Mexiko",
-            "zoneName": "Nordöstra"
-        },
-        "MX-NO": {
-            "countryName": "Mexiko",
-            "zoneName": "Norra"
-        },
-        "MX-NW": {
-            "countryName": "Mexiko",
-            "zoneName": "Nordvästra"
-        },
-        "MX-OC": {
-            "countryName": "Mexiko",
-            "zoneName": "Occidental"
-        },
-        "MX-OR": {
-            "countryName": "Mexiko",
-            "zoneName": "Oriental"
-        },
-        "MX-PN": {
-            "countryName": "Mexico",
-            "zoneName": "Peninsula"
-        },
-        "MY-EM": {
-            "countryName": "Malaysia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malaysia",
-            "zoneName": "Västmalaysia"
-        },
-        "MZ": {
-            "zoneName": "Moçambique"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "Nya Kaledonien"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Norfolkön"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabach"
-        },
-        "NL": {
-            "zoneName": "Nederländerna"
-        },
-        "NO-NO1": {
-            "countryName": "Norge",
-            "zoneName": "Sydöstra Norge"
-        },
-        "NO-NO2": {
-            "countryName": "Norge",
-            "zoneName": "Sydvästra Norge"
-        },
-        "NO-NO3": {
-            "countryName": "Norge",
-            "zoneName": "Mellersta Norge"
-        },
-        "NO-NO4": {
-            "countryName": "Norge",
-            "zoneName": "Norra Norge"
-        },
-        "NO-NO5": {
-            "countryName": "Norge",
-            "zoneName": "Västra Norge"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "Nya Zeeland"
-        },
-        "NZ-NZA": {
-            "countryName": "Nya Zeeland",
-            "zoneName": "Aucklandöarna"
-        },
-        "NZ-NZC": {
-            "countryName": "Nya Zeeland",
-            "zoneName": "Chathamöarna"
-        },
-        "NZ-NZST": {
-            "countryName": "Nya Zeeland",
-            "zoneName": "Stewart Island"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Franska Polynesien"
-        },
-        "PG": {
-            "zoneName": "Papua Nya Guinea"
-        },
-        "PH": {
-            "zoneName": "Filippinerna"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Polen"
-        },
-        "PM": {
-            "zoneName": "Saint-Pierre och Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairnöarna"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Staten Palestina"
-        },
-        "PT": {
-            "zoneName": "Portugal"
-        },
-        "PT-AC": {
-            "countryName": "Portugal",
-            "zoneName": "Azorerna"
-        },
-        "PT-MA": {
-            "countryName": "Portugal",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Qatar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Rumänien"
-        },
-        "RS": {
-            "zoneName": "Serbien"
-        },
-        "RU": {
-            "zoneName": "Ryssland"
-        },
-        "RU-1": {
-            "countryName": "Ryssland",
-            "zoneName": "Europeiska Ryssland och Ural"
-        },
-        "RU-2": {
-            "countryName": "Ryssland",
-            "zoneName": "Sibirien"
-        },
-        "RU-EU": {
-            "zoneName": "Ryssland"
-        },
-        "RU-AS": {
-            "zoneName": "Ryssland"
-        },
-        "RU-KGD": {
-            "countryName": "Ryssland",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Saudiarabien"
-        },
-        "SB": {
-            "zoneName": "Salomonöarna"
-        },
-        "SC": {
-            "zoneName": "Seychellerna"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Sverige"
-        },
-        "SG": {
-            "zoneName": "Singapore"
-        },
-        "SH": {
-            "zoneName": "Sankta Helena, Ascension och Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovenien"
-        },
-        "SJ": {
-            "zoneName": "Svalbard och Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovakien"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Surinam"
-        },
-        "SS": {
-            "zoneName": "Sydsudan"
-        },
-        "ST": {
-            "zoneName": "São Tomé och Príncipe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Nederländerna"
-        },
-        "SY": {
-            "zoneName": "Syrien"
-        },
-        "SZ": {
-            "zoneName": "Swaziland"
-        },
-        "TC": {
-            "zoneName": "Turks- och Caicosöarna"
-        },
-        "TD": {
-            "zoneName": "Tchad"
-        },
-        "TF": {
-            "zoneName": "Franska sydterritorierna"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thailand"
-        },
-        "TJ": {
-            "zoneName": "Tadzjikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Östtimor"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunisien"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Turkiet"
-        },
-        "TT": {
-            "zoneName": "Trinidad och Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Taiwan"
-        },
-        "TZ": {
-            "zoneName": "Tanzania"
-        },
-        "UA": {
-            "zoneName": "Ukraina"
-        },
-        "UA-CR": {
-            "countryName": "Krim",
-            "zoneName": "Ukraina"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Förenta staternas mindre öar i Oceanien och Västindien"
-        },
-        "US-HI-HA": {
-            "countryName": "USA",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "USA",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "USA",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "USA",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "USA",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "USA",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "USA",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "USA",
-            "zoneName": "Oahu"
-        },
-        "US-CAL-BANC": {
-            "countryName": "USA",
-            "zoneName": "Balancing Authority Of Northern California"
-        },
-        "US-CAL-CISO": {
-            "countryName": "USA",
-            "zoneName": "California Independent System Operator"
-        },
-        "US-CAL-IID": {
-            "countryName": "USA",
-            "zoneName": "Imperial Irrigation District"
-        },
-        "US-CAL-LDWP": {
-            "countryName": "USA",
-            "zoneName": "Los Angeles Department Of Water And Power"
-        },
-        "US-CAL-TIDC": {
-            "countryName": "USA",
-            "zoneName": "Turlock Irrigation District"
-        },
-        "US-CAR-CPLE": {
-            "countryName": "USA",
-            "zoneName": "Duke Energy Progress East"
-        },
-        "US-CAR-CPLW": {
-            "countryName": "USA",
-            "zoneName": "Duke Energy Progress West"
-        },
-        "US-CAR-DUK": {
-            "countryName": "USA",
-            "zoneName": "Duke Energy Carolinas"
-        },
-        "US-CAR-SC": {
-            "countryName": "USA",
-            "zoneName": "South Carolina Public Service Authority"
-        },
-        "US-CAR-SCEG": {
-            "countryName": "USA",
-            "zoneName": "South Carolina Electric & Gas Company"
-        },
-        "US-CAR-YAD": {
-            "countryName": "USA",
-            "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
-        },
-        "US-CENT-SPA": {
-            "countryName": "USA",
-            "zoneName": "Southwestern Power Administration"
-        },
-        "US-CENT-SWPP": {
-            "countryName": "USA",
-            "zoneName": "Southwest Power Pool"
-        },
-        "US-FLA-FMPP": {
-            "countryName": "USA",
-            "zoneName": "Florida Municipal Power Pool"
-        },
-        "US-FLA-FPC": {
-            "countryName": "USA",
-            "zoneName": "Duke Energy Florida Inc"
-        },
-        "US-FLA-FPL": {
-            "countryName": "USA",
-            "zoneName": "Florida Power & Light Company"
-        },
-        "US-FLA-GVL": {
-            "countryName": "USA",
-            "zoneName": "Gainesville Regional Utilities"
-        },
-        "US-FLA-HST": {
-            "countryName": "USA",
-            "zoneName": "City Of Homestead"
-        },
-        "US-FLA-JEA": {
-            "countryName": "USA",
-            "zoneName": "JEA"
-        },
-        "US-FLA-NSB": {
-            "countryName": "USA",
-            "zoneName": "Utilities Commission Of New Smyrna Beach"
-        },
-        "US-FLA-SEC": {
-            "countryName": "USA",
-            "zoneName": "Seminole Electric Cooperative"
-        },
-        "US-FLA-TAL": {
-            "countryName": "USA",
-            "zoneName": "City Of Tallahassee"
-        },
-        "US-FLA-TEC": {
-            "countryName": "USA",
-            "zoneName": "Tampa Electric Company"
-        },
-        "US-MIDA-PJM": {
-            "countryName": "USA",
-            "zoneName": "PJM Interconnection, Llc"
-        },
-        "US-MIDW-AECI": {
-            "countryName": "USA",
-            "zoneName": "Associated Electric Cooperative, Inc."
-        },
-        "US-MIDW-GLHB": {
-            "countryName": "USA",
-            "zoneName": "GridLiance"
-        },
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Förenade Arabemiraten" },
+        "AF": { "zoneName": "Afghanistan" },
+        "AG": { "zoneName": "Antigua och Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albanien" },
+        "AM": { "zoneName": "Armenien" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Antarktis" },
+        "AS": { "zoneName": "Amerikanska Samoa" },
+        "AT": { "zoneName": "Österrike" },
+        "AR": { "zoneName": "Argentina" },
+        "AUS-NSW": { "countryName": "Australien", "zoneName": "New South Wales" },
+        "AUS-NT": { "countryName": "Australien", "zoneName": "Northern Territory" },
+        "AUS-QLD": { "countryName": "Australien", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Australien", "zoneName": "South Australia" },
+        "AUS-TAS": { "countryName": "Australien", "zoneName": "Tasmanien" },
+        "AUS-TAS-KI": { "countryName": "Australien", "zoneName": "King Island" },
+        "AUS-TAS-FI": { "countryName": "Australien", "zoneName": "Flinders Island" },
+        "AUS-TAS-CBI": { "countryName": "Australien", "zoneName": "Cape Barren Island" },
+        "AUS-VIC": { "countryName": "Australien", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Australien", "zoneName": "Western Australia" },
+        "AUS-WA-RI": { "countryName": "Australien", "zoneName": "Rottnest Island" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Åland" },
+        "AZ": { "zoneName": "Azerbajdzjan" },
+        "BA": { "zoneName": "Bosnien och Hercegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Belgien" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgarien" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius och Saba" },
+        "BR-CS": { "countryName": "Brasilien", "zoneName": "Centrala Brasilien" },
+        "BR-N": { "countryName": "Brasilien", "zoneName": "Norra Brasilien" },
+        "BR-NE": { "countryName": "Brasilien", "zoneName": "Nordöstra Brasilien" },
+        "BR-S": { "countryName": "Brasilien", "zoneName": "Södra Brasilien" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Bouvetön" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Belarus" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Kanada", "zoneName": "British Columbia" },
+        "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland och Labrador" },
+        "CA-NL-LB": { "countryName": "Kanada", "zoneName": "Labrador" },
+        "CA-NL-NF": { "countryName": "Kanada", "zoneName": "Newfoundland" },
+        "CA-NB": { "countryName": "Kanada", "zoneName": "New Brunswick" },
+        "CA-NT": { "countryName": "Kanada", "zoneName": "Northwest Territories" },
+        "CA-NS": { "countryName": "Kanada", "zoneName": "Nova Scotia" },
+        "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Kanada", "zoneName": "Prince Edward Island" },
+        "CA-QC": { "countryName": "Kanada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Kokosöarna" },
+        "CD": { "zoneName": "Demokratiska republiken Kongo" },
+        "CF": { "zoneName": "Centralafrikanska republiken" },
+        "CG": { "zoneName": "Kongo" },
+        "CH": { "zoneName": "Schweiz" },
+        "CI": { "zoneName": "Elfenbenskusten" },
+        "CK": { "zoneName": "Cooköarna" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Aysén" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Magallanes" },
+        "CL-SEN": { "countryName": "Chile", "zoneName": "Sistema Eléctrico Nacional" },
+        "CL-CHP": { "countryName": "Chile", "zoneName": "Påskön" },
+        "CM": { "zoneName": "Kamerun" },
+        "CN": { "zoneName": "Kina" },
+        "CO": { "zoneName": "Colombia" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Kuba" },
+        "CV": { "zoneName": "Kap Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Julön" },
+        "CY": { "zoneName": "Cypern" },
+        "CZ": { "zoneName": "Tjeckien" },
+        "DE": { "zoneName": "Tyskland" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Danmark" },
+        "DK-DK1": { "countryName": "Danmark", "zoneName": "Västra Danmark" },
+        "DK-DK2": { "countryName": "Danmark", "zoneName": "Östra Danmark" },
+        "DK-BHM": { "countryName": "Danmark", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "Dominikanska republiken" },
+        "DZ": { "zoneName": "Algeriet" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Estland" },
+        "EG": { "zoneName": "Egypten" },
+        "EH": { "zoneName": "Västsahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Spanien" },
+        "ES-IB-FO": { "countryName": "Spanien", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Spanien", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Spanien", "zoneName": "Mallorca " },
+        "ES-IB-ME": { "countryName": "Spanien", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Spanien", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Spanien", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Spanien", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Spanien", "zoneName": "La Gomera" },
+        "ES-CN-LP": { "countryName": "Spanien", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Spanien", "zoneName": "Teneriffa" },
+        "ET": { "zoneName": "Etiopien" },
+        "FI": { "zoneName": "Finland" },
+        "FJ": { "zoneName": "Fiji" },
+        "FK": { "zoneName": "Falklandsöarna" },
+        "FM": { "zoneName": "Mikronesien" },
+        "FO": { "zoneName": "Färöarna" },
+        "FR": { "zoneName": "Frankrike" },
+        "FR-COR": { "countryName": "Frankrike", "zoneName": "Korsika" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Storbritannien" },
+        "GB-NIR": { "zoneName": "Nordirland" },
+        "GB-ORK": { "countryName": "Storbritannien", "zoneName": "Orkneyöarna" },
+        "GB-SHI": { "countryName": "Storbritannien", "zoneName": "Shetlandsöarna" },
+        "GB-ZET": { "countryName": "Storbritannien", "zoneName": "Shetlandsöarna" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgien" },
+        "GF": { "zoneName": "Franska Guyana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Grönland" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Ekvatorialguinea" },
+        "GR": { "zoneName": "Grekland" },
+        "GR-IS": { "countryName": "Grekland", "zoneName": "Egeiska öarna" },
+        "GS": { "zoneName": "Sydgeorgien och Sydsandwichöarna" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hongkong" },
+        "HM": { "zoneName": "Heard- och McDonaldöarna" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Kroatien" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Ungern" },
+        "ID": { "zoneName": "Indonesien" },
+        "IE": { "zoneName": "Irland" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Isle of Man" },
+        "IN-AN": { "countryName": "Indien", "zoneName": "Andamanerna och Nikobarerna" },
+        "IN-AP": { "countryName": "Indien", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Indien", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Indien", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "Indien", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Indien", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Indien", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "Indien", "zoneName": "Dadra och Nagar Haveli" },
+        "IN-GA": { "countryName": "Indien", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Indien", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "Indien", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Indien", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "Indien", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Indien", "zoneName": "Jammu och Kashmir" },
+        "IN-KA": { "countryName": "Indien", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Indien", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Indien", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "Indien", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Indien", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Indien", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Indien", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Indien", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Indien", "zoneName": "Odisha" },
+        "IN-PB": { "countryName": "Indien", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "Indien", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "Indien", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "Indien", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "Indien", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "Indien", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Indien", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Indien", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Indien", "zoneName": "Västbengalen" },
+        "IO": { "zoneName": "Brittiska territoriet i Indiska oceanen" },
+        "IQ": { "zoneName": "Irak" },
+        "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Island" },
+        "IT": { "zoneName": "Italien" },
+        "IT-CNO": { "countryName": "Italien", "zoneName": "Centrala norra" },
+        "IT-CSO": { "countryName": "Italien", "zoneName": "Centrala södra" },
+        "IT-NO": { "countryName": "Italien", "zoneName": "Norra" },
+        "IT-SAR": { "countryName": "Italien", "zoneName": "Sardinien" },
+        "IT-SIC": { "countryName": "Italien", "zoneName": "Sicilien" },
+        "IT-SO": { "countryName": "Italien", "zoneName": "Södra" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaica" },
+        "JO": { "zoneName": "Jordanien" },
+        "JP-CB": { "countryName": "Japan", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Japan", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Japan", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Japan", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Japan", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Japan", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Japan", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Japan", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Japan", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Japan", "zoneName": "Tōkyō" },
+        "KE": { "zoneName": "Kenya" },
+        "KG": { "zoneName": "Kirgizistan" },
+        "KH": { "zoneName": "Kambodja" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Komorerna" },
+        "KN": { "zoneName": "Saint Kitts och Nevis" },
+        "KP": { "zoneName": "Nordkorea" },
+        "KR": { "zoneName": "Sydkorea" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Caymanöarna" },
+        "KZ": { "zoneName": "Kazakstan" },
+        "LA": { "zoneName": "Laos" },
+        "LB": { "zoneName": "Libanon" },
+        "LC": { "zoneName": "Saint Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Litauen" },
+        "LU": { "zoneName": "Luxemburg" },
+        "LV": { "zoneName": "Lettland" },
+        "LY": { "zoneName": "Libyen" },
+        "MA": { "zoneName": "Marocko" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldavien" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Saint-Martin", "zoneName": "Franska" },
+        "MG": { "zoneName": "Madagaskar" },
+        "MH": { "zoneName": "Marshallöarna" },
+        "MK": { "zoneName": "Nordmakedonien" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Burma" },
+        "MN": { "zoneName": "Mongoliet" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Nordmarianerna" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauretanien" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Maldiverna" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mexiko" },
+        "MX-BC": { "countryName": "Mexiko", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mexiko", "zoneName": "Centrala" },
+        "MX-NE": { "countryName": "Mexiko", "zoneName": "Nordöstra" },
+        "MX-NO": { "countryName": "Mexiko", "zoneName": "Norra" },
+        "MX-NW": { "countryName": "Mexiko", "zoneName": "Nordvästra" },
+        "MX-OC": { "countryName": "Mexiko", "zoneName": "Occidental" },
+        "MX-OR": { "countryName": "Mexiko", "zoneName": "Oriental" },
+        "MX-PN": { "countryName": "Mexico", "zoneName": "Peninsula" },
+        "MY-EM": { "countryName": "Malaysia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malaysia", "zoneName": "Västmalaysia" },
+        "MZ": { "zoneName": "Moçambique" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "Nya Kaledonien" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Norfolkön" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Nagorno-Karabach" },
+        "NL": { "zoneName": "Nederländerna" },
+        "NO-NO1": { "countryName": "Norge", "zoneName": "Sydöstra Norge" },
+        "NO-NO2": { "countryName": "Norge", "zoneName": "Sydvästra Norge" },
+        "NO-NO3": { "countryName": "Norge", "zoneName": "Mellersta Norge" },
+        "NO-NO4": { "countryName": "Norge", "zoneName": "Norra Norge" },
+        "NO-NO5": { "countryName": "Norge", "zoneName": "Västra Norge" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "Nya Zeeland" },
+        "NZ-NZA": { "countryName": "Nya Zeeland", "zoneName": "Aucklandöarna" },
+        "NZ-NZC": { "countryName": "Nya Zeeland", "zoneName": "Chathamöarna" },
+        "NZ-NZST": { "countryName": "Nya Zeeland", "zoneName": "Stewart Island" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Franska Polynesien" },
+        "PG": { "zoneName": "Papua Nya Guinea" },
+        "PH": { "zoneName": "Filippinerna" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Polen" },
+        "PM": { "zoneName": "Saint-Pierre och Miquelon" },
+        "PN": { "zoneName": "Pitcairnöarna" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Staten Palestina" },
+        "PT": { "zoneName": "Portugal" },
+        "PT-AC": { "countryName": "Portugal", "zoneName": "Azorerna" },
+        "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Qatar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Rumänien" },
+        "RS": { "zoneName": "Serbien" },
+        "RU": { "zoneName": "Ryssland" },
+        "RU-1": { "countryName": "Ryssland", "zoneName": "Europeiska Ryssland och Ural" },
+        "RU-2": { "countryName": "Ryssland", "zoneName": "Sibirien" },
+        "RU-EU": { "zoneName": "Ryssland" },
+        "RU-AS": { "zoneName": "Ryssland" },
+        "RU-KGD": { "countryName": "Ryssland", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Saudiarabien" },
+        "SB": { "zoneName": "Salomonöarna" },
+        "SC": { "zoneName": "Seychellerna" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Sverige" },
+        "SG": { "zoneName": "Singapore" },
+        "SH": { "zoneName": "Sankta Helena, Ascension och Tristan da Cunha" },
+        "SI": { "zoneName": "Slovenien" },
+        "SJ": { "zoneName": "Svalbard och Jan Mayen" },
+        "SK": { "zoneName": "Slovakien" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Surinam" },
+        "SS": { "zoneName": "Sydsudan" },
+        "ST": { "zoneName": "São Tomé och Príncipe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Nederländerna" },
+        "SY": { "zoneName": "Syrien" },
+        "SZ": { "zoneName": "Swaziland" },
+        "TC": { "zoneName": "Turks- och Caicosöarna" },
+        "TD": { "zoneName": "Tchad" },
+        "TF": { "zoneName": "Franska sydterritorierna" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thailand" },
+        "TJ": { "zoneName": "Tadzjikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Östtimor" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunisien" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Turkiet" },
+        "TT": { "zoneName": "Trinidad och Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Taiwan" },
+        "TZ": { "zoneName": "Tanzania" },
+        "UA": { "zoneName": "Ukraina" },
+        "UA-CR": { "countryName": "Krim", "zoneName": "Ukraina" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Förenta staternas mindre öar i Oceanien och Västindien" },
+        "US-HI-HA": { "countryName": "USA", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "USA", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "USA", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "USA", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "USA", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "USA", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "USA", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "USA", "zoneName": "Oahu" },
+        "US-CAL-BANC": { "countryName": "USA", "zoneName": "Balancing Authority Of Northern California" },
+        "US-CAL-CISO": { "countryName": "USA", "zoneName": "California Independent System Operator" },
+        "US-CAL-IID": { "countryName": "USA", "zoneName": "Imperial Irrigation District" },
+        "US-CAL-LDWP": { "countryName": "USA", "zoneName": "Los Angeles Department Of Water And Power" },
+        "US-CAL-TIDC": { "countryName": "USA", "zoneName": "Turlock Irrigation District" },
+        "US-CAR-CPLE": { "countryName": "USA", "zoneName": "Duke Energy Progress East" },
+        "US-CAR-CPLW": { "countryName": "USA", "zoneName": "Duke Energy Progress West" },
+        "US-CAR-DUK": { "countryName": "USA", "zoneName": "Duke Energy Carolinas" },
+        "US-CAR-SC": { "countryName": "USA", "zoneName": "South Carolina Public Service Authority" },
+        "US-CAR-SCEG": { "countryName": "USA", "zoneName": "South Carolina Electric & Gas Company" },
+        "US-CAR-YAD": { "countryName": "USA", "zoneName": "Alcoa Power Generating, Inc. Yadkin Division" },
+        "US-CENT-SPA": { "countryName": "USA", "zoneName": "Southwestern Power Administration" },
+        "US-CENT-SWPP": { "countryName": "USA", "zoneName": "Southwest Power Pool" },
+        "US-FLA-FMPP": { "countryName": "USA", "zoneName": "Florida Municipal Power Pool" },
+        "US-FLA-FPC": { "countryName": "USA", "zoneName": "Duke Energy Florida Inc" },
+        "US-FLA-FPL": { "countryName": "USA", "zoneName": "Florida Power & Light Company" },
+        "US-FLA-GVL": { "countryName": "USA", "zoneName": "Gainesville Regional Utilities" },
+        "US-FLA-HST": { "countryName": "USA", "zoneName": "City Of Homestead" },
+        "US-FLA-JEA": { "countryName": "USA", "zoneName": "JEA" },
+        "US-FLA-NSB": { "countryName": "USA", "zoneName": "Utilities Commission Of New Smyrna Beach" },
+        "US-FLA-SEC": { "countryName": "USA", "zoneName": "Seminole Electric Cooperative" },
+        "US-FLA-TAL": { "countryName": "USA", "zoneName": "City Of Tallahassee" },
+        "US-FLA-TEC": { "countryName": "USA", "zoneName": "Tampa Electric Company" },
+        "US-MIDA-PJM": { "countryName": "USA", "zoneName": "PJM Interconnection, Llc" },
+        "US-MIDW-AECI": { "countryName": "USA", "zoneName": "Associated Electric Cooperative, Inc." },
+        "US-MIDW-GLHB": { "countryName": "USA", "zoneName": "GridLiance" },
         "US-MIDW-LGEE": {
             "countryName": "USA",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -1534,213 +595,67 @@
             "countryName": "USA",
             "zoneName": "Midcontinent Independent Transmission System Operator, Inc.."
         },
-        "US-NE-ISNE": {
-            "countryName": "USA",
-            "zoneName": "Iso New England Inc."
-        },
-        "US-NW-AVA": {
-            "countryName": "USA",
-            "zoneName": "Avista Corporation"
-        },
-        "US-NW-AVRN": {
-            "countryName": "USA",
-            "zoneName": "Avangrid Renewables Cooperative"
-        },
-        "US-NW-BPAT": {
-            "countryName": "USA",
-            "zoneName": "Bonneville Power Administration"
-        },
-        "US-NW-CHPD": {
-            "countryName": "USA",
-            "zoneName": "PUD No. 1 Of Chelan County"
-        },
-        "US-NW-DOPD": {
-            "countryName": "USA",
-            "zoneName": "PUD No. 1 Of Douglas County"
-        },
-        "US-NW-GCPD": {
-            "countryName": "USA",
-            "zoneName": "PUD No. 2 Of Grant County, Washington"
-        },
-        "US-NW-GRID": {
-            "countryName": "USA",
-            "zoneName": "Gridforce Energy Management, Llc"
-        },
-        "US-NW-GWA": {
-            "countryName": "USA",
-            "zoneName": "Naturener Power Watch, Llc (Gwa)"
-        },
-        "US-NW-IPCO": {
-            "countryName": "USA",
-            "zoneName": "Idaho Power Company"
-        },
-        "US-NW-NEVP": {
-            "countryName": "USA",
-            "zoneName": "Nevada Power Company"
-        },
-        "US-NW-NWMT": {
-            "countryName": "USA",
-            "zoneName": "Northwestern Energy"
-        },
-        "US-NW-PACE": {
-            "countryName": "USA",
-            "zoneName": "Pacificorp East"
-        },
-        "US-NW-PACW": {
-            "countryName": "USA",
-            "zoneName": "Pacificorp West"
-        },
-        "US-NW-PGE": {
-            "countryName": "USA",
-            "zoneName": "Portland General Electric Company"
-        },
-        "US-NW-PSCO": {
-            "countryName": "USA",
-            "zoneName": "Public Service Company Of Colorado"
-        },
-        "US-NW-PSEI": {
-            "countryName": "USA",
-            "zoneName": "Puget Sound Energy"
-        },
-        "US-NW-SCL": {
-            "countryName": "USA",
-            "zoneName": "Seattle City Light"
-        },
+        "US-NE-ISNE": { "countryName": "USA", "zoneName": "Iso New England Inc." },
+        "US-NW-AVA": { "countryName": "USA", "zoneName": "Avista Corporation" },
+        "US-NW-AVRN": { "countryName": "USA", "zoneName": "Avangrid Renewables Cooperative" },
+        "US-NW-BPAT": { "countryName": "USA", "zoneName": "Bonneville Power Administration" },
+        "US-NW-CHPD": { "countryName": "USA", "zoneName": "PUD No. 1 Of Chelan County" },
+        "US-NW-DOPD": { "countryName": "USA", "zoneName": "PUD No. 1 Of Douglas County" },
+        "US-NW-GCPD": { "countryName": "USA", "zoneName": "PUD No. 2 Of Grant County, Washington" },
+        "US-NW-GRID": { "countryName": "USA", "zoneName": "Gridforce Energy Management, Llc" },
+        "US-NW-GWA": { "countryName": "USA", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
+        "US-NW-IPCO": { "countryName": "USA", "zoneName": "Idaho Power Company" },
+        "US-NW-NEVP": { "countryName": "USA", "zoneName": "Nevada Power Company" },
+        "US-NW-NWMT": { "countryName": "USA", "zoneName": "Northwestern Energy" },
+        "US-NW-PACE": { "countryName": "USA", "zoneName": "Pacificorp East" },
+        "US-NW-PACW": { "countryName": "USA", "zoneName": "Pacificorp West" },
+        "US-NW-PGE": { "countryName": "USA", "zoneName": "Portland General Electric Company" },
+        "US-NW-PSCO": { "countryName": "USA", "zoneName": "Public Service Company Of Colorado" },
+        "US-NW-PSEI": { "countryName": "USA", "zoneName": "Puget Sound Energy" },
+        "US-NW-SCL": { "countryName": "USA", "zoneName": "Seattle City Light" },
         "US-NW-TPWR": {
             "countryName": "USA",
             "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
         },
-        "US-NW-WACM": {
-            "countryName": "USA",
-            "zoneName": "Western Area Power Administration - Rocky Mountain Region"
-        },
-        "US-NW-WAUW": {
-            "countryName": "USA",
-            "zoneName": "Western Area Power Administration UGP West"
-        },
-        "US-NW-WWA": {
-            "countryName": "USA",
-            "zoneName": "Naturener Wind Watch, Llc"
-        },
-        "US-NY-NYIS": {
-            "countryName": "USA",
-            "zoneName": "New York Independent System Operator"
-        },
-        "US-SE-AEC": {
-            "countryName": "USA",
-            "zoneName": "Powersouth Energy Cooperative"
-        },
-        "US-SE-SEPA": {
-            "countryName": "USA",
-            "zoneName": "Southeastern Power Administration"
-        },
-        "US-SE-SOCO": {
-            "countryName": "USA",
-            "zoneName": "Southern Company Services, Inc. - Trans"
-        },
-        "US-SW-AZPS": {
-            "countryName": "USA",
-            "zoneName": "Arizona Public Service Company"
-        },
-        "US-SW-DEAA": {
-            "countryName": "USA",
-            "zoneName": "Arlington Valley, LLC"
-        },
-        "US-SW-EPE": {
-            "countryName": "USA",
-            "zoneName": "El Paso Electric Company"
-        },
-        "US-SW-GRIF": {
-            "countryName": "USA",
-            "zoneName": "Griffith Energy, LLC"
-        },
-        "US-SW-GRMA": {
-            "countryName": "USA",
-            "zoneName": "Gila River Power, LLC"
-        },
-        "US-SW-HGMA": {
-            "countryName": "USA",
-            "zoneName": "New Harquahala Generating Company, LLC"
-        },
-        "US-SW-PNM": {
-            "countryName": "USA",
-            "zoneName": "Public Service Company Of New Mexico"
-        },
-        "US-SW-SRP": {
-            "countryName": "USA",
-            "zoneName": "Salt River Project"
-        },
-        "US-SW-TEPC": {
-            "countryName": "USA",
-            "zoneName": "Tucson Electric Power Company"
-        },
+        "US-NW-WACM": { "countryName": "USA", "zoneName": "Western Area Power Administration - Rocky Mountain Region" },
+        "US-NW-WAUW": { "countryName": "USA", "zoneName": "Western Area Power Administration UGP West" },
+        "US-NW-WWA": { "countryName": "USA", "zoneName": "Naturener Wind Watch, Llc" },
+        "US-NY-NYIS": { "countryName": "USA", "zoneName": "New York Independent System Operator" },
+        "US-SE-AEC": { "countryName": "USA", "zoneName": "Powersouth Energy Cooperative" },
+        "US-SE-SEPA": { "countryName": "USA", "zoneName": "Southeastern Power Administration" },
+        "US-SE-SOCO": { "countryName": "USA", "zoneName": "Southern Company Services, Inc. - Trans" },
+        "US-SW-AZPS": { "countryName": "USA", "zoneName": "Arizona Public Service Company" },
+        "US-SW-DEAA": { "countryName": "USA", "zoneName": "Arlington Valley, LLC" },
+        "US-SW-EPE": { "countryName": "USA", "zoneName": "El Paso Electric Company" },
+        "US-SW-GRIF": { "countryName": "USA", "zoneName": "Griffith Energy, LLC" },
+        "US-SW-GRMA": { "countryName": "USA", "zoneName": "Gila River Power, LLC" },
+        "US-SW-HGMA": { "countryName": "USA", "zoneName": "New Harquahala Generating Company, LLC" },
+        "US-SW-PNM": { "countryName": "USA", "zoneName": "Public Service Company Of New Mexico" },
+        "US-SW-SRP": { "countryName": "USA", "zoneName": "Salt River Project" },
+        "US-SW-TEPC": { "countryName": "USA", "zoneName": "Tucson Electric Power Company" },
         "US-SW-WALC": {
             "countryName": "USA",
             "zoneName": "Western Area Power Administration - Desert Southwest Region"
         },
-        "US-TEN-TVA": {
-            "countryName": "USA",
-            "zoneName": "Tennessee Valley Authority"
-        },
-        "US-TEX-ERCO": {
-            "countryName": "USA",
-            "zoneName": "Electric Reliability Council Of Texas, Inc."
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatikanstaten"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent och Grenadinerna"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Jungfruöarna",
-            "zoneName": "Brittiska"
-        },
-        "VI": {
-            "countryName": "Jungfruöarna",
-            "zoneName": "Amerikanska"
-        },
-        "VN": {
-            "zoneName": "Vietnam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis- och Futunaöarna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XK": {
-            "zoneName": "Kosovo"
-        },
-        "XX": {
-            "zoneName": "Nordcypern"
-        },
-        "YE": {
-            "zoneName": "Jemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Sydafrika"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "US-TEN-TVA": { "countryName": "USA", "zoneName": "Tennessee Valley Authority" },
+        "US-TEX-ERCO": { "countryName": "USA", "zoneName": "Electric Reliability Council Of Texas, Inc." },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Vatikanstaten" },
+        "VC": { "zoneName": "Saint Vincent och Grenadinerna" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Jungfruöarna", "zoneName": "Brittiska" },
+        "VI": { "countryName": "Jungfruöarna", "zoneName": "Amerikanska" },
+        "VN": { "zoneName": "Vietnam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis- och Futunaöarna" },
+        "WS": { "zoneName": "Samoa" },
+        "XK": { "zoneName": "Kosovo" },
+        "XX": { "zoneName": "Nordcypern" },
+        "YE": { "zoneName": "Jemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Sydafrika" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/vi.json
+++ b/web/public/locales/vi.json
@@ -6,15 +6,9 @@
         "datasources": "các nguồn dữ liệu",
         "contribute": "Tham gia bằng cách <a href=\"%s\" target=\"_blank\">thêm khu vực của bạn</a>"
     },
-    "mobile-main-menu": {
-        "map": "Bản đồ",
-        "areas": "Khu vực",
-        "about": "Thông tin"
-    },
+    "mobile-main-menu": { "map": "Bản đồ", "areas": "Khu vực", "about": "Thông tin" },
     "onboarding-modal": {
-        "view1": {
-            "subtitle": "Mapping the climate impact of electricity"
-        },
+        "view1": { "subtitle": "Mapping the climate impact of electricity" },
         "view2": {
             "header": "Xem lượng CO₂ được thải ra trong quá trình sản xuất điện năng của bạn trong thời gian thực",
             "text": "We color areas around the world by their Carbon Intensity (includes all greenhouse gases) of electricity consumed there. Greener colors means more climate friendly electricity."
@@ -50,13 +44,13 @@
         "search": "Tìm khu vực"
     },
     "country-history": {
-        "carbonintensity24h": "Mật độ cacbon trong vòng 24 giờ",
-        "emissionsorigin24h": "Nguồn gốc chất thải trong vòng 24 giờ",
-        "emissionsproduction24h": "Chất thải được sản sinh ra trong vòng 24 giờ",
-        "electricityorigin24h": "Origin of electricity in the last 24 hours",
-        "electricityproduction24h": "Electricity production in the last 24 hours",
-        "electricityprices24h": "Electricity prices in the last 24 hours",
-        "Getdata": "Get historical data, marginal and forecast API"
+        "Getdata": "Get historical data, marginal and forecast API",
+        "carbonintensity": { "hourly": "Mật độ cacbon trong vòng 24 giờ" },
+        "emissionsorigin": { "hourly": "Nguồn gốc chất thải trong vòng 24 giờ" },
+        "emissionsproduction": { "hourly": "Chất thải được sản sinh ra trong vòng 24 giờ" },
+        "electricityorigin": { "hourly": "Origin of electricity in the last 24 hours" },
+        "electricityproduction": { "hourly": "Electricity production in the last 24 hours" },
+        "electricityprices": { "hourly": "Electricity prices in the last 24 hours" }
     },
     "footer": {
         "foundbugs": "Found bugs or have ideas? Report them",
@@ -190,1245 +184,375 @@
         "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">electricityMap</a> publishes data and images on the <a href=\"https://www.electricitymap.org/\" target=\"_blank\">electricityMap</a> for information purposes. It makes no claims of correctness nor provides any form of warranties, and reserves the right to change the content at any time or to remove parts without having to inform you of this. electricityMap assumes no responsibility for, and shall not be liable for, any damages or expenses you may incur as a result of any inaccuracy, incompleteness, untimeliness or obsolescence of the electricityMap, or the information derived from them.  It is not allowed to include this webpage, or any of its individual elements, in another webpage, without formal prior written consent.<br><br> All intellectual property rights belong to the rightful owners and its licensors. Copying, distribution and any other use of these materials, in particular the energy data, is not permitted without the written permission of electricityMap, except and only to the extent otherwise provided in regulations of mandatory law (such as the right to quote), unless specified otherwise for specific materials. <br><br>This disclaimer may be updated from time to time."
     },
     "zoneShortName": {
-        "AD": {
-            "zoneName": "Andorra"
-        },
-        "AE": {
-            "zoneName": "Các Tiểu vương quốc Ả rập Thống nhất"
-        },
-        "AF": {
-            "zoneName": "Afghanistan"
-        },
-        "AG": {
-            "zoneName": "Antigua và Barbuda"
-        },
-        "AI": {
-            "zoneName": "Anguilla"
-        },
-        "AL": {
-            "zoneName": "Albania"
-        },
-        "AM": {
-            "zoneName": "Armenia"
-        },
-        "AO": {
-            "zoneName": "Angola"
-        },
-        "AQ": {
-            "zoneName": "Bắc Cực"
-        },
-        "AS": {
-            "zoneName": "American Samoa"
-        },
-        "AT": {
-            "zoneName": "Áo"
-        },
-        "AR": {
-            "zoneName": "Argentina"
-        },
-        "AUS-NSW": {
-            "countryName": "Úc",
-            "zoneName": "New South Wales"
-        },
-        "AUS-NT": {
-            "countryName": "Úc",
-            "zoneName": "Lãnh thổ phía Bắc"
-        },
-        "AUS-QLD": {
-            "countryName": "Úc",
-            "zoneName": "Queensland"
-        },
-        "AUS-SA": {
-            "countryName": "Úc",
-            "zoneName": "Nam Úc"
-        },
-        "AUS-TAS": {
-            "countryName": "Úc",
-            "zoneName": "Tasmania"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "Tasmania",
-            "zoneName": "Đảo King"
-        },
-        "AUS-VIC": {
-            "countryName": "Úc",
-            "zoneName": "Victoria"
-        },
-        "AUS-WA": {
-            "countryName": "Úc",
-            "zoneName": "Tây Úc"
-        },
-        "AW": {
-            "zoneName": "Aruba"
-        },
-        "AX": {
-            "zoneName": "Quần đảo Åland"
-        },
-        "AZ": {
-            "zoneName": "Azerbaijan"
-        },
-        "BA": {
-            "zoneName": "Bosnia và Herzegovina"
-        },
-        "BB": {
-            "zoneName": "Barbados"
-        },
-        "BD": {
-            "zoneName": "Bangladesh"
-        },
-        "BE": {
-            "zoneName": "Bỉ"
-        },
-        "BF": {
-            "zoneName": "Burkina Faso"
-        },
-        "BG": {
-            "zoneName": "Bulgaria"
-        },
-        "BH": {
-            "zoneName": "Bahrain"
-        },
-        "BI": {
-            "zoneName": "Burundi"
-        },
-        "BJ": {
-            "zoneName": "Benin"
-        },
-        "BM": {
-            "zoneName": "Bermuda"
-        },
-        "BN": {
-            "zoneName": "Brunei"
-        },
-        "BO": {
-            "zoneName": "Bolivia"
-        },
-        "BQ": {
-            "zoneName": "Bonaire, Sint Eustatius và Saba"
-        },
-        "BR-CS": {
-            "countryName": "Brazil",
-            "zoneName": "Trung Brazil"
-        },
-        "BR-N": {
-            "countryName": "Brazil",
-            "zoneName": "Đông Brazil"
-        },
-        "BR-NE": {
-            "countryName": "Brazil",
-            "zoneName": "Đông Bắc Brazil"
-        },
-        "BR-S": {
-            "countryName": "Brazil",
-            "zoneName": "Nam Brazil"
-        },
-        "BS": {
-            "zoneName": "Bahamas"
-        },
-        "BT": {
-            "zoneName": "Bhutan"
-        },
-        "BV": {
-            "zoneName": "Đảo Bouvet"
-        },
-        "BW": {
-            "zoneName": "Botswana"
-        },
-        "BY": {
-            "zoneName": "Belarus"
-        },
-        "BZ": {
-            "zoneName": "Belize"
-        },
-        "CA-AB": {
-            "countryName": "Canada",
-            "zoneName": "Alberta"
-        },
-        "CA-BC": {
-            "countryName": "Canada",
-            "zoneName": "British Columbia"
-        },
-        "CA-MB": {
-            "countryName": "Canada",
-            "zoneName": "Manitoba"
-        },
-        "CA-NL": {
-            "countryName": "Canada",
-            "zoneName": "Newfoundland và Labrador"
-        },
-        "CA-NB": {
-            "countryName": "Canada",
-            "zoneName": "New Brunswick"
-        },
-        "CA-NT": {
-            "countryName": "Canada",
-            "zoneName": "Các Lãnh thổ Tây Bắc"
-        },
-        "CA-NS": {
-            "countryName": "Canada",
-            "zoneName": "Nova Scotia"
-        },
-        "CA-NU": {
-            "countryName": "Canada",
-            "zoneName": "Nunavut"
-        },
-        "CA-ON": {
-            "countryName": "Canada",
-            "zoneName": "Ontario"
-        },
-        "CA-PE": {
-            "countryName": "Canada",
-            "zoneName": "Đảo Hoàng tử Edward"
-        },
-        "CA-QC": {
-            "countryName": "Canada",
-            "zoneName": "Québec"
-        },
-        "CA-SK": {
-            "countryName": "Canada",
-            "zoneName": "Saskatchewan"
-        },
-        "CA-YT": {
-            "countryName": "Canada",
-            "zoneName": "Yukon"
-        },
-        "CC": {
-            "zoneName": "Quần đảo Cocos"
-        },
-        "CD": {
-            "zoneName": "Cộng hòa Dân chủ Congo"
-        },
-        "CF": {
-            "zoneName": "Cộng hòa Trung Phi"
-        },
-        "CG": {
-            "zoneName": "Congo"
-        },
-        "CH": {
-            "zoneName": "Thụy Sỹ"
-        },
-        "CI": {
-            "zoneName": "Bờ Biển Ngà"
-        },
-        "CK": {
-            "zoneName": "Quần đảo Cook"
-        },
-        "CL-SING-SIC": {
-            "countryName": "Chile",
-            "zoneName": "SING/SIC"
-        },
-        "CL-SEM": {
-            "countryName": "Chile",
-            "zoneName": "SEM"
-        },
-        "CL-SEA": {
-            "countryName": "Chile",
-            "zoneName": "SEA"
-        },
-        "CM": {
-            "zoneName": "Cameroon"
-        },
-        "CN": {
-            "zoneName": "Trung Quốc"
-        },
-        "CO": {
-            "zoneName": "Colombia"
-        },
-        "CR": {
-            "zoneName": "Costa Rica"
-        },
-        "CU": {
-            "zoneName": "Cuba"
-        },
-        "CV": {
-            "zoneName": "Cabo Verde"
-        },
-        "CW": {
-            "zoneName": "Curaçao"
-        },
-        "CX": {
-            "zoneName": "Đảo Giáng Sinh"
-        },
-        "CY": {
-            "zoneName": "Cyprus"
-        },
-        "CZ": {
-            "zoneName": "Czechia"
-        },
-        "DE": {
-            "zoneName": "Đức"
-        },
-        "DJ": {
-            "zoneName": "Djibouti"
-        },
-        "DK": {
-            "zoneName": "Đan Mạch"
-        },
-        "DK-DK1": {
-            "countryName": "Đan Mạch",
-            "zoneName": "Tây Đan Mạch"
-        },
-        "DK-DK2": {
-            "countryName": "Đan Mạch",
-            "zoneName": "Đông Đan Mạch"
-        },
-        "DK-BHM": {
-            "countryName": "Đan Mạch",
-            "zoneName": "Bornholm"
-        },
-        "DM": {
-            "zoneName": "Dominica"
-        },
-        "DO": {
-            "zoneName": "Cộng hòa Dominican"
-        },
-        "DZ": {
-            "zoneName": "Algeria"
-        },
-        "EC": {
-            "zoneName": "Ecuador"
-        },
-        "EE": {
-            "zoneName": "Estonia"
-        },
-        "EG": {
-            "zoneName": "Ai Cập"
-        },
-        "EH": {
-            "zoneName": "Tây Sahara"
-        },
-        "ER": {
-            "zoneName": "Eritrea"
-        },
-        "ES": {
-            "zoneName": "Tây Ban Nha"
-        },
-        "ES-IB-FO": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "Formentera"
-        },
-        "ES-IB-IZ": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "Ibiza"
-        },
-        "ES-IB-MA": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "Mallorca"
-        },
-        "ES-IB-ME": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "Menorca"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "Fuerteventura/Lanzarote"
-        },
-        "ES-CN-GC": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "Gran Canaria"
-        },
-        "ES-CN-HI": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "El Hierro"
-        },
-        "ES-CN-IG": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "Isla de la Gomera"
-        },
-        "ES-CN-LP": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "La Palma"
-        },
-        "ES-CN-TE": {
-            "countryName": "Tây Ban Nha",
-            "zoneName": "Tenerife"
-        },
-        "ET": {
-            "zoneName": "Ethiopia"
-        },
-        "FI": {
-            "zoneName": "Phần Lan"
-        },
-        "FJ": {
-            "zoneName": "Fiji"
-        },
-        "FK": {
-            "zoneName": "Quần đảo Falkland"
-        },
-        "FM": {
-            "zoneName": "Micronesia"
-        },
-        "FO": {
-            "zoneName": "Quần đảo Faroe"
-        },
-        "FR": {
-            "zoneName": "Pháp"
-        },
-        "FR-COR": {
-            "countryName": "Pháp",
-            "zoneName": "Corsica"
-        },
-        "GA": {
-            "zoneName": "Gabon"
-        },
-        "GB": {
-            "zoneName": "Đảo Anh"
-        },
-        "GB-NIR": {
-            "zoneName": "Bắc Ireland"
-        },
-        "GB-ORK": {
-            "countryName": "Great Britain",
-            "zoneName": "Quần đảo Orkney"
-        },
-        "GB-SHI": {
-            "countryName": "Great Britain",
-            "zoneName": "Quần đảo Shetland"
-        },
-        "GB-ZET": {
-            "countryName": "Great Britain",
-            "zoneName": "Quần đảo Shetland"
-        },
-        "GD": {
-            "zoneName": "Grenada"
-        },
-        "GE": {
-            "zoneName": "Georgia"
-        },
-        "GF": {
-            "zoneName": "French Guiana"
-        },
-        "GG": {
-            "zoneName": "Guernsey"
-        },
-        "GH": {
-            "zoneName": "Ghana"
-        },
-        "GI": {
-            "zoneName": "Gibraltar"
-        },
-        "GL": {
-            "zoneName": "Greenland"
-        },
-        "GM": {
-            "zoneName": "Gambia"
-        },
-        "GN": {
-            "zoneName": "Guinea"
-        },
-        "GP": {
-            "zoneName": "Guadeloupe"
-        },
-        "GQ": {
-            "zoneName": "Guinea Xích đạo"
-        },
-        "GR": {
-            "zoneName": "Hy Lạp"
-        },
-        "GR-IS": {
-            "countryName": "Hy Lạp",
-            "zoneName": "Quần đảo Aegean"
-        },
-        "GS": {
-            "zoneName": "Nam Georgia và Quần đảo Nam Sandwich"
-        },
-        "GT": {
-            "zoneName": "Guatemala"
-        },
-        "GU": {
-            "zoneName": "Guam"
-        },
-        "GW": {
-            "zoneName": "Guinea-Bissau"
-        },
-        "GY": {
-            "zoneName": "Guyana"
-        },
-        "HK": {
-            "zoneName": "Hồng Kông"
-        },
-        "HM": {
-            "zoneName": "Đảo Heard và Quần đảo McDonald"
-        },
-        "HN": {
-            "zoneName": "Honduras"
-        },
-        "HR": {
-            "zoneName": "Croatia"
-        },
-        "HT": {
-            "zoneName": "Haiti"
-        },
-        "HU": {
-            "zoneName": "Hungary"
-        },
-        "ID": {
-            "zoneName": "Indonesia"
-        },
-        "IE": {
-            "zoneName": "Ireland"
-        },
-        "IL": {
-            "zoneName": "Israel"
-        },
-        "IM": {
-            "zoneName": "Đảo Man"
-        },
-        "IN-AN": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Andaman và Quần đảo Nicobar"
-        },
-        "IN-AP": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Andhra Pradesh"
-        },
-        "IN-AR": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Arunachal Pradesh"
-        },
-        "IN-AS": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Assam"
-        },
-        "IN-BR": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Bihar"
-        },
-        "IN-CT": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Chhattisgarh"
-        },
-        "IN-DL": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Delhi"
-        },
-        "IN-DN": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Dadra và Nagar Haveli"
-        },
-        "IN-GA": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Goa"
-        },
-        "IN-GJ": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Gujarat"
-        },
-        "IN-HP": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Himachal Pradesh"
-        },
-        "IN-HR": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Haryana"
-        },
-        "IN-JH": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Jharkhand"
-        },
-        "IN-JK": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Jammu và Kashmir"
-        },
-        "IN-KA": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Karnataka"
-        },
-        "IN-KL": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Kerala"
-        },
-        "IN-MH": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Maharashtra"
-        },
-        "IN-ML": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Meghalaya"
-        },
-        "IN-MN": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Manipur"
-        },
-        "IN-MP": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Madhya Pradesh"
-        },
-        "IN-MZ": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Mizoram"
-        },
-        "IN-NL": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Nagaland"
-        },
-        "IN-OR": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Orissa"
-        },
-        "IN-PB": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Punjab"
-        },
-        "IN-PY": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Pondicherry"
-        },
-        "IN-RJ": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Rajasthan"
-        },
-        "IN-SK": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Sikkim"
-        },
-        "IN-TN": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Tamil Nadu"
-        },
-        "IN-TR": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Tripura"
-        },
-        "IN-UP": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Uttar Pradesh"
-        },
-        "IN-UT": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Uttarakhand"
-        },
-        "IN-WB": {
-            "countryName": "Ấn Độ",
-            "zoneName": "Tây Bengal"
-        },
-        "IO": {
-            "zoneName": "Lãnh thổ Ấn Độ Dương thuộc Anh"
-        },
-        "IQ": {
-            "zoneName": "Iraq"
-        },
-        "IQ-KUR": {
-            "countryName": "Iraq",
-            "zoneName": "Kurdistan"
-        },
-        "IR": {
-            "zoneName": "Iran"
-        },
-        "IS": {
-            "zoneName": "Iceland"
-        },
-        "IT": {
-            "zoneName": "Ý"
-        },
-        "IT-CNO": {
-            "countryName": "Ý",
-            "zoneName": "Trung Bắc"
-        },
-        "IT-CSO": {
-            "countryName": "Ý",
-            "zoneName": "Trung Nam"
-        },
-        "IT-NO": {
-            "countryName": "Ý",
-            "zoneName": "Bắc"
-        },
-        "IT-SAR": {
-            "countryName": "Ý",
-            "zoneName": "Sardinia"
-        },
-        "IT-SIC": {
-            "countryName": "Ý",
-            "zoneName": "Sicily"
-        },
-        "IT-SO": {
-            "countryName": "Ý",
-            "zoneName": "Nam"
-        },
-        "JE": {
-            "zoneName": "Jersey"
-        },
-        "JM": {
-            "zoneName": "Jamaica"
-        },
-        "JO": {
-            "zoneName": "Jordan"
-        },
-        "JP-CB": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Chūbu"
-        },
-        "JP-CG": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Chūgoku"
-        },
-        "JP-HKD": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Hokkaidō"
-        },
-        "JP-HR": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Hokuriku"
-        },
-        "JP-KN": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Kansai"
-        },
-        "JP-KY": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Kyūshū"
-        },
-        "JP-ON": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Okinawa"
-        },
-        "JP-SK": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Shikoku"
-        },
-        "JP-TH": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Tōhoku"
-        },
-        "JP-TK": {
-            "countryName": "Nhật Bản",
-            "zoneName": "Tōkyō"
-        },
-        "KE": {
-            "zoneName": "Kenya"
-        },
-        "KG": {
-            "zoneName": "Kyrgyzstan"
-        },
-        "KH": {
-            "zoneName": "Cam-pu-chia"
-        },
-        "KI": {
-            "zoneName": "Kiribati"
-        },
-        "KM": {
-            "zoneName": "Comoros"
-        },
-        "KN": {
-            "zoneName": "Saint Kitts và Nevis"
-        },
-        "KP": {
-            "zoneName": "Bắc Triều Tiên"
-        },
-        "KR": {
-            "zoneName": "Hàn Quốc"
-        },
-        "KW": {
-            "zoneName": "Kuwait"
-        },
-        "KY": {
-            "zoneName": "Quần đảo Cayman"
-        },
-        "KZ": {
-            "zoneName": "Kazakhstan"
-        },
-        "LA": {
-            "zoneName": "Lào"
-        },
-        "LB": {
-            "zoneName": "Lebanon"
-        },
-        "LC": {
-            "zoneName": "Saint Lucia"
-        },
-        "LI": {
-            "zoneName": "Liechtenstein"
-        },
-        "LK": {
-            "zoneName": "Sri Lanka"
-        },
-        "LR": {
-            "zoneName": "Liberia"
-        },
-        "LS": {
-            "zoneName": "Lesotho"
-        },
-        "LT": {
-            "zoneName": "Lithuania"
-        },
-        "LU": {
-            "zoneName": "Luxembourg"
-        },
-        "LV": {
-            "zoneName": "Latvia"
-        },
-        "LY": {
-            "zoneName": "Libya"
-        },
-        "MA": {
-            "zoneName": "Morocco"
-        },
-        "MC": {
-            "zoneName": "Monaco"
-        },
-        "MD": {
-            "zoneName": "Moldova"
-        },
-        "ME": {
-            "zoneName": "Montenegro"
-        },
-        "MF": {
-            "countryName": "Saint Martin",
-            "zoneName": "French"
-        },
-        "MG": {
-            "zoneName": "Madagascar"
-        },
-        "MH": {
-            "zoneName": "Quần đảo Marshall"
-        },
-        "MK": {
-            "zoneName": "Bắc Macedonia"
-        },
-        "ML": {
-            "zoneName": "Mali"
-        },
-        "MM": {
-            "zoneName": "Myanmar"
-        },
-        "MN": {
-            "zoneName": "Mông Cổ"
-        },
-        "MO": {
-            "zoneName": "Macao"
-        },
-        "MP": {
-            "zoneName": "Quần đảo Bắc Mariana"
-        },
-        "MQ": {
-            "zoneName": "Martinique"
-        },
-        "MR": {
-            "zoneName": "Mauritania"
-        },
-        "MS": {
-            "zoneName": "Montserrat"
-        },
-        "MT": {
-            "zoneName": "Malta"
-        },
-        "MU": {
-            "zoneName": "Mauritius"
-        },
-        "MV": {
-            "zoneName": "Maldives"
-        },
-        "MW": {
-            "zoneName": "Malawi"
-        },
-        "MX": {
-            "zoneName": "Mexico"
-        },
-        "MX-BC": {
-            "countryName": "Mexico",
-            "zoneName": "Baja California"
-        },
-        "MX-CE": {
-            "countryName": "Mexico",
-            "zoneName": "Central"
-        },
-        "MX-NE": {
-            "countryName": "Mexico",
-            "zoneName": "Đông Bắc"
-        },
-        "MX-NO": {
-            "countryName": "Mexico",
-            "zoneName": "Đông"
-        },
-        "MX-NW": {
-            "countryName": "Mexico",
-            "zoneName": "Đông Nam"
-        },
-        "MX-OC": {
-            "countryName": "Mexico",
-            "zoneName": "Occidental"
-        },
-        "MX-OR": {
-            "countryName": "Mexico",
-            "zoneName": "Oriental"
-        },
-        "MX-PN": {
-            "countryName": "Mexico",
-            "zoneName": "Peninsula"
-        },
-        "MY-EM": {
-            "countryName": "Malaysia",
-            "zoneName": "Borneo"
-        },
-        "MY-WM": {
-            "countryName": "Malaysia",
-            "zoneName": "Peninsula"
-        },
-        "MZ": {
-            "zoneName": "Mozambique"
-        },
-        "NA": {
-            "zoneName": "Namibia"
-        },
-        "NC": {
-            "zoneName": "Tân Caledonia"
-        },
-        "NE": {
-            "zoneName": "Niger"
-        },
-        "NF": {
-            "zoneName": "Đảo Norfolk"
-        },
-        "NG": {
-            "zoneName": "Nigeria"
-        },
-        "NI": {
-            "zoneName": "Nicaragua"
-        },
-        "NKR": {
-            "zoneName": "Nagorno-Karabakh"
-        },
-        "NL": {
-            "zoneName": "Hà Lan"
-        },
-        "NO-NO1": {
-            "countryName": "Na Uy",
-            "zoneName": "Đông Nam Na Uy"
-        },
-        "NO-NO2": {
-            "countryName": "Na Uy",
-            "zoneName": "Tây Bắc Na Uy"
-        },
-        "NO-NO3": {
-            "countryName": "Na Uy",
-            "zoneName": "Trung Na Uy"
-        },
-        "NO-NO4": {
-            "countryName": "Na Uy",
-            "zoneName": "Bắc Na Uy"
-        },
-        "NO-NO5": {
-            "countryName": "Na Uy",
-            "zoneName": "Tây Na Uy"
-        },
-        "NP": {
-            "zoneName": "Nepal"
-        },
-        "NR": {
-            "zoneName": "Nauru"
-        },
-        "NU": {
-            "zoneName": "Niue"
-        },
-        "NZ": {
-            "zoneName": "New Zealand"
-        },
-        "NZ-NZA": {
-            "countryName": "New Zealand",
-            "zoneName": "Quần đảo Auckland"
-        },
-        "NZ-NZC": {
-            "countryName": "New Zealand",
-            "zoneName": "Quần đảo Chatham"
-        },
-        "OM": {
-            "zoneName": "Oman"
-        },
-        "PA": {
-            "zoneName": "Panama"
-        },
-        "PE": {
-            "zoneName": "Peru"
-        },
-        "PF": {
-            "zoneName": "Polynésie thuộc Pháp"
-        },
-        "PG": {
-            "zoneName": "Papua New Guinea"
-        },
-        "PH": {
-            "zoneName": "Philippines"
-        },
-        "PK": {
-            "zoneName": "Pakistan"
-        },
-        "PL": {
-            "zoneName": "Ba Lan"
-        },
-        "PM": {
-            "zoneName": "Saint Pierre và Miquelon"
-        },
-        "PN": {
-            "zoneName": "Pitcairn"
-        },
-        "PR": {
-            "zoneName": "Puerto Rico"
-        },
-        "PS": {
-            "zoneName": "Nhà nước Palestine"
-        },
-        "PT": {
-            "zoneName": "Bồ Đào Nha"
-        },
-        "PT-AC": {
-            "countryName": "Bồ Đào Nha",
-            "zoneName": "Azores"
-        },
-        "PT-MA": {
-            "countryName": "Bồ Đào Nha",
-            "zoneName": "Madeira"
-        },
-        "PW": {
-            "zoneName": "Palau"
-        },
-        "PY": {
-            "zoneName": "Paraguay"
-        },
-        "QA": {
-            "zoneName": "Qatar"
-        },
-        "RE": {
-            "zoneName": "Réunion"
-        },
-        "RO": {
-            "zoneName": "Romania"
-        },
-        "RS": {
-            "zoneName": "Serbia"
-        },
-        "RU": {
-            "zoneName": "Nga"
-        },
-        "RU-1": {
-            "countryName": "Nga",
-            "zoneName": "Nga thuộc châu Âu và Ural"
-        },
-        "RU-2": {
-            "countryName": "Nga",
-            "zoneName": "Siberia"
-        },
-        "RU-EU": {
-            "zoneName": "Nga"
-        },
-        "RU-AS": {
-            "zoneName": "Nga"
-        },
-        "RU-KGD": {
-            "countryName": "Nga",
-            "zoneName": "Kaliningrad"
-        },
-        "RW": {
-            "zoneName": "Rwanda"
-        },
-        "SA": {
-            "zoneName": "Saudi Arabia"
-        },
-        "SB": {
-            "zoneName": "Quần đảo Solomon"
-        },
-        "SC": {
-            "zoneName": "Seychelles"
-        },
-        "SD": {
-            "zoneName": "Sudan"
-        },
-        "SE": {
-            "zoneName": "Thụy Điển"
-        },
-        "SG": {
-            "zoneName": "Singapore"
-        },
-        "SH": {
-            "zoneName": "Saint Helena, Ascension và Tristan da Cunha"
-        },
-        "SI": {
-            "zoneName": "Slovenia"
-        },
-        "SJ": {
-            "zoneName": "Svalbard và Jan Mayen"
-        },
-        "SK": {
-            "zoneName": "Slovakia"
-        },
-        "SL": {
-            "zoneName": "Sierra Leone"
-        },
-        "SM": {
-            "zoneName": "San Marino"
-        },
-        "SN": {
-            "zoneName": "Senegal"
-        },
-        "SO": {
-            "zoneName": "Somalia"
-        },
-        "SR": {
-            "zoneName": "Suriname"
-        },
-        "SS": {
-            "zoneName": "Nam Sudan"
-        },
-        "ST": {
-            "zoneName": "Sao Tome và Principe"
-        },
-        "SV": {
-            "zoneName": "El Salvador"
-        },
-        "SX": {
-            "countryName": "Sint Maarten",
-            "zoneName": "Dutch"
-        },
-        "SY": {
-            "zoneName": "Syria"
-        },
-        "SZ": {
-            "zoneName": "Swaziland"
-        },
-        "TC": {
-            "zoneName": "Quần đảo Turks và Caicos"
-        },
-        "TD": {
-            "zoneName": "Chad"
-        },
-        "TF": {
-            "zoneName": "Vùng đất phía Nam thuộc Pháp"
-        },
-        "TG": {
-            "zoneName": "Togo"
-        },
-        "TH": {
-            "zoneName": "Thái Lan"
-        },
-        "TJ": {
-            "zoneName": "Tajikistan"
-        },
-        "TK": {
-            "zoneName": "Tokelau"
-        },
-        "TL": {
-            "zoneName": "Timor-Leste"
-        },
-        "TM": {
-            "zoneName": "Turkmenistan"
-        },
-        "TN": {
-            "zoneName": "Tunisia"
-        },
-        "TO": {
-            "zoneName": "Tonga"
-        },
-        "TR": {
-            "zoneName": "Thổ Nhĩ Kỳ"
-        },
-        "TT": {
-            "zoneName": "Trinidad và Tobago"
-        },
-        "TV": {
-            "zoneName": "Tuvalu"
-        },
-        "TW": {
-            "zoneName": "Đài Loan"
-        },
-        "TZ": {
-            "zoneName": "Tanzania"
-        },
-        "UA": {
-            "zoneName": "Ukraine"
-        },
-        "UA-CR": {
-            "countryName": "Crimea",
-            "zoneName": "Ukraine"
-        },
-        "UG": {
-            "zoneName": "Uganda"
-        },
-        "UM": {
-            "zoneName": "Các tiểu đảo xa của Hoa Kỳ"
-        },
-        "US-HI-HA": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Hawaii"
-        },
-        "US-HI-KA": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Kauai"
-        },
-        "US-HI-KH": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Kahoolawe"
-        },
-        "US-HI-LA": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Lanai"
-        },
-        "US-HI-MA": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Maui"
-        },
-        "US-HI-MO": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Molokai"
-        },
-        "US-HI-NI": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Niihau"
-        },
-        "US-HI-OA": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Oahu"
-        },
-        "UY": {
-            "zoneName": "Uruguay"
-        },
-        "UZ": {
-            "zoneName": "Uzbekistan"
-        },
-        "VA": {
-            "zoneName": "Vatican City"
-        },
-        "VC": {
-            "zoneName": "Saint Vincent and the Grenadines"
-        },
-        "VE": {
-            "zoneName": "Venezuela"
-        },
-        "VG": {
-            "countryName": "Virgin Islands",
-            "zoneName": "Virgin Islands"
-        },
-        "VI": {
-            "countryName": "Hoa Kỳ",
-            "zoneName": "Virgin Islands"
-        },
-        "VN": {
-            "zoneName": "Việt Nam"
-        },
-        "VU": {
-            "zoneName": "Vanuatu"
-        },
-        "WF": {
-            "zoneName": "Wallis and Futuna"
-        },
-        "WS": {
-            "zoneName": "Samoa"
-        },
-        "XX": {
-            "zoneName": "Northern Cyprus"
-        },
-        "YE": {
-            "zoneName": "Yemen"
-        },
-        "YT": {
-            "zoneName": "Mayotte"
-        },
-        "ZA": {
-            "zoneName": "Nam Phi"
-        },
-        "ZM": {
-            "zoneName": "Zambia"
-        },
-        "ZW": {
-            "zoneName": "Zimbabwe"
-        }
+        "AD": { "zoneName": "Andorra" },
+        "AE": { "zoneName": "Các Tiểu vương quốc Ả rập Thống nhất" },
+        "AF": { "zoneName": "Afghanistan" },
+        "AG": { "zoneName": "Antigua và Barbuda" },
+        "AI": { "zoneName": "Anguilla" },
+        "AL": { "zoneName": "Albania" },
+        "AM": { "zoneName": "Armenia" },
+        "AO": { "zoneName": "Angola" },
+        "AQ": { "zoneName": "Bắc Cực" },
+        "AS": { "zoneName": "American Samoa" },
+        "AT": { "zoneName": "Áo" },
+        "AR": { "zoneName": "Argentina" },
+        "AUS-NSW": { "countryName": "Úc", "zoneName": "New South Wales" },
+        "AUS-NT": { "countryName": "Úc", "zoneName": "Lãnh thổ phía Bắc" },
+        "AUS-QLD": { "countryName": "Úc", "zoneName": "Queensland" },
+        "AUS-SA": { "countryName": "Úc", "zoneName": "Nam Úc" },
+        "AUS-TAS": { "countryName": "Úc", "zoneName": "Tasmania" },
+        "AUS-TAS-KI": { "countryName": "Tasmania", "zoneName": "Đảo King" },
+        "AUS-VIC": { "countryName": "Úc", "zoneName": "Victoria" },
+        "AUS-WA": { "countryName": "Úc", "zoneName": "Tây Úc" },
+        "AW": { "zoneName": "Aruba" },
+        "AX": { "zoneName": "Quần đảo Åland" },
+        "AZ": { "zoneName": "Azerbaijan" },
+        "BA": { "zoneName": "Bosnia và Herzegovina" },
+        "BB": { "zoneName": "Barbados" },
+        "BD": { "zoneName": "Bangladesh" },
+        "BE": { "zoneName": "Bỉ" },
+        "BF": { "zoneName": "Burkina Faso" },
+        "BG": { "zoneName": "Bulgaria" },
+        "BH": { "zoneName": "Bahrain" },
+        "BI": { "zoneName": "Burundi" },
+        "BJ": { "zoneName": "Benin" },
+        "BM": { "zoneName": "Bermuda" },
+        "BN": { "zoneName": "Brunei" },
+        "BO": { "zoneName": "Bolivia" },
+        "BQ": { "zoneName": "Bonaire, Sint Eustatius và Saba" },
+        "BR-CS": { "countryName": "Brazil", "zoneName": "Trung Brazil" },
+        "BR-N": { "countryName": "Brazil", "zoneName": "Đông Brazil" },
+        "BR-NE": { "countryName": "Brazil", "zoneName": "Đông Bắc Brazil" },
+        "BR-S": { "countryName": "Brazil", "zoneName": "Nam Brazil" },
+        "BS": { "zoneName": "Bahamas" },
+        "BT": { "zoneName": "Bhutan" },
+        "BV": { "zoneName": "Đảo Bouvet" },
+        "BW": { "zoneName": "Botswana" },
+        "BY": { "zoneName": "Belarus" },
+        "BZ": { "zoneName": "Belize" },
+        "CA-AB": { "countryName": "Canada", "zoneName": "Alberta" },
+        "CA-BC": { "countryName": "Canada", "zoneName": "British Columbia" },
+        "CA-MB": { "countryName": "Canada", "zoneName": "Manitoba" },
+        "CA-NL": { "countryName": "Canada", "zoneName": "Newfoundland và Labrador" },
+        "CA-NB": { "countryName": "Canada", "zoneName": "New Brunswick" },
+        "CA-NT": { "countryName": "Canada", "zoneName": "Các Lãnh thổ Tây Bắc" },
+        "CA-NS": { "countryName": "Canada", "zoneName": "Nova Scotia" },
+        "CA-NU": { "countryName": "Canada", "zoneName": "Nunavut" },
+        "CA-ON": { "countryName": "Canada", "zoneName": "Ontario" },
+        "CA-PE": { "countryName": "Canada", "zoneName": "Đảo Hoàng tử Edward" },
+        "CA-QC": { "countryName": "Canada", "zoneName": "Québec" },
+        "CA-SK": { "countryName": "Canada", "zoneName": "Saskatchewan" },
+        "CA-YT": { "countryName": "Canada", "zoneName": "Yukon" },
+        "CC": { "zoneName": "Quần đảo Cocos" },
+        "CD": { "zoneName": "Cộng hòa Dân chủ Congo" },
+        "CF": { "zoneName": "Cộng hòa Trung Phi" },
+        "CG": { "zoneName": "Congo" },
+        "CH": { "zoneName": "Thụy Sỹ" },
+        "CI": { "zoneName": "Bờ Biển Ngà" },
+        "CK": { "zoneName": "Quần đảo Cook" },
+        "CL-SING-SIC": { "countryName": "Chile", "zoneName": "SING/SIC" },
+        "CL-SEM": { "countryName": "Chile", "zoneName": "SEM" },
+        "CL-SEA": { "countryName": "Chile", "zoneName": "SEA" },
+        "CM": { "zoneName": "Cameroon" },
+        "CN": { "zoneName": "Trung Quốc" },
+        "CO": { "zoneName": "Colombia" },
+        "CR": { "zoneName": "Costa Rica" },
+        "CU": { "zoneName": "Cuba" },
+        "CV": { "zoneName": "Cabo Verde" },
+        "CW": { "zoneName": "Curaçao" },
+        "CX": { "zoneName": "Đảo Giáng Sinh" },
+        "CY": { "zoneName": "Cyprus" },
+        "CZ": { "zoneName": "Czechia" },
+        "DE": { "zoneName": "Đức" },
+        "DJ": { "zoneName": "Djibouti" },
+        "DK": { "zoneName": "Đan Mạch" },
+        "DK-DK1": { "countryName": "Đan Mạch", "zoneName": "Tây Đan Mạch" },
+        "DK-DK2": { "countryName": "Đan Mạch", "zoneName": "Đông Đan Mạch" },
+        "DK-BHM": { "countryName": "Đan Mạch", "zoneName": "Bornholm" },
+        "DM": { "zoneName": "Dominica" },
+        "DO": { "zoneName": "Cộng hòa Dominican" },
+        "DZ": { "zoneName": "Algeria" },
+        "EC": { "zoneName": "Ecuador" },
+        "EE": { "zoneName": "Estonia" },
+        "EG": { "zoneName": "Ai Cập" },
+        "EH": { "zoneName": "Tây Sahara" },
+        "ER": { "zoneName": "Eritrea" },
+        "ES": { "zoneName": "Tây Ban Nha" },
+        "ES-IB-FO": { "countryName": "Tây Ban Nha", "zoneName": "Formentera" },
+        "ES-IB-IZ": { "countryName": "Tây Ban Nha", "zoneName": "Ibiza" },
+        "ES-IB-MA": { "countryName": "Tây Ban Nha", "zoneName": "Mallorca" },
+        "ES-IB-ME": { "countryName": "Tây Ban Nha", "zoneName": "Menorca" },
+        "ES-CN-FVLZ": { "countryName": "Tây Ban Nha", "zoneName": "Fuerteventura/Lanzarote" },
+        "ES-CN-GC": { "countryName": "Tây Ban Nha", "zoneName": "Gran Canaria" },
+        "ES-CN-HI": { "countryName": "Tây Ban Nha", "zoneName": "El Hierro" },
+        "ES-CN-IG": { "countryName": "Tây Ban Nha", "zoneName": "Isla de la Gomera" },
+        "ES-CN-LP": { "countryName": "Tây Ban Nha", "zoneName": "La Palma" },
+        "ES-CN-TE": { "countryName": "Tây Ban Nha", "zoneName": "Tenerife" },
+        "ET": { "zoneName": "Ethiopia" },
+        "FI": { "zoneName": "Phần Lan" },
+        "FJ": { "zoneName": "Fiji" },
+        "FK": { "zoneName": "Quần đảo Falkland" },
+        "FM": { "zoneName": "Micronesia" },
+        "FO": { "zoneName": "Quần đảo Faroe" },
+        "FR": { "zoneName": "Pháp" },
+        "FR-COR": { "countryName": "Pháp", "zoneName": "Corsica" },
+        "GA": { "zoneName": "Gabon" },
+        "GB": { "zoneName": "Đảo Anh" },
+        "GB-NIR": { "zoneName": "Bắc Ireland" },
+        "GB-ORK": { "countryName": "Great Britain", "zoneName": "Quần đảo Orkney" },
+        "GB-SHI": { "countryName": "Great Britain", "zoneName": "Quần đảo Shetland" },
+        "GB-ZET": { "countryName": "Great Britain", "zoneName": "Quần đảo Shetland" },
+        "GD": { "zoneName": "Grenada" },
+        "GE": { "zoneName": "Georgia" },
+        "GF": { "zoneName": "French Guiana" },
+        "GG": { "zoneName": "Guernsey" },
+        "GH": { "zoneName": "Ghana" },
+        "GI": { "zoneName": "Gibraltar" },
+        "GL": { "zoneName": "Greenland" },
+        "GM": { "zoneName": "Gambia" },
+        "GN": { "zoneName": "Guinea" },
+        "GP": { "zoneName": "Guadeloupe" },
+        "GQ": { "zoneName": "Guinea Xích đạo" },
+        "GR": { "zoneName": "Hy Lạp" },
+        "GR-IS": { "countryName": "Hy Lạp", "zoneName": "Quần đảo Aegean" },
+        "GS": { "zoneName": "Nam Georgia và Quần đảo Nam Sandwich" },
+        "GT": { "zoneName": "Guatemala" },
+        "GU": { "zoneName": "Guam" },
+        "GW": { "zoneName": "Guinea-Bissau" },
+        "GY": { "zoneName": "Guyana" },
+        "HK": { "zoneName": "Hồng Kông" },
+        "HM": { "zoneName": "Đảo Heard và Quần đảo McDonald" },
+        "HN": { "zoneName": "Honduras" },
+        "HR": { "zoneName": "Croatia" },
+        "HT": { "zoneName": "Haiti" },
+        "HU": { "zoneName": "Hungary" },
+        "ID": { "zoneName": "Indonesia" },
+        "IE": { "zoneName": "Ireland" },
+        "IL": { "zoneName": "Israel" },
+        "IM": { "zoneName": "Đảo Man" },
+        "IN-AN": { "countryName": "Ấn Độ", "zoneName": "Andaman và Quần đảo Nicobar" },
+        "IN-AP": { "countryName": "Ấn Độ", "zoneName": "Andhra Pradesh" },
+        "IN-AR": { "countryName": "Ấn Độ", "zoneName": "Arunachal Pradesh" },
+        "IN-AS": { "countryName": "Ấn Độ", "zoneName": "Assam" },
+        "IN-BR": { "countryName": "Ấn Độ", "zoneName": "Bihar" },
+        "IN-CT": { "countryName": "Ấn Độ", "zoneName": "Chhattisgarh" },
+        "IN-DL": { "countryName": "Ấn Độ", "zoneName": "Delhi" },
+        "IN-DN": { "countryName": "Ấn Độ", "zoneName": "Dadra và Nagar Haveli" },
+        "IN-GA": { "countryName": "Ấn Độ", "zoneName": "Goa" },
+        "IN-GJ": { "countryName": "Ấn Độ", "zoneName": "Gujarat" },
+        "IN-HP": { "countryName": "Ấn Độ", "zoneName": "Himachal Pradesh" },
+        "IN-HR": { "countryName": "Ấn Độ", "zoneName": "Haryana" },
+        "IN-JH": { "countryName": "Ấn Độ", "zoneName": "Jharkhand" },
+        "IN-JK": { "countryName": "Ấn Độ", "zoneName": "Jammu và Kashmir" },
+        "IN-KA": { "countryName": "Ấn Độ", "zoneName": "Karnataka" },
+        "IN-KL": { "countryName": "Ấn Độ", "zoneName": "Kerala" },
+        "IN-MH": { "countryName": "Ấn Độ", "zoneName": "Maharashtra" },
+        "IN-ML": { "countryName": "Ấn Độ", "zoneName": "Meghalaya" },
+        "IN-MN": { "countryName": "Ấn Độ", "zoneName": "Manipur" },
+        "IN-MP": { "countryName": "Ấn Độ", "zoneName": "Madhya Pradesh" },
+        "IN-MZ": { "countryName": "Ấn Độ", "zoneName": "Mizoram" },
+        "IN-NL": { "countryName": "Ấn Độ", "zoneName": "Nagaland" },
+        "IN-OR": { "countryName": "Ấn Độ", "zoneName": "Orissa" },
+        "IN-PB": { "countryName": "Ấn Độ", "zoneName": "Punjab" },
+        "IN-PY": { "countryName": "Ấn Độ", "zoneName": "Pondicherry" },
+        "IN-RJ": { "countryName": "Ấn Độ", "zoneName": "Rajasthan" },
+        "IN-SK": { "countryName": "Ấn Độ", "zoneName": "Sikkim" },
+        "IN-TN": { "countryName": "Ấn Độ", "zoneName": "Tamil Nadu" },
+        "IN-TR": { "countryName": "Ấn Độ", "zoneName": "Tripura" },
+        "IN-UP": { "countryName": "Ấn Độ", "zoneName": "Uttar Pradesh" },
+        "IN-UT": { "countryName": "Ấn Độ", "zoneName": "Uttarakhand" },
+        "IN-WB": { "countryName": "Ấn Độ", "zoneName": "Tây Bengal" },
+        "IO": { "zoneName": "Lãnh thổ Ấn Độ Dương thuộc Anh" },
+        "IQ": { "zoneName": "Iraq" },
+        "IQ-KUR": { "countryName": "Iraq", "zoneName": "Kurdistan" },
+        "IR": { "zoneName": "Iran" },
+        "IS": { "zoneName": "Iceland" },
+        "IT": { "zoneName": "Ý" },
+        "IT-CNO": { "countryName": "Ý", "zoneName": "Trung Bắc" },
+        "IT-CSO": { "countryName": "Ý", "zoneName": "Trung Nam" },
+        "IT-NO": { "countryName": "Ý", "zoneName": "Bắc" },
+        "IT-SAR": { "countryName": "Ý", "zoneName": "Sardinia" },
+        "IT-SIC": { "countryName": "Ý", "zoneName": "Sicily" },
+        "IT-SO": { "countryName": "Ý", "zoneName": "Nam" },
+        "JE": { "zoneName": "Jersey" },
+        "JM": { "zoneName": "Jamaica" },
+        "JO": { "zoneName": "Jordan" },
+        "JP-CB": { "countryName": "Nhật Bản", "zoneName": "Chūbu" },
+        "JP-CG": { "countryName": "Nhật Bản", "zoneName": "Chūgoku" },
+        "JP-HKD": { "countryName": "Nhật Bản", "zoneName": "Hokkaidō" },
+        "JP-HR": { "countryName": "Nhật Bản", "zoneName": "Hokuriku" },
+        "JP-KN": { "countryName": "Nhật Bản", "zoneName": "Kansai" },
+        "JP-KY": { "countryName": "Nhật Bản", "zoneName": "Kyūshū" },
+        "JP-ON": { "countryName": "Nhật Bản", "zoneName": "Okinawa" },
+        "JP-SK": { "countryName": "Nhật Bản", "zoneName": "Shikoku" },
+        "JP-TH": { "countryName": "Nhật Bản", "zoneName": "Tōhoku" },
+        "JP-TK": { "countryName": "Nhật Bản", "zoneName": "Tōkyō" },
+        "KE": { "zoneName": "Kenya" },
+        "KG": { "zoneName": "Kyrgyzstan" },
+        "KH": { "zoneName": "Cam-pu-chia" },
+        "KI": { "zoneName": "Kiribati" },
+        "KM": { "zoneName": "Comoros" },
+        "KN": { "zoneName": "Saint Kitts và Nevis" },
+        "KP": { "zoneName": "Bắc Triều Tiên" },
+        "KR": { "zoneName": "Hàn Quốc" },
+        "KW": { "zoneName": "Kuwait" },
+        "KY": { "zoneName": "Quần đảo Cayman" },
+        "KZ": { "zoneName": "Kazakhstan" },
+        "LA": { "zoneName": "Lào" },
+        "LB": { "zoneName": "Lebanon" },
+        "LC": { "zoneName": "Saint Lucia" },
+        "LI": { "zoneName": "Liechtenstein" },
+        "LK": { "zoneName": "Sri Lanka" },
+        "LR": { "zoneName": "Liberia" },
+        "LS": { "zoneName": "Lesotho" },
+        "LT": { "zoneName": "Lithuania" },
+        "LU": { "zoneName": "Luxembourg" },
+        "LV": { "zoneName": "Latvia" },
+        "LY": { "zoneName": "Libya" },
+        "MA": { "zoneName": "Morocco" },
+        "MC": { "zoneName": "Monaco" },
+        "MD": { "zoneName": "Moldova" },
+        "ME": { "zoneName": "Montenegro" },
+        "MF": { "countryName": "Saint Martin", "zoneName": "French" },
+        "MG": { "zoneName": "Madagascar" },
+        "MH": { "zoneName": "Quần đảo Marshall" },
+        "MK": { "zoneName": "Bắc Macedonia" },
+        "ML": { "zoneName": "Mali" },
+        "MM": { "zoneName": "Myanmar" },
+        "MN": { "zoneName": "Mông Cổ" },
+        "MO": { "zoneName": "Macao" },
+        "MP": { "zoneName": "Quần đảo Bắc Mariana" },
+        "MQ": { "zoneName": "Martinique" },
+        "MR": { "zoneName": "Mauritania" },
+        "MS": { "zoneName": "Montserrat" },
+        "MT": { "zoneName": "Malta" },
+        "MU": { "zoneName": "Mauritius" },
+        "MV": { "zoneName": "Maldives" },
+        "MW": { "zoneName": "Malawi" },
+        "MX": { "zoneName": "Mexico" },
+        "MX-BC": { "countryName": "Mexico", "zoneName": "Baja California" },
+        "MX-CE": { "countryName": "Mexico", "zoneName": "Central" },
+        "MX-NE": { "countryName": "Mexico", "zoneName": "Đông Bắc" },
+        "MX-NO": { "countryName": "Mexico", "zoneName": "Đông" },
+        "MX-NW": { "countryName": "Mexico", "zoneName": "Đông Nam" },
+        "MX-OC": { "countryName": "Mexico", "zoneName": "Occidental" },
+        "MX-OR": { "countryName": "Mexico", "zoneName": "Oriental" },
+        "MX-PN": { "countryName": "Mexico", "zoneName": "Peninsula" },
+        "MY-EM": { "countryName": "Malaysia", "zoneName": "Borneo" },
+        "MY-WM": { "countryName": "Malaysia", "zoneName": "Peninsula" },
+        "MZ": { "zoneName": "Mozambique" },
+        "NA": { "zoneName": "Namibia" },
+        "NC": { "zoneName": "Tân Caledonia" },
+        "NE": { "zoneName": "Niger" },
+        "NF": { "zoneName": "Đảo Norfolk" },
+        "NG": { "zoneName": "Nigeria" },
+        "NI": { "zoneName": "Nicaragua" },
+        "NKR": { "zoneName": "Nagorno-Karabakh" },
+        "NL": { "zoneName": "Hà Lan" },
+        "NO-NO1": { "countryName": "Na Uy", "zoneName": "Đông Nam Na Uy" },
+        "NO-NO2": { "countryName": "Na Uy", "zoneName": "Tây Bắc Na Uy" },
+        "NO-NO3": { "countryName": "Na Uy", "zoneName": "Trung Na Uy" },
+        "NO-NO4": { "countryName": "Na Uy", "zoneName": "Bắc Na Uy" },
+        "NO-NO5": { "countryName": "Na Uy", "zoneName": "Tây Na Uy" },
+        "NP": { "zoneName": "Nepal" },
+        "NR": { "zoneName": "Nauru" },
+        "NU": { "zoneName": "Niue" },
+        "NZ": { "zoneName": "New Zealand" },
+        "NZ-NZA": { "countryName": "New Zealand", "zoneName": "Quần đảo Auckland" },
+        "NZ-NZC": { "countryName": "New Zealand", "zoneName": "Quần đảo Chatham" },
+        "OM": { "zoneName": "Oman" },
+        "PA": { "zoneName": "Panama" },
+        "PE": { "zoneName": "Peru" },
+        "PF": { "zoneName": "Polynésie thuộc Pháp" },
+        "PG": { "zoneName": "Papua New Guinea" },
+        "PH": { "zoneName": "Philippines" },
+        "PK": { "zoneName": "Pakistan" },
+        "PL": { "zoneName": "Ba Lan" },
+        "PM": { "zoneName": "Saint Pierre và Miquelon" },
+        "PN": { "zoneName": "Pitcairn" },
+        "PR": { "zoneName": "Puerto Rico" },
+        "PS": { "zoneName": "Nhà nước Palestine" },
+        "PT": { "zoneName": "Bồ Đào Nha" },
+        "PT-AC": { "countryName": "Bồ Đào Nha", "zoneName": "Azores" },
+        "PT-MA": { "countryName": "Bồ Đào Nha", "zoneName": "Madeira" },
+        "PW": { "zoneName": "Palau" },
+        "PY": { "zoneName": "Paraguay" },
+        "QA": { "zoneName": "Qatar" },
+        "RE": { "zoneName": "Réunion" },
+        "RO": { "zoneName": "Romania" },
+        "RS": { "zoneName": "Serbia" },
+        "RU": { "zoneName": "Nga" },
+        "RU-1": { "countryName": "Nga", "zoneName": "Nga thuộc châu Âu và Ural" },
+        "RU-2": { "countryName": "Nga", "zoneName": "Siberia" },
+        "RU-EU": { "zoneName": "Nga" },
+        "RU-AS": { "zoneName": "Nga" },
+        "RU-KGD": { "countryName": "Nga", "zoneName": "Kaliningrad" },
+        "RW": { "zoneName": "Rwanda" },
+        "SA": { "zoneName": "Saudi Arabia" },
+        "SB": { "zoneName": "Quần đảo Solomon" },
+        "SC": { "zoneName": "Seychelles" },
+        "SD": { "zoneName": "Sudan" },
+        "SE": { "zoneName": "Thụy Điển" },
+        "SG": { "zoneName": "Singapore" },
+        "SH": { "zoneName": "Saint Helena, Ascension và Tristan da Cunha" },
+        "SI": { "zoneName": "Slovenia" },
+        "SJ": { "zoneName": "Svalbard và Jan Mayen" },
+        "SK": { "zoneName": "Slovakia" },
+        "SL": { "zoneName": "Sierra Leone" },
+        "SM": { "zoneName": "San Marino" },
+        "SN": { "zoneName": "Senegal" },
+        "SO": { "zoneName": "Somalia" },
+        "SR": { "zoneName": "Suriname" },
+        "SS": { "zoneName": "Nam Sudan" },
+        "ST": { "zoneName": "Sao Tome và Principe" },
+        "SV": { "zoneName": "El Salvador" },
+        "SX": { "countryName": "Sint Maarten", "zoneName": "Dutch" },
+        "SY": { "zoneName": "Syria" },
+        "SZ": { "zoneName": "Swaziland" },
+        "TC": { "zoneName": "Quần đảo Turks và Caicos" },
+        "TD": { "zoneName": "Chad" },
+        "TF": { "zoneName": "Vùng đất phía Nam thuộc Pháp" },
+        "TG": { "zoneName": "Togo" },
+        "TH": { "zoneName": "Thái Lan" },
+        "TJ": { "zoneName": "Tajikistan" },
+        "TK": { "zoneName": "Tokelau" },
+        "TL": { "zoneName": "Timor-Leste" },
+        "TM": { "zoneName": "Turkmenistan" },
+        "TN": { "zoneName": "Tunisia" },
+        "TO": { "zoneName": "Tonga" },
+        "TR": { "zoneName": "Thổ Nhĩ Kỳ" },
+        "TT": { "zoneName": "Trinidad và Tobago" },
+        "TV": { "zoneName": "Tuvalu" },
+        "TW": { "zoneName": "Đài Loan" },
+        "TZ": { "zoneName": "Tanzania" },
+        "UA": { "zoneName": "Ukraine" },
+        "UA-CR": { "countryName": "Crimea", "zoneName": "Ukraine" },
+        "UG": { "zoneName": "Uganda" },
+        "UM": { "zoneName": "Các tiểu đảo xa của Hoa Kỳ" },
+        "US-HI-HA": { "countryName": "Hoa Kỳ", "zoneName": "Hawaii" },
+        "US-HI-KA": { "countryName": "Hoa Kỳ", "zoneName": "Kauai" },
+        "US-HI-KH": { "countryName": "Hoa Kỳ", "zoneName": "Kahoolawe" },
+        "US-HI-LA": { "countryName": "Hoa Kỳ", "zoneName": "Lanai" },
+        "US-HI-MA": { "countryName": "Hoa Kỳ", "zoneName": "Maui" },
+        "US-HI-MO": { "countryName": "Hoa Kỳ", "zoneName": "Molokai" },
+        "US-HI-NI": { "countryName": "Hoa Kỳ", "zoneName": "Niihau" },
+        "US-HI-OA": { "countryName": "Hoa Kỳ", "zoneName": "Oahu" },
+        "UY": { "zoneName": "Uruguay" },
+        "UZ": { "zoneName": "Uzbekistan" },
+        "VA": { "zoneName": "Vatican City" },
+        "VC": { "zoneName": "Saint Vincent and the Grenadines" },
+        "VE": { "zoneName": "Venezuela" },
+        "VG": { "countryName": "Virgin Islands", "zoneName": "Virgin Islands" },
+        "VI": { "countryName": "Hoa Kỳ", "zoneName": "Virgin Islands" },
+        "VN": { "zoneName": "Việt Nam" },
+        "VU": { "zoneName": "Vanuatu" },
+        "WF": { "zoneName": "Wallis and Futuna" },
+        "WS": { "zoneName": "Samoa" },
+        "XX": { "zoneName": "Northern Cyprus" },
+        "YE": { "zoneName": "Yemen" },
+        "YT": { "zoneName": "Mayotte" },
+        "ZA": { "zoneName": "Nam Phi" },
+        "ZM": { "zoneName": "Zambia" },
+        "ZW": { "zoneName": "Zimbabwe" }
     }
 }

--- a/web/public/locales/zh-CN.json
+++ b/web/public/locales/zh-CN.json
@@ -21,18 +21,15 @@
         "noParserInfo": "我们目前还没有该地区的信息。<br/> 想要帮忙改善？可以通过<a href=\"%s\" target=\"_blank\">添加该地区的数据</a>。",
         "now": "当前"
     },
-    "rankings-panel": {
-        "country-ranking": "国家排名",
-        "show-ranking": "显示排名"
-    },
+    "rankings-panel": { "country-ranking": "国家排名", "show-ranking": "显示排名" },
     "country-history": {
-        "carbonintensity24h": "过去24小时的碳强度",
-        "emissions24h": "过去24小时的排放量",
-        "emissionsorigin24h": "过去24小时的排放来源",
-        "emissionsproduction24h": "过去24小时产生的排放",
-        "electricityorigin24h": "过去24小时的电力来源",
-        "electricityproduction24h": "过去24小时的发电量",
-        "electricityprices24h": "过去24小时的电价"
+        "carbonintensity": { "hourly": "过去24小时的碳强度" },
+        "emissionsorigin": { "hourly": "过去24小时的排放来源" },
+        "emissionsproduction": { "hourly": "过去24小时产生的排放" },
+        "electricityorigin": { "hourly": "过去24小时的电力来源" },
+        "electricityproduction": { "hourly": "过去24小时的发电量" },
+        "electricityprices": { "hourly": "过去24小时的电价" },
+        "emissions": { "hourly": "过去24小时的排放量" }
     },
     "footer": {
         "foundbugs": "发现错误或有其他想法？请回报",
@@ -122,557 +119,171 @@
         "seeHistoricalData-answer": "您可以通过我们的网站上的 <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">数据库</a>购买对我们所有历史数据的访问权限。"
     },
     "zoneShortName": {
-        "AL": {
-            "zoneName": "阿尔巴尼亚"
-        },
-        "AM": {
-            "zoneName": "亚美尼亚"
-        },
-        "AT": {
-            "zoneName": "奥地利"
-        },
-        "AUS-NSW": {
-            "zoneName": "澳大利亚（新南威尔士州）",
-            "countryName": "澳大利亚"
-        },
-        "AUS-NT": {
-            "zoneName": "澳大利亚（北领地）",
-            "countryName": "澳大利亚"
-        },
-        "AUS-QLD": {
-            "zoneName": "澳大利亚（昆士兰州）",
-            "countryName": "澳大利亚"
-        },
-        "AUS-SA": {
-            "zoneName": "澳大利亚（南澳大利亚）",
-            "countryName": "澳大利亚"
-        },
-        "AUS-TAS": {
-            "zoneName": "澳大利亚（塔斯马尼亚）",
-            "countryName": "澳大利亚"
-        },
-        "AUS-VIC": {
-            "zoneName": "澳大利亚（维多利亚）",
-            "countryName": "澳大利亚"
-        },
-        "AUS-WA": {
-            "zoneName": "澳大利亚（西澳大利亚）",
-            "countryName": "澳大利亚"
-        },
-        "AX": {
-            "zoneName": "奥兰"
-        },
-        "AZ": {
-            "zoneName": "阿塞拜疆"
-        },
-        "BA": {
-            "zoneName": "波斯尼亚和黑塞哥维那"
-        },
-        "BE": {
-            "zoneName": "比利时"
-        },
-        "BG": {
-            "zoneName": "保加利亚"
-        },
-        "BY": {
-            "zoneName": "白俄罗斯"
-        },
-        "CA-AB": {
-            "zoneName": "加拿大（阿尔伯塔）",
-            "countryName": "加拿大"
-        },
-        "CA-BC": {
-            "zoneName": "加拿大（不列颠哥伦比亚省）",
-            "countryName": "加拿大"
-        },
-        "CA-MB": {
-            "zoneName": "加拿大（马尼托巴省）",
-            "countryName": "加拿大"
-        },
-        "CA-NB": {
-            "zoneName": "加拿大（新不伦瑞克）",
-            "countryName": "加拿大"
-        },
-        "CA-NS": {
-            "zoneName": "加拿大（新斯科舍省）",
-            "countryName": "加拿大"
-        },
-        "CA-ON": {
-            "zoneName": "加拿大（安大略省）",
-            "countryName": "加拿大"
-        },
-        "CA-PE": {
-            "zoneName": "加拿大（太子港）",
-            "countryName": "加拿大"
-        },
-        "CA-QC": {
-            "zoneName": "加拿大（魁北克）",
-            "countryName": "加拿大"
-        },
-        "CA-SK": {
-            "zoneName": "加拿大（萨斯喀彻温省）",
-            "countryName": "加拿大"
-        },
-        "CH": {
-            "zoneName": "瑞士"
-        },
-        "CN": {
-            "zoneName": "中国"
-        },
-        "CY": {
-            "zoneName": "塞浦路斯"
-        },
-        "CZ": {
-            "zoneName": "捷克"
-        },
-        "DE": {
-            "zoneName": "德国"
-        },
-        "DK": {
-            "zoneName": "丹麦"
-        },
-        "DZ": {
-            "zoneName": "阿尔及利亚"
-        },
-        "EE": {
-            "zoneName": "爱沙尼亚"
-        },
-        "EG": {
-            "zoneName": "埃及"
-        },
-        "ES": {
-            "zoneName": "西班牙"
-        },
-        "FI": {
-            "zoneName": "芬兰"
-        },
-        "FO": {
-            "zoneName": "法罗群岛"
-        },
-        "FR": {
-            "zoneName": "法国"
-        },
-        "GB": {
-            "zoneName": "英国"
-        },
-        "GB-NIR": {
-            "zoneName": "北爱尔兰"
-        },
-        "GE": {
-            "zoneName": "格鲁吉亚"
-        },
-        "GR": {
-            "zoneName": "希腊"
-        },
-        "HR": {
-            "zoneName": "克罗地亚"
-        },
-        "HU": {
-            "zoneName": "匈牙利"
-        },
-        "IE": {
-            "zoneName": "爱尔兰"
-        },
-        "IL": {
-            "zoneName": "以色列"
-        },
-        "IQ": {
-            "zoneName": "伊拉克"
-        },
-        "IR": {
-            "zoneName": "伊朗"
-        },
-        "IS": {
-            "zoneName": "冰岛"
-        },
-        "IT": {
-            "zoneName": "意大利"
-        },
-        "JO": {
-            "zoneName": "约旦"
-        },
-        "JP": {
-            "zoneName": "日本"
-        },
-        "KR": {
-            "zoneName": "韩国"
-        },
-        "KZ": {
-            "zoneName": "哈萨克斯坦"
-        },
-        "LB": {
-            "zoneName": "黎巴嫩"
-        },
-        "LT": {
-            "zoneName": "立陶宛"
-        },
-        "LU": {
-            "zoneName": "卢森堡"
-        },
-        "LV": {
-            "zoneName": "拉脱维亚"
-        },
-        "LY": {
-            "zoneName": "利比亚"
-        },
-        "MA": {
-            "zoneName": "摩洛哥"
-        },
-        "MD": {
-            "zoneName": "摩尔多瓦"
-        },
-        "ME": {
-            "zoneName": "黑山共和国"
-        },
-        "MK": {
-            "zoneName": "北马其顿"
-        },
-        "MT": {
-            "zoneName": "马耳他"
-        },
-        "NKR": {
-            "zoneName": "纳戈尔诺-卡拉巴赫"
-        },
-        "NL": {
-            "zoneName": "荷兰"
-        },
-        "NO": {
-            "zoneName": "挪威"
-        },
-        "NZ": {
-            "zoneName": "新西兰"
-        },
-        "PL": {
-            "zoneName": "波兰"
-        },
-        "PS": {
-            "zoneName": "巴勒斯坦"
-        },
-        "PT": {
-            "zoneName": "葡萄牙"
-        },
-        "RO": {
-            "zoneName": "罗马尼亚"
-        },
-        "RS": {
-            "zoneName": "塞尔维亚"
-        },
-        "RU": {
-            "zoneName": "俄罗斯"
-        },
-        "SA": {
-            "zoneName": "沙乌地阿拉伯"
-        },
-        "SE": {
-            "zoneName": "瑞典"
-        },
-        "SI": {
-            "zoneName": "斯洛文尼亚"
-        },
-        "SK": {
-            "zoneName": "斯洛伐克"
-        },
-        "SY": {
-            "zoneName": "叙利亚"
-        },
-        "TM": {
-            "zoneName": "土库曼斯坦"
-        },
-        "TN": {
-            "zoneName": "突尼斯"
-        },
-        "TR": {
-            "zoneName": "土耳其"
-        },
-        "TW": {
-            "zoneName": "台湾"
-        },
-        "UA": {
-            "zoneName": "乌克兰"
-        },
-        "US": {
-            "zoneName": "美国"
-        },
-        "UZ": {
-            "zoneName": "乌兹别克"
-        },
-        "AE": {
-            "zoneName": "阿联酋"
-        },
-        "AF": {
-            "zoneName": "阿富汗"
-        },
-        "AG": {
-            "zoneName": "安提瓜和巴布达"
-        },
-        "AI": {
-            "zoneName": "安圭拉"
-        },
-        "AO": {
-            "zoneName": "安哥拉"
-        },
-        "AQ": {
-            "zoneName": "南极洲"
-        },
-        "AR": {
-            "zoneName": "美属萨摩亚阿根廷"
-        },
-        "AUS-TAS-KI": {
-            "countryName": "塔斯马尼亚",
-            "zoneName": "国王岛"
-        },
-        "AW": {
-            "zoneName": "阿鲁"
-        },
-        "BB": {
-            "zoneName": "巴巴多斯"
-        },
-        "BD": {
-            "zoneName": "孟加拉国"
-        },
-        "BF": {
-            "zoneName": "布基纳法索"
-        },
-        "BH": {
-            "zoneName": "巴林"
-        },
-        "BI": {
-            "zoneName": "布隆迪"
-        },
-        "BJ": {
-            "zoneName": "贝宁"
-        },
-        "BM": {
-            "zoneName": "百慕大"
-        },
-        "BN": {
-            "zoneName": "文莱"
-        },
-        "BO": {
-            "zoneName": "玻利维亚"
-        },
-        "BR-CS": {
-            "countryName": "巴西",
-            "zoneName": "巴西中部"
-        },
-        "BR-N": {
-            "countryName": "巴西",
-            "zoneName": "巴西北部"
-        },
-        "BR-NE": {
-            "countryName": "巴西",
-            "zoneName": "巴西东北部"
-        },
-        "BR-S": {
-            "countryName": "巴西",
-            "zoneName": "巴西南部"
-        },
-        "BS": {
-            "zoneName": "巴哈马"
-        },
-        "BT": {
-            "zoneName": "不丹"
-        },
-        "BV": {
-            "zoneName": "布韦岛"
-        },
-        "BW": {
-            "zoneName": "博茨瓦纳"
-        },
-        "BZ": {
-            "zoneName": "伯利兹"
-        },
-        "CA-NL": {
-            "countryName": "加拿大",
-            "zoneName": "纽芬兰与拉布拉多"
-        },
-        "CA-NT": {
-            "countryName": "加拿大",
-            "zoneName": "西北地区"
-        },
-        "CA-NU": {
-            "countryName": "加拿大",
-            "zoneName": "努纳武特地区"
-        },
-        "CA-YT": {
-            "countryName": "加拿大",
-            "zoneName": "育空地区"
-        },
-        "CC": {
-            "zoneName": "科科斯群岛"
-        },
-        "CD": {
-            "zoneName": "刚果民主共和国"
-        },
-        "CF": {
-            "zoneName": "中非共和国"
-        },
-        "CG": {
-            "zoneName": "刚果"
-        },
-        "CR": {
-            "zoneName": "哥斯达黎加"
-        },
-        "DO": {
-            "zoneName": "多米尼加共和国"
-        },
-        "ES-CN-FVLZ": {
-            "countryName": "西班牙",
-            "zoneName": "富埃特文图拉岛"
-        },
-        "ES-CN-GC": {
-            "countryName": "西班牙",
-            "zoneName": "大加那利岛"
-        },
-        "ES-CN-HI": {
-            "countryName": "西班牙",
-            "zoneName": "耶罗岛"
-        },
-        "ES-CN-IG": {
-            "countryName": "西班牙",
-            "zoneName": "戈梅拉岛"
-        },
-        "ES-CN-TE": {
-            "countryName": "西班牙",
-            "zoneName": "特内里费岛"
-        },
-        "ES-IB-MA": {
-            "countryName": "西班牙",
-            "zoneName": "马略卡岛"
-        },
-        "GT": {
-            "zoneName": "危地马拉"
-        },
-        "MY-WM": {
-            "countryName": "马来西亚",
-            "zoneName": "马来半岛"
-        },
-        "NA": {
-            "zoneName": "纳米比亚"
-        },
-        "IN-AN": {
-            "countryName": "印度",
-            "zoneName": "安达曼-尼科巴群岛"
-        },
-        "IN-AP": {
-            "countryName": "印度",
-            "zoneName": "安得拉邦"
-        },
-        "IN-AR": {
-            "countryName": "印度",
-            "zoneName": "阿鲁纳恰尔邦"
-        },
-        "IN-AS": {
-            "countryName": "印度",
-            "zoneName": "阿萨姆邦"
-        },
-        "IN-BR": {
-            "countryName": "印度",
-            "zoneName": "比哈尔邦"
-        },
-        "IN-CT": {
-            "countryName": "印度",
-            "zoneName": "恰蒂斯加尔邦"
-        },
-        "IN-DL": {
-            "countryName": "印度",
-            "zoneName": "德里"
-        },
-        "IN-GA": {
-            "countryName": "印度",
-            "zoneName": "果阿邦"
-        },
-        "IN-GJ": {
-            "countryName": "印度",
-            "zoneName": "古吉拉特邦"
-        },
-        "IN-HP": {
-            "countryName": "印度",
-            "zoneName": "喜马偕尔邦"
-        },
-        "IN-HR": {
-            "countryName": "印度",
-            "zoneName": "哈里亚纳邦"
-        },
-        "IN-PB": {
-            "countryName": "印度",
-            "zoneName": "旁遮普邦"
-        },
-        "IN-UP": {
-            "countryName": "印度",
-            "zoneName": "北方邦"
-        },
-        "IN-KA": {
-            "countryName": "印度",
-            "zoneName": "卡纳塔克邦"
-        },
-        "IT-CNO": {
-            "countryName": "意大利",
-            "zoneName": "意大利中北部"
-        },
-        "IT-CSO": {
-            "countryName": "意大利",
-            "zoneName": "意大利中南部"
-        },
-        "IT-NO": {
-            "countryName": "意大利",
-            "zoneName": "意大利北部"
-        },
-        "IT-SAR": {
-            "countryName": "意大利",
-            "zoneName": "撒丁岛"
-        },
-        "IT-SIC": {
-            "countryName": "意大利",
-            "zoneName": "西西里岛"
-        },
-        "IT-SO": {
-            "countryName": "Italy",
-            "zoneName": "北意大利"
-        },
-        "NI": {
-            "zoneName": " 尼加拉瓜"
-        },
-        "NO-NO1": {
-            "countryName": "挪威",
-            "zoneName": "挪威东南部"
-        },
-        "NO-NO2": {
-            "countryName": "挪威",
-            "zoneName": "挪威西南部"
-        },
-        "NO-NO3": {
-            "countryName": "挪威",
-            "zoneName": "挪威中部"
-        },
-        "NO-NO4": {
-            "countryName": "挪威",
-            "zoneName": "挪威北部"
-        },
-        "NO-NO5": {
-            "countryName": "挪威",
-            "zoneName": "挪威西部"
-        },
-        "PA": {
-            "zoneName": "巴拿马"
-        },
-        "PE": {
-            "zoneName": "秘鲁"
-        },
-        "UY": {
-            "zoneName": "乌拉圭"
-        },
-        "SG": {
-            "zoneName": "新加坡"
-        },
-        "SV": {
-            "zoneName": "萨尔瓦多"
-        }
+        "AL": { "zoneName": "阿尔巴尼亚" },
+        "AM": { "zoneName": "亚美尼亚" },
+        "AT": { "zoneName": "奥地利" },
+        "AUS-NSW": { "zoneName": "澳大利亚（新南威尔士州）", "countryName": "澳大利亚" },
+        "AUS-NT": { "zoneName": "澳大利亚（北领地）", "countryName": "澳大利亚" },
+        "AUS-QLD": { "zoneName": "澳大利亚（昆士兰州）", "countryName": "澳大利亚" },
+        "AUS-SA": { "zoneName": "澳大利亚（南澳大利亚）", "countryName": "澳大利亚" },
+        "AUS-TAS": { "zoneName": "澳大利亚（塔斯马尼亚）", "countryName": "澳大利亚" },
+        "AUS-VIC": { "zoneName": "澳大利亚（维多利亚）", "countryName": "澳大利亚" },
+        "AUS-WA": { "zoneName": "澳大利亚（西澳大利亚）", "countryName": "澳大利亚" },
+        "AX": { "zoneName": "奥兰" },
+        "AZ": { "zoneName": "阿塞拜疆" },
+        "BA": { "zoneName": "波斯尼亚和黑塞哥维那" },
+        "BE": { "zoneName": "比利时" },
+        "BG": { "zoneName": "保加利亚" },
+        "BY": { "zoneName": "白俄罗斯" },
+        "CA-AB": { "zoneName": "加拿大（阿尔伯塔）", "countryName": "加拿大" },
+        "CA-BC": { "zoneName": "加拿大（不列颠哥伦比亚省）", "countryName": "加拿大" },
+        "CA-MB": { "zoneName": "加拿大（马尼托巴省）", "countryName": "加拿大" },
+        "CA-NB": { "zoneName": "加拿大（新不伦瑞克）", "countryName": "加拿大" },
+        "CA-NS": { "zoneName": "加拿大（新斯科舍省）", "countryName": "加拿大" },
+        "CA-ON": { "zoneName": "加拿大（安大略省）", "countryName": "加拿大" },
+        "CA-PE": { "zoneName": "加拿大（太子港）", "countryName": "加拿大" },
+        "CA-QC": { "zoneName": "加拿大（魁北克）", "countryName": "加拿大" },
+        "CA-SK": { "zoneName": "加拿大（萨斯喀彻温省）", "countryName": "加拿大" },
+        "CH": { "zoneName": "瑞士" },
+        "CN": { "zoneName": "中国" },
+        "CY": { "zoneName": "塞浦路斯" },
+        "CZ": { "zoneName": "捷克" },
+        "DE": { "zoneName": "德国" },
+        "DK": { "zoneName": "丹麦" },
+        "DZ": { "zoneName": "阿尔及利亚" },
+        "EE": { "zoneName": "爱沙尼亚" },
+        "EG": { "zoneName": "埃及" },
+        "ES": { "zoneName": "西班牙" },
+        "FI": { "zoneName": "芬兰" },
+        "FO": { "zoneName": "法罗群岛" },
+        "FR": { "zoneName": "法国" },
+        "GB": { "zoneName": "英国" },
+        "GB-NIR": { "zoneName": "北爱尔兰" },
+        "GE": { "zoneName": "格鲁吉亚" },
+        "GR": { "zoneName": "希腊" },
+        "HR": { "zoneName": "克罗地亚" },
+        "HU": { "zoneName": "匈牙利" },
+        "IE": { "zoneName": "爱尔兰" },
+        "IL": { "zoneName": "以色列" },
+        "IQ": { "zoneName": "伊拉克" },
+        "IR": { "zoneName": "伊朗" },
+        "IS": { "zoneName": "冰岛" },
+        "IT": { "zoneName": "意大利" },
+        "JO": { "zoneName": "约旦" },
+        "JP": { "zoneName": "日本" },
+        "KR": { "zoneName": "韩国" },
+        "KZ": { "zoneName": "哈萨克斯坦" },
+        "LB": { "zoneName": "黎巴嫩" },
+        "LT": { "zoneName": "立陶宛" },
+        "LU": { "zoneName": "卢森堡" },
+        "LV": { "zoneName": "拉脱维亚" },
+        "LY": { "zoneName": "利比亚" },
+        "MA": { "zoneName": "摩洛哥" },
+        "MD": { "zoneName": "摩尔多瓦" },
+        "ME": { "zoneName": "黑山共和国" },
+        "MK": { "zoneName": "北马其顿" },
+        "MT": { "zoneName": "马耳他" },
+        "NKR": { "zoneName": "纳戈尔诺-卡拉巴赫" },
+        "NL": { "zoneName": "荷兰" },
+        "NO": { "zoneName": "挪威" },
+        "NZ": { "zoneName": "新西兰" },
+        "PL": { "zoneName": "波兰" },
+        "PS": { "zoneName": "巴勒斯坦" },
+        "PT": { "zoneName": "葡萄牙" },
+        "RO": { "zoneName": "罗马尼亚" },
+        "RS": { "zoneName": "塞尔维亚" },
+        "RU": { "zoneName": "俄罗斯" },
+        "SA": { "zoneName": "沙乌地阿拉伯" },
+        "SE": { "zoneName": "瑞典" },
+        "SI": { "zoneName": "斯洛文尼亚" },
+        "SK": { "zoneName": "斯洛伐克" },
+        "SY": { "zoneName": "叙利亚" },
+        "TM": { "zoneName": "土库曼斯坦" },
+        "TN": { "zoneName": "突尼斯" },
+        "TR": { "zoneName": "土耳其" },
+        "TW": { "zoneName": "台湾" },
+        "UA": { "zoneName": "乌克兰" },
+        "US": { "zoneName": "美国" },
+        "UZ": { "zoneName": "乌兹别克" },
+        "AE": { "zoneName": "阿联酋" },
+        "AF": { "zoneName": "阿富汗" },
+        "AG": { "zoneName": "安提瓜和巴布达" },
+        "AI": { "zoneName": "安圭拉" },
+        "AO": { "zoneName": "安哥拉" },
+        "AQ": { "zoneName": "南极洲" },
+        "AR": { "zoneName": "美属萨摩亚阿根廷" },
+        "AUS-TAS-KI": { "countryName": "塔斯马尼亚", "zoneName": "国王岛" },
+        "AW": { "zoneName": "阿鲁" },
+        "BB": { "zoneName": "巴巴多斯" },
+        "BD": { "zoneName": "孟加拉国" },
+        "BF": { "zoneName": "布基纳法索" },
+        "BH": { "zoneName": "巴林" },
+        "BI": { "zoneName": "布隆迪" },
+        "BJ": { "zoneName": "贝宁" },
+        "BM": { "zoneName": "百慕大" },
+        "BN": { "zoneName": "文莱" },
+        "BO": { "zoneName": "玻利维亚" },
+        "BR-CS": { "countryName": "巴西", "zoneName": "巴西中部" },
+        "BR-N": { "countryName": "巴西", "zoneName": "巴西北部" },
+        "BR-NE": { "countryName": "巴西", "zoneName": "巴西东北部" },
+        "BR-S": { "countryName": "巴西", "zoneName": "巴西南部" },
+        "BS": { "zoneName": "巴哈马" },
+        "BT": { "zoneName": "不丹" },
+        "BV": { "zoneName": "布韦岛" },
+        "BW": { "zoneName": "博茨瓦纳" },
+        "BZ": { "zoneName": "伯利兹" },
+        "CA-NL": { "countryName": "加拿大", "zoneName": "纽芬兰与拉布拉多" },
+        "CA-NT": { "countryName": "加拿大", "zoneName": "西北地区" },
+        "CA-NU": { "countryName": "加拿大", "zoneName": "努纳武特地区" },
+        "CA-YT": { "countryName": "加拿大", "zoneName": "育空地区" },
+        "CC": { "zoneName": "科科斯群岛" },
+        "CD": { "zoneName": "刚果民主共和国" },
+        "CF": { "zoneName": "中非共和国" },
+        "CG": { "zoneName": "刚果" },
+        "CR": { "zoneName": "哥斯达黎加" },
+        "DO": { "zoneName": "多米尼加共和国" },
+        "ES-CN-FVLZ": { "countryName": "西班牙", "zoneName": "富埃特文图拉岛" },
+        "ES-CN-GC": { "countryName": "西班牙", "zoneName": "大加那利岛" },
+        "ES-CN-HI": { "countryName": "西班牙", "zoneName": "耶罗岛" },
+        "ES-CN-IG": { "countryName": "西班牙", "zoneName": "戈梅拉岛" },
+        "ES-CN-TE": { "countryName": "西班牙", "zoneName": "特内里费岛" },
+        "ES-IB-MA": { "countryName": "西班牙", "zoneName": "马略卡岛" },
+        "GT": { "zoneName": "危地马拉" },
+        "MY-WM": { "countryName": "马来西亚", "zoneName": "马来半岛" },
+        "NA": { "zoneName": "纳米比亚" },
+        "IN-AN": { "countryName": "印度", "zoneName": "安达曼-尼科巴群岛" },
+        "IN-AP": { "countryName": "印度", "zoneName": "安得拉邦" },
+        "IN-AR": { "countryName": "印度", "zoneName": "阿鲁纳恰尔邦" },
+        "IN-AS": { "countryName": "印度", "zoneName": "阿萨姆邦" },
+        "IN-BR": { "countryName": "印度", "zoneName": "比哈尔邦" },
+        "IN-CT": { "countryName": "印度", "zoneName": "恰蒂斯加尔邦" },
+        "IN-DL": { "countryName": "印度", "zoneName": "德里" },
+        "IN-GA": { "countryName": "印度", "zoneName": "果阿邦" },
+        "IN-GJ": { "countryName": "印度", "zoneName": "古吉拉特邦" },
+        "IN-HP": { "countryName": "印度", "zoneName": "喜马偕尔邦" },
+        "IN-HR": { "countryName": "印度", "zoneName": "哈里亚纳邦" },
+        "IN-PB": { "countryName": "印度", "zoneName": "旁遮普邦" },
+        "IN-UP": { "countryName": "印度", "zoneName": "北方邦" },
+        "IN-KA": { "countryName": "印度", "zoneName": "卡纳塔克邦" },
+        "IT-CNO": { "countryName": "意大利", "zoneName": "意大利中北部" },
+        "IT-CSO": { "countryName": "意大利", "zoneName": "意大利中南部" },
+        "IT-NO": { "countryName": "意大利", "zoneName": "意大利北部" },
+        "IT-SAR": { "countryName": "意大利", "zoneName": "撒丁岛" },
+        "IT-SIC": { "countryName": "意大利", "zoneName": "西西里岛" },
+        "IT-SO": { "countryName": "Italy", "zoneName": "北意大利" },
+        "NI": { "zoneName": " 尼加拉瓜" },
+        "NO-NO1": { "countryName": "挪威", "zoneName": "挪威东南部" },
+        "NO-NO2": { "countryName": "挪威", "zoneName": "挪威西南部" },
+        "NO-NO3": { "countryName": "挪威", "zoneName": "挪威中部" },
+        "NO-NO4": { "countryName": "挪威", "zoneName": "挪威北部" },
+        "NO-NO5": { "countryName": "挪威", "zoneName": "挪威西部" },
+        "PA": { "zoneName": "巴拿马" },
+        "PE": { "zoneName": "秘鲁" },
+        "UY": { "zoneName": "乌拉圭" },
+        "SG": { "zoneName": "新加坡" },
+        "SV": { "zoneName": "萨尔瓦多" }
     },
-    "mobile-main-menu": {
-        "areas": "地区",
-        "about": "关于"
-    },
+    "mobile-main-menu": { "areas": "地区", "about": "关于" },
     "onboarding-modal": {},
     "left-panel": {
         "zone-list-header-title": "气候影响-按地域划分",

--- a/web/public/locales/zh-HK.json
+++ b/web/public/locales/zh-HK.json
@@ -14,13 +14,8 @@
         "emissions": "碳排放量",
         "addeditsource": "<a href=\"%s\" target=\"_blank\">新增或編輯來源</a>"
     },
-    "country-history": {
-        "carbonintensity24h": "過去24小時的碳強度"
-    },
-    "footer": {
-        "foundbugs": "發現錯誤或有其他想法？請回報",
-        "here": "這裡"
-    },
+    "country-history": { "carbonintensity": { "hourly": "過去24小時的碳強度" } },
+    "footer": { "foundbugs": "發現錯誤或有其他想法？請回報", "here": "這裡" },
     "legends": {
         "windpotential": "風力發電潛力",
         "solarpotential": "太陽能發電潛力",
@@ -60,263 +55,91 @@
     "emissionsImportedFrom": "<img id=\"country-flag\"></img> <b>%2$s</b> <b>%1$s %%</b> 的排放量從 <img id=\"country-exchange-flag\"></img> <b>%3$s</b> 匯入",
     "ofCO2eqPerMinute": "of CO₂eq per minute",
     "zoneShortName": {
-        "AL": {
-            "zoneName": "阿爾巴尼亞"
-        },
-        "AM": {
-            "zoneName": "亞美尼亞"
-        },
-        "AT": {
-            "zoneName": "奧地利"
-        },
-        "AUS-NSW": {
-            "zoneName": "澳大利亞（新南威爾士州）"
-        },
-        "AUS-NT": {
-            "zoneName": "澳大利亞（北領地）"
-        },
-        "AUS-QLD": {
-            "zoneName": "澳大利亞（昆士蘭州）"
-        },
-        "AUS-SA": {
-            "zoneName": "澳大利亞（南澳大利亞）"
-        },
-        "AUS-TAS": {
-            "zoneName": "澳大利亞（塔斯馬尼亞）"
-        },
-        "AUS-VIC": {
-            "zoneName": "澳大利亞（維多利亞）"
-        },
-        "AUS-WA": {
-            "zoneName": "澳大利亞（西澳大利亞）"
-        },
-        "AX": {
-            "zoneName": "奧蘭群島"
-        },
-        "AZ": {
-            "zoneName": "阿塞拜疆"
-        },
-        "BA": {
-            "zoneName": "波斯尼亞和黑塞哥維那"
-        },
-        "BE": {
-            "zoneName": "比利時"
-        },
-        "BG": {
-            "zoneName": "保加利亞"
-        },
-        "BY": {
-            "zoneName": "白俄羅斯"
-        },
-        "CA-AB": {
-            "zoneName": "加拿大（阿爾伯塔）"
-        },
-        "CA-BC": {
-            "zoneName": "加拿大（不列顛哥倫比亞省）"
-        },
-        "CA-MB": {
-            "zoneName": "加拿大（馬尼托巴省）"
-        },
-        "CA-NB": {
-            "zoneName": "加拿大（新不倫瑞克）"
-        },
-        "CA-NS": {
-            "zoneName": "加拿大（新斯科舍省）"
-        },
-        "CA-ON": {
-            "zoneName": "加拿大（安大略省）"
-        },
-        "CA-PE": {
-            "zoneName": "加拿大（太子港）"
-        },
-        "CA-QC": {
-            "zoneName": "加拿大（魁北克）"
-        },
-        "CA-SK": {
-            "zoneName": "加拿大（薩斯喀徹溫省）"
-        },
-        "CH": {
-            "zoneName": "瑞士"
-        },
-        "CN": {
-            "zoneName": "中國"
-        },
-        "CY": {
-            "zoneName": "塞浦路斯"
-        },
-        "CZ": {
-            "zoneName": "捷克"
-        },
-        "DE": {
-            "zoneName": "德國"
-        },
-        "DK": {
-            "zoneName": "丹麥"
-        },
-        "DZ": {
-            "zoneName": "阿爾及利亞"
-        },
-        "EE": {
-            "zoneName": "愛沙尼亞"
-        },
-        "EG": {
-            "zoneName": "埃及"
-        },
-        "ES": {
-            "zoneName": "西班牙"
-        },
-        "FI": {
-            "zoneName": "芬蘭"
-        },
-        "FO": {
-            "zoneName": "法羅群島"
-        },
-        "FR": {
-            "zoneName": "法國"
-        },
-        "GB": {
-            "zoneName": "英國"
-        },
-        "GB-NIR": {
-            "zoneName": "北愛爾蘭"
-        },
-        "GE": {
-            "zoneName": "格魯吉亞"
-        },
-        "GR": {
-            "zoneName": "希臘"
-        },
-        "HR": {
-            "zoneName": "克羅地亞"
-        },
-        "HU": {
-            "zoneName": "匈牙利"
-        },
-        "IE": {
-            "zoneName": "愛爾蘭"
-        },
-        "IL": {
-            "zoneName": "以色列"
-        },
-        "IQ": {
-            "zoneName": "伊拉克"
-        },
-        "IR": {
-            "zoneName": "伊朗"
-        },
-        "IS": {
-            "zoneName": "冰島"
-        },
-        "IT": {
-            "zoneName": "義大利"
-        },
-        "JO": {
-            "zoneName": "約旦"
-        },
-        "JP": {
-            "zoneName": "日本"
-        },
-        "KR": {
-            "zoneName": "南韓"
-        },
-        "KZ": {
-            "zoneName": "哈薩克斯坦"
-        },
-        "LB": {
-            "zoneName": "黎巴嫩"
-        },
-        "LT": {
-            "zoneName": "立陶宛"
-        },
-        "LU": {
-            "zoneName": "盧森堡"
-        },
-        "LV": {
-            "zoneName": "拉脫維亞"
-        },
-        "LY": {
-            "zoneName": "利比亞"
-        },
-        "MA": {
-            "zoneName": "摩洛哥"
-        },
-        "MD": {
-            "zoneName": "摩爾多瓦"
-        },
-        "ME": {
-            "zoneName": "黑山共和國"
-        },
-        "MK": {
-            "zoneName": "北馬其頓"
-        },
-        "MT": {
-            "zoneName": "馬耳他"
-        },
-        "NKR": {
-            "zoneName": "納戈爾諾-卡拉巴赫"
-        },
-        "NL": {
-            "zoneName": "荷蘭"
-        },
-        "NO": {
-            "zoneName": "挪威"
-        },
-        "NZ": {
-            "zoneName": "紐西蘭"
-        },
-        "PL": {
-            "zoneName": "波蘭"
-        },
-        "PS": {
-            "zoneName": "巴勒斯坦"
-        },
-        "PT": {
-            "zoneName": "葡萄牙"
-        },
-        "RO": {
-            "zoneName": "羅馬尼亞"
-        },
-        "RS": {
-            "zoneName": "塞爾維亞"
-        },
-        "RU": {
-            "zoneName": "俄羅斯"
-        },
-        "SA": {
-            "zoneName": "沙烏地阿拉伯"
-        },
-        "SE": {
-            "zoneName": "瑞典"
-        },
-        "SI": {
-            "zoneName": "斯洛維尼亞"
-        },
-        "SK": {
-            "zoneName": "斯洛伐克"
-        },
-        "SY": {
-            "zoneName": "敘利亞"
-        },
-        "TM": {
-            "zoneName": "土庫曼斯坦"
-        },
-        "TN": {
-            "zoneName": "突尼西亞"
-        },
-        "TR": {
-            "zoneName": "土耳其"
-        },
-        "TW": {
-            "zoneName": "台灣"
-        },
-        "UA": {
-            "zoneName": "烏克蘭"
-        },
-        "US": {
-            "zoneName": "美國"
-        },
-        "UZ": {
-            "zoneName": "烏茲別克"
-        }
+        "AL": { "zoneName": "阿爾巴尼亞" },
+        "AM": { "zoneName": "亞美尼亞" },
+        "AT": { "zoneName": "奧地利" },
+        "AUS-NSW": { "zoneName": "澳大利亞（新南威爾士州）" },
+        "AUS-NT": { "zoneName": "澳大利亞（北領地）" },
+        "AUS-QLD": { "zoneName": "澳大利亞（昆士蘭州）" },
+        "AUS-SA": { "zoneName": "澳大利亞（南澳大利亞）" },
+        "AUS-TAS": { "zoneName": "澳大利亞（塔斯馬尼亞）" },
+        "AUS-VIC": { "zoneName": "澳大利亞（維多利亞）" },
+        "AUS-WA": { "zoneName": "澳大利亞（西澳大利亞）" },
+        "AX": { "zoneName": "奧蘭群島" },
+        "AZ": { "zoneName": "阿塞拜疆" },
+        "BA": { "zoneName": "波斯尼亞和黑塞哥維那" },
+        "BE": { "zoneName": "比利時" },
+        "BG": { "zoneName": "保加利亞" },
+        "BY": { "zoneName": "白俄羅斯" },
+        "CA-AB": { "zoneName": "加拿大（阿爾伯塔）" },
+        "CA-BC": { "zoneName": "加拿大（不列顛哥倫比亞省）" },
+        "CA-MB": { "zoneName": "加拿大（馬尼托巴省）" },
+        "CA-NB": { "zoneName": "加拿大（新不倫瑞克）" },
+        "CA-NS": { "zoneName": "加拿大（新斯科舍省）" },
+        "CA-ON": { "zoneName": "加拿大（安大略省）" },
+        "CA-PE": { "zoneName": "加拿大（太子港）" },
+        "CA-QC": { "zoneName": "加拿大（魁北克）" },
+        "CA-SK": { "zoneName": "加拿大（薩斯喀徹溫省）" },
+        "CH": { "zoneName": "瑞士" },
+        "CN": { "zoneName": "中國" },
+        "CY": { "zoneName": "塞浦路斯" },
+        "CZ": { "zoneName": "捷克" },
+        "DE": { "zoneName": "德國" },
+        "DK": { "zoneName": "丹麥" },
+        "DZ": { "zoneName": "阿爾及利亞" },
+        "EE": { "zoneName": "愛沙尼亞" },
+        "EG": { "zoneName": "埃及" },
+        "ES": { "zoneName": "西班牙" },
+        "FI": { "zoneName": "芬蘭" },
+        "FO": { "zoneName": "法羅群島" },
+        "FR": { "zoneName": "法國" },
+        "GB": { "zoneName": "英國" },
+        "GB-NIR": { "zoneName": "北愛爾蘭" },
+        "GE": { "zoneName": "格魯吉亞" },
+        "GR": { "zoneName": "希臘" },
+        "HR": { "zoneName": "克羅地亞" },
+        "HU": { "zoneName": "匈牙利" },
+        "IE": { "zoneName": "愛爾蘭" },
+        "IL": { "zoneName": "以色列" },
+        "IQ": { "zoneName": "伊拉克" },
+        "IR": { "zoneName": "伊朗" },
+        "IS": { "zoneName": "冰島" },
+        "IT": { "zoneName": "義大利" },
+        "JO": { "zoneName": "約旦" },
+        "JP": { "zoneName": "日本" },
+        "KR": { "zoneName": "南韓" },
+        "KZ": { "zoneName": "哈薩克斯坦" },
+        "LB": { "zoneName": "黎巴嫩" },
+        "LT": { "zoneName": "立陶宛" },
+        "LU": { "zoneName": "盧森堡" },
+        "LV": { "zoneName": "拉脫維亞" },
+        "LY": { "zoneName": "利比亞" },
+        "MA": { "zoneName": "摩洛哥" },
+        "MD": { "zoneName": "摩爾多瓦" },
+        "ME": { "zoneName": "黑山共和國" },
+        "MK": { "zoneName": "北馬其頓" },
+        "MT": { "zoneName": "馬耳他" },
+        "NKR": { "zoneName": "納戈爾諾-卡拉巴赫" },
+        "NL": { "zoneName": "荷蘭" },
+        "NO": { "zoneName": "挪威" },
+        "NZ": { "zoneName": "紐西蘭" },
+        "PL": { "zoneName": "波蘭" },
+        "PS": { "zoneName": "巴勒斯坦" },
+        "PT": { "zoneName": "葡萄牙" },
+        "RO": { "zoneName": "羅馬尼亞" },
+        "RS": { "zoneName": "塞爾維亞" },
+        "RU": { "zoneName": "俄羅斯" },
+        "SA": { "zoneName": "沙烏地阿拉伯" },
+        "SE": { "zoneName": "瑞典" },
+        "SI": { "zoneName": "斯洛維尼亞" },
+        "SK": { "zoneName": "斯洛伐克" },
+        "SY": { "zoneName": "敘利亞" },
+        "TM": { "zoneName": "土庫曼斯坦" },
+        "TN": { "zoneName": "突尼西亞" },
+        "TR": { "zoneName": "土耳其" },
+        "TW": { "zoneName": "台灣" },
+        "UA": { "zoneName": "烏克蘭" },
+        "US": { "zoneName": "美國" },
+        "UZ": { "zoneName": "烏茲別克" }
     }
 }

--- a/web/public/locales/zh-TW.json
+++ b/web/public/locales/zh-TW.json
@@ -14,13 +14,8 @@
         "emissions": "碳排放量",
         "addeditsource": "<a href=\"%s\" target=\"_blank\">新增或編輯來源</a>"
     },
-    "country-history": {
-        "carbonintensity24h": "過去24小時的碳強度"
-    },
-    "footer": {
-        "foundbugs": "發現錯誤或有其他想法？請回報",
-        "here": "這裡"
-    },
+    "country-history": { "carbonintensity": { "hourly": "過去24小時的碳強度" } },
+    "footer": { "foundbugs": "發現錯誤或有其他想法？請回報", "here": "這裡" },
     "legends": {
         "windpotential": "風力發電潛力",
         "solarpotential": "太陽能發電潛力",
@@ -61,263 +56,91 @@
     "emissionsImportedFrom": "<img id=\"country-flag\"></img> <b>%2$s</b> <b>%1$s %%</b> 的排放量從 <img id=\"country-exchange-flag\"></img> <b>%3$s</b> 匯入",
     "ofCO2eqPerMinute": "of CO₂eq per minute",
     "zoneShortName": {
-        "AL": {
-            "zoneName": "阿爾巴尼亞"
-        },
-        "AM": {
-            "zoneName": "亞美尼亞"
-        },
-        "AT": {
-            "zoneName": "奧地利"
-        },
-        "AUS-NSW": {
-            "zoneName": "澳大利亞（新南威爾士州）"
-        },
-        "AUS-NT": {
-            "zoneName": "澳大利亞（北領地）"
-        },
-        "AUS-QLD": {
-            "zoneName": "澳大利亞（昆士蘭州）"
-        },
-        "AUS-SA": {
-            "zoneName": "澳大利亞（南澳大利亞）"
-        },
-        "AUS-TAS": {
-            "zoneName": "澳大利亞（塔斯馬尼亞）"
-        },
-        "AUS-VIC": {
-            "zoneName": "澳大利亞（維多利亞）"
-        },
-        "AUS-WA": {
-            "zoneName": "澳大利亞（西澳大利亞）"
-        },
-        "AX": {
-            "zoneName": "奧蘭"
-        },
-        "AZ": {
-            "zoneName": "阿塞拜疆"
-        },
-        "BA": {
-            "zoneName": "波斯尼亞和黑塞哥維那"
-        },
-        "BE": {
-            "zoneName": "比利時"
-        },
-        "BG": {
-            "zoneName": "保加利亞"
-        },
-        "BY": {
-            "zoneName": "白俄羅斯"
-        },
-        "CA-AB": {
-            "zoneName": "加拿大（阿爾伯塔）"
-        },
-        "CA-BC": {
-            "zoneName": "加拿大（不列顛哥倫比亞省）"
-        },
-        "CA-MB": {
-            "zoneName": "加拿大（馬尼托巴省）"
-        },
-        "CA-NB": {
-            "zoneName": "加拿大（新不倫瑞克）"
-        },
-        "CA-NS": {
-            "zoneName": "加拿大（新斯科舍省）"
-        },
-        "CA-ON": {
-            "zoneName": "加拿大（安大略省）"
-        },
-        "CA-PE": {
-            "zoneName": "加拿大（太子港）"
-        },
-        "CA-QC": {
-            "zoneName": "加拿大（魁北克）"
-        },
-        "CA-SK": {
-            "zoneName": "加拿大（薩斯喀徹溫省）"
-        },
-        "CH": {
-            "zoneName": "瑞士"
-        },
-        "CN": {
-            "zoneName": "中國"
-        },
-        "CY": {
-            "zoneName": "塞浦路斯"
-        },
-        "CZ": {
-            "zoneName": "捷克"
-        },
-        "DE": {
-            "zoneName": "德國"
-        },
-        "DK": {
-            "zoneName": "丹麥"
-        },
-        "DZ": {
-            "zoneName": "阿爾及利亞"
-        },
-        "EE": {
-            "zoneName": "愛沙尼亞"
-        },
-        "EG": {
-            "zoneName": "埃及"
-        },
-        "ES": {
-            "zoneName": "西班牙"
-        },
-        "FI": {
-            "zoneName": "芬蘭"
-        },
-        "FO": {
-            "zoneName": "法羅群島"
-        },
-        "FR": {
-            "zoneName": "法國"
-        },
-        "GB": {
-            "zoneName": "英國"
-        },
-        "GB-NIR": {
-            "zoneName": "北愛爾蘭"
-        },
-        "GE": {
-            "zoneName": "格魯吉亞"
-        },
-        "GR": {
-            "zoneName": "希臘"
-        },
-        "HR": {
-            "zoneName": "克羅地亞"
-        },
-        "HU": {
-            "zoneName": "匈牙利"
-        },
-        "IE": {
-            "zoneName": "愛爾蘭"
-        },
-        "IL": {
-            "zoneName": "以色列"
-        },
-        "IQ": {
-            "zoneName": "伊拉克"
-        },
-        "IR": {
-            "zoneName": "伊朗"
-        },
-        "IS": {
-            "zoneName": "冰島"
-        },
-        "IT": {
-            "zoneName": "義大利"
-        },
-        "JO": {
-            "zoneName": "約旦"
-        },
-        "JP": {
-            "zoneName": "日本"
-        },
-        "KR": {
-            "zoneName": "南韓"
-        },
-        "KZ": {
-            "zoneName": "哈薩克斯坦"
-        },
-        "LB": {
-            "zoneName": "黎巴嫩"
-        },
-        "LT": {
-            "zoneName": "立陶宛"
-        },
-        "LU": {
-            "zoneName": "盧森堡"
-        },
-        "LV": {
-            "zoneName": "拉脫維亞"
-        },
-        "LY": {
-            "zoneName": "利比亞"
-        },
-        "MA": {
-            "zoneName": "摩洛哥"
-        },
-        "MD": {
-            "zoneName": "摩爾多瓦"
-        },
-        "ME": {
-            "zoneName": "黑山共和國"
-        },
-        "MK": {
-            "zoneName": "北馬其頓"
-        },
-        "MT": {
-            "zoneName": "馬耳他"
-        },
-        "NKR": {
-            "zoneName": "納戈爾諾-卡拉巴赫"
-        },
-        "NL": {
-            "zoneName": "荷蘭"
-        },
-        "NO": {
-            "zoneName": "挪威"
-        },
-        "NZ": {
-            "zoneName": "紐西蘭"
-        },
-        "PL": {
-            "zoneName": "波蘭"
-        },
-        "PS": {
-            "zoneName": "巴勒斯坦"
-        },
-        "PT": {
-            "zoneName": "葡萄牙"
-        },
-        "RO": {
-            "zoneName": "羅馬尼亞"
-        },
-        "RS": {
-            "zoneName": "塞爾維亞"
-        },
-        "RU": {
-            "zoneName": "俄羅斯"
-        },
-        "SA": {
-            "zoneName": "沙烏地阿拉伯"
-        },
-        "SE": {
-            "zoneName": "瑞典"
-        },
-        "SI": {
-            "zoneName": "斯洛維尼亞"
-        },
-        "SK": {
-            "zoneName": "斯洛伐克"
-        },
-        "SY": {
-            "zoneName": "敘利亞"
-        },
-        "TM": {
-            "zoneName": "土庫曼斯坦"
-        },
-        "TN": {
-            "zoneName": "突尼西亞"
-        },
-        "TR": {
-            "zoneName": "土耳其"
-        },
-        "TW": {
-            "zoneName": "台灣"
-        },
-        "UA": {
-            "zoneName": "烏克蘭"
-        },
-        "US": {
-            "zoneName": "美國"
-        },
-        "UZ": {
-            "zoneName": "烏茲別克"
-        }
+        "AL": { "zoneName": "阿爾巴尼亞" },
+        "AM": { "zoneName": "亞美尼亞" },
+        "AT": { "zoneName": "奧地利" },
+        "AUS-NSW": { "zoneName": "澳大利亞（新南威爾士州）" },
+        "AUS-NT": { "zoneName": "澳大利亞（北領地）" },
+        "AUS-QLD": { "zoneName": "澳大利亞（昆士蘭州）" },
+        "AUS-SA": { "zoneName": "澳大利亞（南澳大利亞）" },
+        "AUS-TAS": { "zoneName": "澳大利亞（塔斯馬尼亞）" },
+        "AUS-VIC": { "zoneName": "澳大利亞（維多利亞）" },
+        "AUS-WA": { "zoneName": "澳大利亞（西澳大利亞）" },
+        "AX": { "zoneName": "奧蘭" },
+        "AZ": { "zoneName": "阿塞拜疆" },
+        "BA": { "zoneName": "波斯尼亞和黑塞哥維那" },
+        "BE": { "zoneName": "比利時" },
+        "BG": { "zoneName": "保加利亞" },
+        "BY": { "zoneName": "白俄羅斯" },
+        "CA-AB": { "zoneName": "加拿大（阿爾伯塔）" },
+        "CA-BC": { "zoneName": "加拿大（不列顛哥倫比亞省）" },
+        "CA-MB": { "zoneName": "加拿大（馬尼托巴省）" },
+        "CA-NB": { "zoneName": "加拿大（新不倫瑞克）" },
+        "CA-NS": { "zoneName": "加拿大（新斯科舍省）" },
+        "CA-ON": { "zoneName": "加拿大（安大略省）" },
+        "CA-PE": { "zoneName": "加拿大（太子港）" },
+        "CA-QC": { "zoneName": "加拿大（魁北克）" },
+        "CA-SK": { "zoneName": "加拿大（薩斯喀徹溫省）" },
+        "CH": { "zoneName": "瑞士" },
+        "CN": { "zoneName": "中國" },
+        "CY": { "zoneName": "塞浦路斯" },
+        "CZ": { "zoneName": "捷克" },
+        "DE": { "zoneName": "德國" },
+        "DK": { "zoneName": "丹麥" },
+        "DZ": { "zoneName": "阿爾及利亞" },
+        "EE": { "zoneName": "愛沙尼亞" },
+        "EG": { "zoneName": "埃及" },
+        "ES": { "zoneName": "西班牙" },
+        "FI": { "zoneName": "芬蘭" },
+        "FO": { "zoneName": "法羅群島" },
+        "FR": { "zoneName": "法國" },
+        "GB": { "zoneName": "英國" },
+        "GB-NIR": { "zoneName": "北愛爾蘭" },
+        "GE": { "zoneName": "格魯吉亞" },
+        "GR": { "zoneName": "希臘" },
+        "HR": { "zoneName": "克羅地亞" },
+        "HU": { "zoneName": "匈牙利" },
+        "IE": { "zoneName": "愛爾蘭" },
+        "IL": { "zoneName": "以色列" },
+        "IQ": { "zoneName": "伊拉克" },
+        "IR": { "zoneName": "伊朗" },
+        "IS": { "zoneName": "冰島" },
+        "IT": { "zoneName": "義大利" },
+        "JO": { "zoneName": "約旦" },
+        "JP": { "zoneName": "日本" },
+        "KR": { "zoneName": "南韓" },
+        "KZ": { "zoneName": "哈薩克斯坦" },
+        "LB": { "zoneName": "黎巴嫩" },
+        "LT": { "zoneName": "立陶宛" },
+        "LU": { "zoneName": "盧森堡" },
+        "LV": { "zoneName": "拉脫維亞" },
+        "LY": { "zoneName": "利比亞" },
+        "MA": { "zoneName": "摩洛哥" },
+        "MD": { "zoneName": "摩爾多瓦" },
+        "ME": { "zoneName": "黑山共和國" },
+        "MK": { "zoneName": "北馬其頓" },
+        "MT": { "zoneName": "馬耳他" },
+        "NKR": { "zoneName": "納戈爾諾-卡拉巴赫" },
+        "NL": { "zoneName": "荷蘭" },
+        "NO": { "zoneName": "挪威" },
+        "NZ": { "zoneName": "紐西蘭" },
+        "PL": { "zoneName": "波蘭" },
+        "PS": { "zoneName": "巴勒斯坦" },
+        "PT": { "zoneName": "葡萄牙" },
+        "RO": { "zoneName": "羅馬尼亞" },
+        "RS": { "zoneName": "塞爾維亞" },
+        "RU": { "zoneName": "俄羅斯" },
+        "SA": { "zoneName": "沙烏地阿拉伯" },
+        "SE": { "zoneName": "瑞典" },
+        "SI": { "zoneName": "斯洛維尼亞" },
+        "SK": { "zoneName": "斯洛伐克" },
+        "SY": { "zoneName": "敘利亞" },
+        "TM": { "zoneName": "土庫曼斯坦" },
+        "TN": { "zoneName": "突尼西亞" },
+        "TR": { "zoneName": "土耳其" },
+        "TW": { "zoneName": "台灣" },
+        "UA": { "zoneName": "烏克蘭" },
+        "US": { "zoneName": "美國" },
+        "UZ": { "zoneName": "烏茲別克" }
     }
 }

--- a/web/src/components/countryhistoryemissionsgraph.jsx
+++ b/web/src/components/countryhistoryemissionsgraph.jsx
@@ -4,7 +4,7 @@ import { scaleLinear } from 'd3-scale';
 import { max as d3Max } from 'd3-array';
 
 import { getTooltipPosition } from '../helpers/graph';
-import { useCurrentZoneHistory, useCurrentZoneHistoryStartTime, useCurrentZoneHistoryEndTime } from '../hooks/redux';
+import { useCurrentZoneHistory, useCurrentZoneHistoryDatetimes } from '../hooks/redux';
 import { tonsPerHourToGramsPerMinute } from '../helpers/math';
 import { getTotalElectricity } from '../helpers/zonedata';
 import { dispatchApplication } from '../store';
@@ -42,8 +42,9 @@ const CountryHistoryEmissionsGraph = ({ isMobile, selectedTimeIndex }) => {
   const [selectedLayerIndex, setSelectedLayerIndex] = useState(null);
 
   const historyData = useCurrentZoneHistory();
-  const startTime = useCurrentZoneHistoryStartTime();
-  const endTime = useCurrentZoneHistoryEndTime();
+  const datetimes = useCurrentZoneHistoryDatetimes();
+  const startTime = datetimes.at(0);
+  const endTime = datetimes.at(-1);
 
   // Recalculate graph data only when the history data is changed
   const { data, layerKeys, layerFill } = useMemo(() => prepareGraphData(historyData), [historyData]);

--- a/web/src/components/countryhistorymixgraph.jsx
+++ b/web/src/components/countryhistorymixgraph.jsx
@@ -6,12 +6,7 @@ import { scalePower } from '../helpers/formatting';
 import { useCo2ColorScale } from '../hooks/theme';
 import { getTooltipPosition } from '../helpers/graph';
 import { modeOrder, modeColor } from '../helpers/constants';
-import {
-  useCurrentZoneHistory,
-  useCurrentZoneHistoryStartTime,
-  useCurrentZoneHistoryEndTime,
-  useCurrentZoneExchangeKeys,
-} from '../hooks/redux';
+import { useCurrentZoneHistory, useCurrentZoneExchangeKeys, useCurrentZoneHistoryDatetimes } from '../hooks/redux';
 import { dispatchApplication } from '../store';
 
 import CountryPanelProductionTooltip from './tooltips/countrypanelproductiontooltip';
@@ -125,8 +120,9 @@ const CountryHistoryMixGraph = ({ displayByEmissions, electricityMixMode, isMobi
 
   const historyData = useCurrentZoneHistory();
   const exchangeKeys = useCurrentZoneExchangeKeys();
-  const startTime = useCurrentZoneHistoryStartTime();
-  const endTime = useCurrentZoneHistoryEndTime();
+  const datetimes = useCurrentZoneHistoryDatetimes();
+  const startTime = datetimes.at(0);
+  const endTime = datetimes.at(-1);
 
   // Recalculate graph data only when the history data is changed
   const { data, layerKeys, layerFill, valueAxisLabel } = useMemo(

--- a/web/src/components/countryhistorypricesgraph.jsx
+++ b/web/src/components/countryhistorypricesgraph.jsx
@@ -6,7 +6,7 @@ import { scaleLinear } from 'd3-scale';
 
 import { getTooltipPosition } from '../helpers/graph';
 import { dispatchApplication } from '../store';
-import { useCurrentZoneHistory, useCurrentZoneHistoryStartTime, useCurrentZoneHistoryEndTime } from '../hooks/redux';
+import { useCurrentZoneHistory, useCurrentZoneHistoryDatetimes } from '../hooks/redux';
 
 import AreaGraph from './graph/areagraph';
 import PriceTooltip from './tooltips/pricetooltip';
@@ -54,8 +54,9 @@ const CountryHistoryPricesGraph = ({ isMobile, selectedTimeIndex }) => {
   const [selectedLayerIndex, setSelectedLayerIndex] = useState(null);
 
   const historyData = useCurrentZoneHistory();
-  const startTime = useCurrentZoneHistoryStartTime();
-  const endTime = useCurrentZoneHistoryEndTime();
+  const datetimes = useCurrentZoneHistoryDatetimes();
+  const startTime = datetimes.at(0);
+  const endTime = datetimes.at(-1);
 
   // Recalculate graph data only when the history data is changed
   const { data, layerKeys, layerStroke, layerFill, markerFill, valueAxisLabel } = useMemo(

--- a/web/src/components/countryhistorytitle.jsx
+++ b/web/src/components/countryhistorytitle.jsx
@@ -1,0 +1,26 @@
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { useTranslation } from '../helpers/translation';
+import React from 'react';
+import { formatTimeRange } from '../helpers/formatting';
+
+const Text = styled.span`
+  font-size: 1.1em;
+`;
+
+export const CountryHistoryTitle = ({ translationKey }) => {
+  const { __, i18n } = useTranslation();
+  const aggregation = useSelector((state) => state.application.selectedTimeAggregate);
+  const localExists = i18n.exists(`${translationKey}.${aggregation}`, { fallbackLng: i18n.language });
+  const localDefaultExists = i18n.exists(`${translationKey}.default`, { fallbackLng: i18n.language });
+  /*
+  Use local for aggregation if exists, otherwise use local default if exists. If no translation exists, use english
+  */
+  return (
+    <Text>
+      {localExists
+        ? __(`${translationKey}.${aggregation}`)
+        : __(`${translationKey}.default`, formatTimeRange(localDefaultExists ? i18n.language : 'en', aggregation))}
+    </Text>
+  );
+};

--- a/web/src/components/graph/areagraph.jsx
+++ b/web/src/components/graph/areagraph.jsx
@@ -10,6 +10,7 @@ import GraphHoverLine from './graphhoverline';
 import ValueAxis from './valueaxis';
 import TimeAxis from './timeaxis';
 import { useRefWidthHeightObserver } from '../../hooks/viewport';
+import { useSelector } from 'react-redux';
 
 const X_AXIS_HEIGHT = 20;
 const Y_AXIS_WIDTH = 40;
@@ -141,6 +142,8 @@ const AreaGraph = React.memo(
       [containerWidth, datetimes, startTime, endTime]
     );
 
+    const selectedTimeAggregate = useSelector((state) => state.application.selectedTimeAggregate);
+
     // Don't render the graph at all if no layers are present
     if (isEmpty(layers)) {
       return null;
@@ -167,7 +170,13 @@ const AreaGraph = React.memo(
           isMobile={isMobile}
           svgNode={node}
         />
-        <TimeAxis scale={timeScale} transform={`translate(-1 ${containerHeight - 1})`} className="x axis" />
+        <TimeAxis
+          tickCount={datetimes.length + 1}
+          scale={timeScale}
+          transform={`translate(-1 ${containerHeight - 1})`}
+          className="x axis"
+          selectedTimeAggregate={selectedTimeAggregate}
+        />
         <ValueAxis scale={valueScale} label={valueAxisLabel} width={containerWidth} height={containerHeight} />
         <GraphHoverLine
           layers={layers}

--- a/web/src/components/graph/timeaxis.jsx
+++ b/web/src/components/graph/timeaxis.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import { formatDateTick } from '../../helpers/formatting';
 import { useTranslation } from '../../helpers/translation';
 
-const TOTAL_TICK_COUNT = 25; // total number of ticks to be displayed
 const TICK_VALUE_FREQUENCY = 6; // Frequency at which values are displayed for a tick
 
-const renderTickValue = (v, idx, displayLive, lang) => {
+const renderTickValue = (v, idx, displayLive, lang, selectedTimeAggregate) => {
   const shouldDisplayLive = idx === 24 && displayLive; // TODO: change this for other aggregations
 
   if (shouldDisplayLive) {
@@ -19,7 +19,7 @@ const renderTickValue = (v, idx, displayLive, lang) => {
   } else {
     return (
       <text fill="currentColor" y="9" x="5" dy="0.71em">
-        {new Intl.DateTimeFormat(lang, { timeStyle: 'short' }).format(v)}
+        {formatDateTick(v, lang, selectedTimeAggregate)}
       </text>
     );
   }
@@ -29,40 +29,43 @@ const roundUp = (number, base) => Math.ceil(number / base) * base;
 
 // Return `count` timestamp values uniformly distributed within the scale
 // domain, including both ends, rounded up to 15 minutes precision.
+
 const getTicksValuesFromTimeScale = (scale, count) => {
   const startTime = scale.domain()[0].valueOf();
   const endTime = scale.domain()[1].valueOf();
-
   const precision = 60 * 60 * 1000; // 60 minutes
   const step = (endTime - startTime) / (count - 1);
-
-  return [...Array(count).keys()].map(
+  const arr = [...Array(count).keys()].map(
     (ind) => new Date(ind === count - 1 ? endTime : roundUp(startTime + ind * step, precision))
   );
+
+  return arr;
 };
 
-const renderTick = (scale, val, idx, displayLive, lang) => {
+const renderTick = (scale, val, idx, displayLive, lang, selectedTimeAggregate) => {
   const shouldShowValue = idx % TICK_VALUE_FREQUENCY === 0;
   return (
     <g key={`timeaxis-tick-${idx}`} className="tick" opacity={1} transform={`translate(${scale(val)},0)`}>
       <line stroke="currentColor" y2="6" opacity={shouldShowValue ? 0.5 : 0.2} />
-      {shouldShowValue && renderTickValue(val, idx, displayLive, lang)}
+      {shouldShowValue && renderTickValue(val, idx, displayLive, lang, selectedTimeAggregate)}
     </g>
   );
 };
 
-const TimeAxis = React.memo(({ className, scale, transform, displayLive }) => {
-  const [x1, x2] = scale.range();
-  const { i18n } = useTranslation();
+const TimeAxis = React.memo(
+  ({ className, scale, transform, displayLive, tickCount = 25, selectedTimeAggregate = 'hourly' }) => {
+    const [x1, x2] = scale.range();
+    const { i18n } = useTranslation();
 
-  return (
-    <g className={className} transform={transform} fill="none" textAnchor="middle" style={{ pointerEvents: 'none' }}>
-      <path className="domain" stroke="currentColor" d={`M${x1 + 0.5},6V0.5H${x2 + 0.5}V6`} />
-      {getTicksValuesFromTimeScale(scale, TOTAL_TICK_COUNT).map((v, idx) =>
-        renderTick(scale, v, idx, displayLive, i18n.language)
-      )}
-    </g>
-  );
-});
+    return (
+      <g className={className} transform={transform} fill="none" textAnchor="middle" style={{ pointerEvents: 'none' }}>
+        <path className="domain" stroke="currentColor" d={`M${x1 + 0.5},6V0.5H${x2 + 0.5}V6`} />
+        {getTicksValuesFromTimeScale(scale, tickCount).map((v, idx) =>
+          renderTick(scale, v, idx, displayLive, i18n.language, selectedTimeAggregate)
+        )}
+      </g>
+    );
+  }
+);
 
 export default TimeAxis;

--- a/web/src/components/timeControls.jsx
+++ b/web/src/components/timeControls.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useTranslation } from '../helpers/translation';
 import styled, { css } from 'styled-components';
-import { formatDate } from '../helpers/formatting';
+import { formatDate, formatTimeRange } from '../helpers/formatting';
+import { TIME } from '../helpers/constants';
 
 const Title = styled.span`
   font-size: calc(11px + 0.2vw);
@@ -23,13 +24,12 @@ const DateRangeOption = styled.span`
   border-radius: 16px;
   white-space: nowrap;
   text-transform: capitalize;
-  cursor: not-allowed;
+  cursor: pointer;
   font-weight: ${(props) => (props.active ? 700 : 500)};
   opacity: ${(props) => (props.active ? 1 : 0.5)};
   ${(props) =>
     props.active &&
     css`
-      cursor: pointer;
       background-color: white;
       box-shadow: 0.1px 0.1px 5px rgba(0, 0, 0, 0.1);
     `}
@@ -66,32 +66,24 @@ const DateOptionWrapper = styled.div`
 
 const getOptions = (language) => [
   {
-    key: 'day',
-    label: new Intl.NumberFormat(language, {
-      style: 'unit',
-      unit: 'hour',
-      unitDisplay: 'long',
-    }).format(24),
+    key: TIME.HOURLY,
+    label: formatTimeRange(language, TIME.HOURLY),
   },
   {
-    key: 'month',
-    label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('month'),
+    key: TIME.DAILY,
+    label: formatTimeRange(language, TIME.DAILY),
   },
   {
-    key: 'year',
-    label: new Intl.DisplayNames(language, { type: 'dateTimeField' }).of('year'),
+    key: TIME.MONTHLY,
+    label: formatTimeRange(language, TIME.MONTHLY),
   },
   {
-    key: '5year',
-    label: new Intl.NumberFormat(language, {
-      style: 'unit',
-      unit: 'year',
-      unitDisplay: 'long',
-    }).format(5),
+    key: TIME.YEARLY,
+    label: formatTimeRange(language, TIME.YEARLY),
   },
 ];
 
-const TimeControls = ({ date, selectedTimeAggregate }) => {
+const TimeControls = ({ date, selectedTimeAggregate, handleTimeAggregationChange }) => {
   const { __, i18n } = useTranslation();
   const options = getOptions(i18n.language);
 
@@ -99,7 +91,7 @@ const TimeControls = ({ date, selectedTimeAggregate }) => {
     <div>
       <Wrapper>
         <Title>{__('time-controller.title')}</Title>
-        <DateDisplay>{formatDate(date, i18n.language)}</DateDisplay>
+        <DateDisplay>{formatDate(date, i18n.language, selectedTimeAggregate)}</DateDisplay>
       </Wrapper>
       <DateOptionWrapper>
         {options.map((o) => (
@@ -108,7 +100,7 @@ const TimeControls = ({ date, selectedTimeAggregate }) => {
             active={o.key === selectedTimeAggregate}
             onClick={() => {
               // TODO: not enabled yet
-              // handleTimeAggregationChange(o.key);
+              handleTimeAggregationChange(o.key);
             }}
           >
             {o.label}

--- a/web/src/components/timeControls.jsx
+++ b/web/src/components/timeControls.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from '../helpers/translation';
 import styled, { css } from 'styled-components';
-import { formatHourlyDate } from '../helpers/formatting';
+import { formatDate } from '../helpers/formatting';
 
 const Title = styled.span`
   font-size: calc(11px + 0.2vw);
@@ -99,7 +99,7 @@ const TimeControls = ({ date, selectedTimeAggregate }) => {
     <div>
       <Wrapper>
         <Title>{__('time-controller.title')}</Title>
-        <DateDisplay>{formatHourlyDate(date, i18n.language)}</DateDisplay>
+        <DateDisplay>{formatDate(date, i18n.language)}</DateDisplay>
       </Wrapper>
       <DateOptionWrapper>
         {options.map((o) => (

--- a/web/src/components/timeslider_new.jsx
+++ b/web/src/components/timeslider_new.jsx
@@ -8,6 +8,7 @@ import TimeSliderTooltip from './tooltips/timeslidertooltip';
 import TimeControls from './timeControls';
 import styled from 'styled-components';
 import { useTranslation } from '../helpers/translation';
+import { TIME } from '../helpers/constants';
 
 const AXIS_HORIZONTAL_MARGINS = 12;
 
@@ -157,7 +158,9 @@ const TimeSlider = ({
           scale={timeScale}
           transform={`translate(${AXIS_HORIZONTAL_MARGINS}, 0)`}
           className="time-slider-axis"
-          displayLive
+          tickCount={datetimes.length + 1}
+          displayLive={selectedTimeAggregate === TIME.HOURLY}
+          selectedTimeAggregate={selectedTimeAggregate}
         />
       </svg>
     </div>

--- a/web/src/components/tooltips/countrypanelproductiontooltip.jsx
+++ b/web/src/components/tooltips/countrypanelproductiontooltip.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
 import { useTranslation, getZoneNameWithCountry } from '../../helpers/translation';
 import { formatCo2, formatPower } from '../../helpers/formatting';
@@ -16,10 +16,10 @@ const mapStateToProps = (state) => ({
 
 const CountryPanelProductionTooltip = ({ displayByEmissions, mode, position, zoneData, onClose }) => {
   const { __ } = useTranslation();
+  const aggregation = useSelector((state) => state.application.selectedTimeAggregate);
   if (!zoneData) {
     return null;
   }
-
   const co2Intensity = getProductionCo2Intensity(mode, zoneData);
 
   const format = displayByEmissions ? formatCo2 : formatPower;
@@ -74,11 +74,15 @@ const CountryPanelProductionTooltip = ({ displayByEmissions, mode, position, zon
       {!displayByEmissions && (
         <React.Fragment>
           <br />
-          <br />
-          {__('tooltips.utilizing')} <b>{getRatioPercent(usage, capacity)} %</b> {__('tooltips.ofinstalled')}
-          <br />
-          <MetricRatio value={usage} total={capacity} format={format} />
-          <br />
+          {aggregation === 'hourly' && (
+            <>
+              <br />
+              {__('tooltips.utilizing')} <b>{getRatioPercent(usage, capacity)} %</b> {__('tooltips.ofinstalled')}
+              <br />
+              <MetricRatio value={usage} total={capacity} format={format} />
+              <br />
+            </>
+          )}
           <br />
           {__('tooltips.representing')} <b>{getRatioPercent(emissions, totalEmissions)} %</b>{' '}
           {__('tooltips.ofemissions')}

--- a/web/src/components/tooltips/timeslidertooltip.jsx
+++ b/web/src/components/tooltips/timeslidertooltip.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatHourlyDate } from '../../helpers/formatting';
+import { formatDate } from '../../helpers/formatting';
 import { useTranslation } from '../../helpers/translation';
 
 import Tooltip from '../tooltip';
@@ -12,7 +12,7 @@ const TimeSliderTooltip = ({ position, onClose, date, disabled }) => {
 
   return (
     <Tooltip id="timeslider-tooltip" position={position} onClose={onClose}>
-      {formatHourlyDate(date, i18n.language)}
+      {formatDate(date, i18n.language)}
     </Tooltip>
   );
 };

--- a/web/src/helpers/constants.js
+++ b/web/src/helpers/constants.js
@@ -95,6 +95,20 @@ const LOCALE_TO_FACEBOOK_LOCALE = {
   'zh-tw': 'zh_TW',
 };
 
+const TIME = {
+  HOURLY: 'hourly',
+  DAILY: 'daily',
+  MONTHLY: 'monthly',
+  YEARLY: 'yearly',
+};
+
+const TIME_TO_RANGE = {
+  HOURLY: 24,
+  DAILY: 30,
+  MONTHLY: 12,
+  YEARLY: 5,
+};
+
 export {
   modeColor,
   modeOrder,
@@ -104,4 +118,6 @@ export {
   DATA_FETCH_INTERVAL,
   LANGUAGE_NAMES,
   LOCALE_TO_FACEBOOK_LOCALE,
+  TIME,
+  TIME_TO_RANGE,
 };

--- a/web/src/helpers/formatting.js
+++ b/web/src/helpers/formatting.js
@@ -84,4 +84,15 @@ const formatTimeRange = (lang, timeAggregate) => {
   }
 };
 
-export { formatPower, formatCo2, scalePower, formatDate, formatTimeRange };
+const formatDateTick = function (date, lang, time) {
+  if (!date) return '';
+
+  switch (time) {
+    case TIME.DAILY:
+      return new Intl.DateTimeFormat(lang, { month: 'long', day: 'numeric' }).format(date);
+    case TIME.HOURLY:
+      return new Intl.DateTimeFormat(lang, { timeStyle: 'short' }).format(date);
+  }
+};
+
+export { formatPower, formatCo2, scalePower, formatDate, formatTimeRange, formatDateTick };

--- a/web/src/layout/leftpanel/countrypanel.jsx
+++ b/web/src/layout/leftpanel/countrypanel.jsx
@@ -33,7 +33,9 @@ import { useTranslation, getZoneNameWithCountry } from '../../helpers/translatio
 import EstimatedLabel from '../../components/countryestimationlabel';
 import SocialButtons from './socialbuttons';
 import { useFeatureToggle } from '../../hooks/router';
-import { formatHourlyDate } from '../../helpers/formatting';
+import { formatDate } from '../../helpers/formatting';
+import { TIME } from '../../helpers/constants';
+import { CountryHistoryTitle } from '../../components/countryhistorytitle';
 
 // TODO: Move all styles from styles.css to here
 // TODO: Remove all unecessary id and class tags
@@ -123,10 +125,6 @@ const BySource = styled.div`
   top: 0.8rem;
 `;
 
-const CountryHistoryTitle = styled.span`
-  font-size: 1.1em;
-`;
-
 const CountryTableHeaderInner = styled.div`
   display: flex;
   flex-basis: 33.3%;
@@ -182,6 +180,7 @@ const CountryHeader = ({ parentPage, zoneId, data, isMobile }) => {
   const shownDatetime = stateDatetime || datetime;
   const isDataEstimated = !(estimationMethod == null);
   const { i18n } = useTranslation();
+  const selectedTimeAggregate = useSelector((state) => state.application.selectedTimeAggregate);
 
   return (
     <div className="left-panel-zone-details-toolbar">
@@ -196,7 +195,7 @@ const CountryHeader = ({ parentPage, zoneId, data, isMobile }) => {
           <div style={{ flexGrow: 1 }}>
             <div className="country-name">{getZoneNameWithCountry(zoneId)}</div>
             <CountryTime>
-              {shownDatetime && formatHourlyDate(new Date(shownDatetime), i18n.language)}
+              {shownDatetime && formatDate(new Date(shownDatetime), i18n.language, selectedTimeAggregate)}
               {isDataEstimated && <EstimatedLabel isMobile={isMobile} />}
             </CountryTime>
           </div>
@@ -218,6 +217,7 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
   const location = useLocation();
   const { zoneId } = useParams();
   const isHistoryFeatureEnabled = useFeatureToggle('history');
+  const timeAggregate = useSelector((state) => state.application.selectedTimeAggregate);
 
   const data = useCurrentZoneData() || {};
 
@@ -327,9 +327,9 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
             <hr />
             {isDataEstimated && <EstimatedDataInfo text={__('country-panel.dataIsEstimated')} />}
             <div className="country-history">
-              <CountryHistoryTitle>
-                {__(tableDisplayEmissions ? 'country-history.emissions24h' : 'country-history.carbonintensity24h')}
-              </CountryHistoryTitle>
+              <CountryHistoryTitle
+                translationKey={tableDisplayEmissions ? 'country-history.emissions' : 'country-history.carbonintensity'}
+              />
               <br />
               <ProContainer>
                 <Icon iconName="file_download" />
@@ -345,14 +345,13 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
                 </span>
               </ProContainer>
               {tableDisplayEmissions ? <CountryHistoryEmissionsGraph /> : <CountryHistoryCarbonGraph />}
-
-              <CountryHistoryTitle>
-                {tableDisplayEmissions
-                  ? __(`country-history.emissions${electricityMixMode === 'consumption' ? 'origin' : 'production'}24h`)
-                  : __(
-                      `country-history.electricity${electricityMixMode === 'consumption' ? 'origin' : 'production'}24h`
-                    )}
-              </CountryHistoryTitle>
+              <CountryHistoryTitle
+                translationKey={
+                  tableDisplayEmissions
+                    ? `country-history.emissions${electricityMixMode === 'consumption' ? 'origin' : 'production'}`
+                    : `country-history.electricity${electricityMixMode === 'consumption' ? 'origin' : 'production'}`
+                }
+              />
               <br />
               <ProContainer>
                 <Icon iconName="file_download" />
@@ -369,8 +368,12 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
               </ProContainer>
               <CountryHistoryMixGraph />
 
-              <CountryHistoryTitle>{__('country-history.electricityprices24h')}</CountryHistoryTitle>
-              <CountryHistoryPricesGraph />
+              {timeAggregate === TIME.HOURLY && (
+                <>
+                  <CountryHistoryTitle translationKey={'country-history.electricityprices'} />
+                  <CountryHistoryPricesGraph />
+                </>
+              )}
             </div>
             <hr />
             <StyledSources historyFeatureEnabled={isHistoryFeatureEnabled}>

--- a/web/src/layout/timeController.jsx
+++ b/web/src/layout/timeController.jsx
@@ -13,6 +13,7 @@ const handleZoneTimeIndexChange = (timeIndex) => {
 
 const handleTimeAggregationChange = (aggregate) => {
   dispatchApplication('selectedTimeAggregate', aggregate);
+  dispatchApplication('selectedZoneTimeIndex', 0); // TODO: this is a hack. Should be length - 1
 };
 
 const mapStateToProps = (state) => ({

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -49,7 +49,7 @@ const initialApplicationState = {
   solarColorbarValue: null,
   webGLSupported: true,
   windColorbarValue: null,
-  selectedTimeAggregate: 'day',
+  selectedTimeAggregate: 'hourly',
 
   // TODO(olc): move this to countryPanel once all React components have been made
   tableDisplayEmissions: false,

--- a/web/src/sagas/index.js
+++ b/web/src/sagas/index.js
@@ -5,8 +5,12 @@ import { handleRequestError, protectedJsonRequest } from '../helpers/api';
 import { getGfsTargetTimeBefore, getGfsTargetTimeAfter, fetchGfsForecast } from '../helpers/gfs';
 
 function* fetchZoneHistory(action) {
-  const { zoneId, features } = action.payload;
+  const { zoneId, features, selectedTimeAggregate } = action.payload;
   let endpoint = `/v4/history?countryCode=${zoneId}`;
+
+  if (features.includes('history')) {
+    endpoint = `/v5/history/${selectedTimeAggregate}?countryCode=${zoneId}`;
+  }
 
   if (features.length > 0) {
     endpoint += `${features.map((f) => `&${f}=true`)}`;


### PR DESCRIPTION
This allows changing between different time aggregates (tested only on hourly and monthly aggregates)

There are quite a few things that needs to happen when the time aggregate changes
- All colors on the map needs to update
- All graphs and tooltips need to update, i.e. we don't have price or capacity for non-hourly data
- Translation of the graphs (i.e. instead of 'last 24 hours' -> 'last month')
- Timeaxis and ticks needs to change

WIP

