### PR TITLE
fix(JP): fix date comparison error in  `price` parser

### DIFF
--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -308,7 +308,7 @@ def fetch_price(
         return []
 
     start = target_datetime - dt.timedelta(days=1)
-    df["Date"] = df["Date"].apply(lambda x: dt.datetime.strptime(x, "%Y/%m/%d"))
+    df["Date"] = pd.to_datetime(df["Date"], format="%Y/%m/%d").dt.date
     df = df[(df["Date"] >= start.date()) & (df["Date"] <= target_datetime.date())]
 
     df["datetime"] = df.apply(


### PR DESCRIPTION
resolves #4346

This is because `df['Date']` column has `datetime64[ns]` dtype instead of `datetime.date` type. This change convert it to `datetime.date` by `.dt.date` attribute.

I also used Pandas' `pd.to_datetime()` method instead of `DataFrame.apply()` for code readability.