### PR TITLE
Åland (AX) capacity update

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -164,6 +164,9 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 
 <details><summary>Click to see the full list of sources</summary>
 
+- Åland
+  - Wind: [Partial data from Kraftnät Åland](https://kraftnat.ax/projekt-langnabba/)
+  - Oil: [Kraftnät Åland](https://kraftnat.ax/stamnatet/)
 - Albania: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)
 - Andorra: [UNFCC](https://unfccc.int/sites/default/files/resource/AND_BUR1_Definitiu.pdf)
 - Argentina: [Cammesa](https://cammesaweb.cammesa.com/informe-sintesis-mensual/)
@@ -381,8 +384,8 @@ Cross-border transmission capacities between the zones are centralized in the [e
 
 <details><summary>Click to see the full list of sources</summary>
 
-- Åland ⇄ Sweden: ["Sverigekabeln": 80 MW](http://www.kraftnat.ax/files/rapportdel_2.pdf)
-- Åland ⇄ Finland: ["Brändö-Gustafs": 9 MW](http://www.kraftnat.ax/files/rapportdel_2.pdf)
+- Åland ⇄ Sweden: ["Sverigekabeln": 80 MW](https://kraftnat.ax/stamnatet/)
+- Åland ⇄ Finland: ["Gustavskablen": 10 MW + "ÅL-Link": 100 MW](https://kraftnat.ax/stamnatet/)
 - Albania ⇄ Greece: [533 MW](https://ec.europa.eu/energy/sites/ener/files/documents/2nd_report_ic_with_neighbouring_countries_b5.pdf)
 - Australia (New South Wales) ⇄ Australia (Queensland) ["QNI": 700MW (NSW -> QLD) 1200MW (QLD -> NSW)](https://en.wikipedia.org/wiki/Queensland_%E2%80%93_New_South_Wales_Interconnector) and ["N-Q-MNSP1": 180MW](https://www.aemo.com.au/-/media/Files/Electricity/NEM/Security_and_Reliability/Congestion-Information/2017/Interconnector-Capabilities.pdf)
 - Australia (Victoria) ⇄ Australia (New South Wales) ["VIC1-NSW1": 1600MW (VIC -> NSW) 1350MW (NSW -> VIC)](https://www.aemo.com.au/-/media/Files/Electricity/NEM/Security_and_Reliability/Congestion-Information/2017/Interconnector-Capabilities.pdf) and ["VNI": 170MW](https://www.transgrid.com.au/what-we-do/projects/current-projects/Victoria%20to%20NSW%20Interconnector)

--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -154,7 +154,7 @@
     "rotation": 0
   },
   "AX->FI": {
-    "capacity": [-9, 9],
+    "capacity": [-110, 110],
     "lonlat": [21.193, 60.386],
     "parsers": {
       "exchange": "AX.fetch_exchange"

--- a/config/zones.json
+++ b/config/zones.json
@@ -379,8 +379,8 @@
       "coal": 0,
       "gas": 0,
       "nuclear": 0,
-      "oil": 65.3,
-      "wind": 16.56
+      "oil": 35,
+      "wind": 58.56
     },
     "contributors": ["tmslaine", "systemcatch"],
     "parsers": {

--- a/parsers/AX.py
+++ b/parsers/AX.py
@@ -6,7 +6,7 @@ import requests
 from PIL import Image
 
 URL = "http://194.110.178.135/grafik/stamnat.php"
-SOURCE = "kraftnat.aland.fi"
+SOURCE = "kraftnat.ax"
 TZ = "Europe/Mariehamn"
 
 


### PR DESCRIPTION
This PR updates Åland (AX) production capacities for wind and oil as well as the exchange capacities between Åland and Finland.

Reference: #4183

EDIT: This PR also changes the source domain of the AX parser to the new domain (kraftnat.ax). It was already used in `DATA_SOURCES.md` but leads to a 404 page there, that should be updated when the changes for #4235 are implemented.