### PR TITLE
Adds sync functionality for history and grid state

### DIFF
--- a/web/src/helpers/redux.js
+++ b/web/src/helpers/redux.js
@@ -33,7 +33,7 @@ function initDataState() {
     zone.geography = geographies[key];
     zone.config = {};
     Object.keys(TIME).forEach((agg) => {
-      zone[TIME[agg]] = { details: [], overviews: [] };
+      zone[TIME[agg]] = { details: [], overviews: [], isExpired: true };
     });
 
     zone.config.capacity = zoneConfig.capacity;
@@ -46,6 +46,11 @@ function initDataState() {
     zone.config.countryCode = key;
 
     zones[key] = zone;
+  });
+
+  const isGridExpired = {};
+  Object.keys(TIME).forEach((agg) => {
+    isGridExpired[TIME[agg]] = true;
   });
 
   const exchanges = Object.assign({}, exchangesConfig);
@@ -62,6 +67,7 @@ function initDataState() {
     hasInitializedGrid: false,
     isLoadingHistories: false,
     isLoadingGrid: false,
+    isGridExpired,
     isLoadingSolar: false,
     isLoadingWind: false,
     solar: null,

--- a/web/src/hooks/fetch.js
+++ b/web/src/hooks/fetch.js
@@ -23,8 +23,8 @@ export function useConditionalZoneHistoryFetch() {
 
   // Fetch zone history data only if it's not there yet (and custom timestamp is not used).
   useEffect(() => {
-    const hasDetailedHistory = zones[zoneId]?.[selectedTimeAggregate].hasDetailedData;
-    if (zoneId && !hasDetailedHistory) {
+    const isExpired = zones[zoneId]?.[selectedTimeAggregate].isExpired;
+    if (zoneId && isExpired) {
       dispatch(ZONE_HISTORY_FETCH_REQUESTED({ zoneId, features, selectedTimeAggregate }));
     }
   }, [zoneId, dispatch, features, selectedTimeAggregate, zones]);
@@ -37,9 +37,10 @@ export function useGridDataPolling() {
   const dispatch = useDispatch();
 
   const hasOverviewData = Object.keys(zones).some((zoneId) => zones[zoneId][selectedTimeAggregate].overviews.length);
+  const isExpired = useSelector((state) => state.data.isGridExpired[selectedTimeAggregate]);
   // After initial request, do the polling only if the custom datetime is not specified.
   useEffect(() => {
-    if (!hasOverviewData) {
+    if (!hasOverviewData || isExpired) {
       dispatch(GRID_DATA_FETCH_REQUESTED({ features, selectedTimeAggregate }));
     }
 
@@ -53,7 +54,7 @@ export function useGridDataPolling() {
       );
     }, DATA_FETCH_INTERVAL);
     return () => clearInterval(pollInterval);
-  }, [dispatch, features, selectedTimeAggregate, hasOverviewData]);
+  }, [dispatch, features, selectedTimeAggregate, hasOverviewData, isExpired]);
 }
 
 export function useConditionalWindDataPolling() {


### PR DESCRIPTION
#4300 got a bit out of hand, so I am reducing the complexity a bit here by just adding another boolean flag for expiration.

It's a bit hard to test properly though but the basic idea is that both the grid and the history can expire each other. This would theoretically make it possible to get into an infinite loop, but I am not sure what the best way to solve that is.

We could implement some kind of number of maximum amount of requests per hour. Keep in mind this loop would require the app-backend to serve fairly nonsensical data.



