### PR TITLE
[BUGFIX] Fix "of installed capacity" on production tooltip

### DIFF
--- a/web/src/components/tooltips/countrypanelproductiontooltip.jsx
+++ b/web/src/components/tooltips/countrypanelproductiontooltip.jsx
@@ -75,7 +75,7 @@ const CountryPanelProductionTooltip = ({ displayByEmissions, mode, position, zon
       {!displayByEmissions && (
         <React.Fragment>
           <br />
-          {aggregation === TIME.hourly && (
+          {aggregation === TIME.HOURLY && (
             <>
               <br />
               {__('tooltips.utilizing')} <b>{getRatioPercent(usage, capacity)} %</b> {__('tooltips.ofinstalled')}


### PR DESCRIPTION
Super small PR to fix the production tooltip.

Before:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/30777521/173207344-d62d3808-4e8e-4c4d-81d2-b4f4f68ad68d.png">

After:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30777521/173207355-b1ef2e0a-bfbd-445f-8589-e869bd008cd5.png">
