### PR TITLE
Add current Åland wind capacity + data source

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -165,7 +165,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 <details><summary>Click to see the full list of sources</summary>
 
 - Åland
-  - Wind: [Partial data from Kraftnät Åland](https://kraftnat.ax/projekt-langnabba/)
+  - Wind: [Finnish Wind Power Association](https://tuulivoimayhdistys.fi/en/wind-power-in-finland/map 'Note: the map states 43MW for the Långnabba project, but as [Vestas](https://www.vestas.com/en/media/company-news/2020/vestas-develops-highly-customised-power-plant-solution--c3249491) and [Kraftnat](https://kraftnat.ax/) state 42MW, the lower figure was used')
   - Oil: [Kraftnät Åland](https://kraftnat.ax/stamnatet/)
 - Albania: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)
 - Andorra: [UNFCC](https://unfccc.int/sites/default/files/resource/AND_BUR1_Definitiu.pdf)

--- a/config/zones.json
+++ b/config/zones.json
@@ -380,7 +380,7 @@
       "gas": 0,
       "nuclear": 0,
       "oil": 35,
-      "wind": 58.56
+      "wind": 63.8
     },
     "contributors": ["tmslaine", "systemcatch"],
     "parsers": {


### PR DESCRIPTION
Closes #4183

Side note, this data source has 43MW for the new Långnabba wind farm, where the TSO data source we found earlier has 42MW. Since both [Vestas](https://www.vestas.com/en/media/company-news/2020/vestas-develops-highly-customised-power-plant-solution--c3249491) and [Kraftnat](https://kraftnat.ax/) state 42MW, the lower figure was used. The brochure for the wind turbine used also [states](https://nozebra.ipapercms.dk/Vestas/Communication/4mw-platform-brochure/?page=20) a more exact rated power of 4,200 kW per turbine (there are ten of the same type), so it's not a rounding error.