### PR TITLE
Move estimated data info box

### DIFF
--- a/web/src/components/countryEstimatedDataInfo.jsx
+++ b/web/src/components/countryEstimatedDataInfo.jsx
@@ -1,0 +1,23 @@
+import React, { memo } from 'react';
+import styled from 'styled-components';
+
+const EstimatedDataInfoBox = styled.p`
+  background-color: #eee;
+  border-radius: 6px;
+  padding: 6px;
+  font-size: 0.75rem;
+  margin: 1rem 0;
+`;
+
+const EstimatedDataInfo = memo(({ text }) => (
+  <>
+    <EstimatedDataInfoBox
+      dangerouslySetInnerHTML={{
+        __html: text,
+      }}
+    />
+    <hr />
+  </>
+));
+
+export default EstimatedDataInfo;

--- a/web/src/layout/leftpanel/countrypanel.jsx
+++ b/web/src/layout/leftpanel/countrypanel.jsx
@@ -20,6 +20,7 @@ import CountryHistoryMixGraph from '../../components/countryhistorymixgraph';
 import CountryHistoryPricesGraph from '../../components/countryhistorypricesgraph';
 import CountryTable from '../../components/countrytable';
 import CountryDisclaimer from '../../components/countrydisclaimer';
+import CountryEstimatedDataInfo from '../../components/countryEstimatedDataInfo';
 import LoadingPlaceholder from '../../components/loadingplaceholder';
 import Icon from '../../components/icon';
 
@@ -158,25 +159,6 @@ const StyledSources = styled.div`
   }
 `;
 
-const EstimatedDataInfoBox = styled.p`
-  background-color: #eee;
-  border-radius: 6px;
-  padding: 6px;
-  font-size: 0.75rem;
-  margin: 1rem 0;
-`;
-
-const EstimatedDataInfo = ({ text }) => (
-  <React.Fragment>
-    <EstimatedDataInfoBox
-      dangerouslySetInnerHTML={{
-        __html: text,
-      }}
-    />
-    <hr />
-  </React.Fragment>
-);
-
 const CountryHeader = ({ parentPage, zoneId, data, isMobile }) => {
   const { disclaimer, estimationMethod, stateDatetime, datetime } = data;
   const shownDatetime = stateDatetime || datetime;
@@ -247,7 +229,7 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
   }
 
   const { hasData, hasParser, estimationMethod } = data;
-  const isDataEstimated = !(estimationMethod == null);
+  const isDataEstimated = estimationMethod ? true : false;
 
   const co2Intensity = electricityMixMode === 'consumption' ? data.co2intensity : data.co2intensityProduction;
 
@@ -325,7 +307,6 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
             <CountryTable />
 
             <hr />
-            {isDataEstimated && <EstimatedDataInfo text={__('country-panel.dataIsEstimated')} />}
             <div className="country-history">
               <CountryHistoryTitle>
                 {__(tableDisplayEmissions ? 'country-history.emissions24h' : 'country-history.carbonintensity24h')}
@@ -374,6 +355,7 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
             </div>
             <hr />
             <StyledSources historyFeatureEnabled={isHistoryFeatureEnabled}>
+              {isDataEstimated && <CountryEstimatedDataInfo text={__('country-panel.dataIsEstimated')} />}
               {__('country-panel.source')}
               {': '}
               <a


### PR DESCRIPTION
This PR moves the estimated data info box to the bottom of the screen (above source and contributors) as discussed in #4122 and #3807.