### PR TITLE
Average by source

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -50,6 +50,7 @@
     "electricityproduction": "Electricity production",
     "electricityconsumption": "Electricity consumption",
     "bysource": "by source",
+    "averagebysource": "average by source",
     "emissions": "Carbon emissions",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">add or edit source</a>",
     "helpfrom": "with help from",

--- a/web/public/locales/sv.json
+++ b/web/public/locales/sv.json
@@ -20,9 +20,15 @@
     "datasources": "datakällor",
     "contribute": "Bidra genom att <a href=\"%s\" target=\"_blank\">lägga till din region</a>"
   },
-  "mobile-main-menu": { "map": "Elkarta", "areas": "Regioner", "about": "Om" },
+  "mobile-main-menu": {
+    "map": "Elkarta",
+    "areas": "Regioner",
+    "about": "Om"
+  },
   "onboarding-modal": {
-    "view1": { "subtitle": "Kartlägger klimatpåverkan från elkonsumtion" },
+    "view1": {
+      "subtitle": "Kartlägger klimatpåverkan från elkonsumtion"
+    },
     "view2": {
       "header": "Se hur mycket CO₂ som släpps ut när din el produceras, i realtid.",
       "text": "Vi färglägger regioner runt om i världen baserat på dess kolintensitet (inklusive alla växthusgaser) från el konsumerad där. Ju grönare färg, desto mer klimatvänlig el."
@@ -58,7 +64,8 @@
     "aggregatedTooltip": "Data för denna zon är aggregerad baserat på historiska timvärden",
     "helpUs": "Hjälp oss identifiera problem genom att kolla på <a href=\"%s\" target=\"_blank\">körningsloggarna</a> eller kontakta dataleverantören.",
     "noParserInfo": "Vi har ännu ingen information om denna region.<br/> Vill du hjälpa till med att fixa det? Du kan bidra genom att <a href=\"%s\" target=\"_blank\">lägga till data för regionen</a>.",
-    "now": "Nu"
+    "now": "Nu",
+    "averagebysource": "genomsnitt per källa"
   },
   "time-controller": {
     "title": "Visa historisk data"
@@ -264,394 +271,1335 @@
     "disclaimer-answer": "<a href=\"https://electricitymap.org/\" target=\"_blank\">Electricity Maps</a> publicerar data och bilder på The <a href=\"https://www.electricitymap.org/\" target=\"_blank\">Electricity Maps</a> för informationsändamål. Det görs inga påståenden om korrekthet och inte heller lämnas några garantier, och vi förbehåller oss rätten att ändra innehållet när som helst eller ta bort delar utan att behöva informera dig om detta. Electricity Maps påtar sig inget ansvar för några skador eller kostnader som kan förorsakas till följd av felaktigheter, ofullständigheter, otydligheter eller inaktuell data på Electricity Maps, eller information som härrör från den. Det är inte tillåtet att använda denna hemsida, eller dess individuella element, på andra hemsidor, utan formellt skriftligt förhandsgodkännande.<br><br>Alla immateriella rättigheter tillhör de berättigade ägarna och dess licensgivare. Kopiering, distribution och annan användning av dessa material, i synnerhet energidata, är otillåtet utan skriftligt tillstånd från Electricity Maps, utom och endast i den utsträckning som anges i bestämmelser i obligatorisk lagstiftning (så som rätten att citera), om inget annat anges för specifikt material.<br><br>Denna ansvarsfriskrivning kan uppdateras då och då"
   },
   "zoneShortName": {
-    "AD": { "zoneName": "Andorra" },
-    "AE": { "zoneName": "Förenade Arabemiraten" },
-    "AF": { "zoneName": "Afghanistan" },
-    "AG": { "zoneName": "Antigua och Barbuda" },
-    "AI": { "zoneName": "Anguilla" },
-    "AL": { "zoneName": "Albanien" },
-    "AM": { "zoneName": "Armenien" },
-    "AO": { "zoneName": "Angola" },
-    "AQ": { "zoneName": "Antarktis" },
-    "AR": { "zoneName": "Argentina" },
-    "AS": { "zoneName": "Amerikanska Samoa" },
-    "AT": { "zoneName": "Österrike" },
-    "AUS-NSW": { "countryName": "Australien", "zoneName": "New South Wales" },
-    "AUS-NT": { "countryName": "Australien", "zoneName": "Northern Territory" },
-    "AUS-QLD": { "countryName": "Australien", "zoneName": "Queensland" },
-    "AUS-SA": { "countryName": "Australien", "zoneName": "South Australia" },
-    "AUS-TAS": { "countryName": "Australien", "zoneName": "Tasmanien" },
-    "AUS-TAS-CBI": { "countryName": "Australien", "zoneName": "Cape Barren Island" },
-    "AUS-TAS-KI": { "countryName": "Australien", "zoneName": "King Island" },
-    "AUS-TAS-FI": { "countryName": "Australien", "zoneName": "Flinders Island" },
-    "AUS-VIC": { "countryName": "Australien", "zoneName": "Victoria" },
-    "AUS-WA": { "countryName": "Australien", "zoneName": "Western Australia" },
-    "AUS-WA-RI": { "countryName": "Australien", "zoneName": "Rottnest Island" },
-    "AW": { "zoneName": "Aruba" },
-    "AX": { "zoneName": "Åland" },
-    "AZ": { "zoneName": "Azerbajdzjan" },
-    "BA": { "zoneName": "Bosnien och Hercegovina" },
-    "BB": { "zoneName": "Barbados" },
-    "BD": { "zoneName": "Bangladesh" },
-    "BE": { "zoneName": "Belgien" },
-    "BF": { "zoneName": "Burkina Faso" },
-    "BG": { "zoneName": "Bulgarien" },
-    "BH": { "zoneName": "Bahrain" },
-    "BI": { "zoneName": "Burundi" },
-    "BJ": { "zoneName": "Benin" },
-    "BM": { "zoneName": "Bermuda" },
-    "BN": { "zoneName": "Brunei" },
-    "BO": { "zoneName": "Bolivia" },
-    "BQ": { "zoneName": "Bonaire, Sint Eustatius och Saba" },
-    "BR-CS": { "countryName": "Brasilien", "zoneName": "Centrala Brasilien" },
-    "BR-I": { "countryName": "Brasilien", "zoneName": "Isolerade system" },
-    "BR-N": { "countryName": "Brasilien", "zoneName": "Norra Brasilien" },
-    "BR-NE": { "countryName": "Brasilien", "zoneName": "Nordöstra Brasilien" },
-    "BR-S": { "countryName": "Brasilien", "zoneName": "Södra Brasilien" },
-    "BS": { "zoneName": "Bahamas" },
-    "BT": { "zoneName": "Bhutan" },
-    "BV": { "zoneName": "Bouvetön" },
-    "BW": { "zoneName": "Botswana" },
-    "BY": { "zoneName": "Belarus" },
-    "BZ": { "zoneName": "Belize" },
-    "CA-AB": { "countryName": "Kanada", "zoneName": "Alberta" },
-    "CA-BC": { "countryName": "Kanada", "zoneName": "British Columbia" },
-    "CA-MB": { "countryName": "Kanada", "zoneName": "Manitoba" },
-    "CA-NB": { "countryName": "Kanada", "zoneName": "New Brunswick" },
-    "CA-NL": { "countryName": "Kanada", "zoneName": "Newfoundland och Labrador" },
-    "CA-NL-LB": { "countryName": "Kanada", "zoneName": "Labrador" },
-    "CA-NL-NF": { "countryName": "Kanada", "zoneName": "Newfoundland" },
-    "CA-NS": { "countryName": "Kanada", "zoneName": "Nova Scotia" },
-    "CA-NT": { "countryName": "Kanada", "zoneName": "Northwest Territories" },
-    "CA-NU": { "countryName": "Kanada", "zoneName": "Nunavut" },
-    "CA-ON": { "countryName": "Kanada", "zoneName": "Ontario" },
-    "CA-PE": { "countryName": "Kanada", "zoneName": "Prince Edward Island" },
-    "CA-QC": { "countryName": "Kanada", "zoneName": "Québec" },
-    "CA-SK": { "countryName": "Kanada", "zoneName": "Saskatchewan" },
-    "CA-YT": { "countryName": "Kanada", "zoneName": "Yukon" },
-    "CC": { "zoneName": "Kokosöarna" },
-    "CD": { "zoneName": "Demokratiska republiken Kongo" },
-    "CF": { "zoneName": "Centralafrikanska republiken" },
-    "CG": { "zoneName": "Kongo" },
-    "CH": { "zoneName": "Schweiz" },
-    "CI": { "zoneName": "Elfenbenskusten" },
-    "CK": { "zoneName": "Cooköarna" },
-    "CL-CHP": { "countryName": "Chile", "zoneName": "Påskön" },
-    "CL-SEA": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Aysén" },
-    "CL-SEM": { "countryName": "Chile", "zoneName": "Sistema Eléctrico de Magallanes" },
-    "CL-SEN": { "countryName": "Chile", "zoneName": "Sistema Eléctrico Nacional" },
-    "CM": { "zoneName": "Kamerun" },
-    "CN": { "zoneName": "Kina" },
-    "CO": { "zoneName": "Colombia" },
-    "CR": { "zoneName": "Costa Rica" },
-    "CU": { "zoneName": "Kuba" },
-    "CV": { "zoneName": "Kap Verde" },
-    "CW": { "zoneName": "Curaçao" },
-    "CX": { "zoneName": "Julön" },
-    "CY": { "zoneName": "Cypern" },
-    "CZ": { "zoneName": "Tjeckien" },
-    "DE": { "zoneName": "Tyskland" },
-    "DJ": { "zoneName": "Djibouti" },
-    "DK": { "zoneName": "Danmark" },
-    "DK-DK1": { "countryName": "Danmark", "zoneName": "Västra Danmark" },
-    "DK-DK2": { "countryName": "Danmark", "zoneName": "Östra Danmark" },
-    "DK-BHM": { "countryName": "Danmark", "zoneName": "Bornholm" },
-    "DM": { "zoneName": "Dominica" },
-    "DO": { "zoneName": "Dominikanska republiken" },
-    "DZ": { "zoneName": "Algeriet" },
-    "EC": { "zoneName": "Ecuador" },
-    "EE": { "zoneName": "Estland" },
-    "EG": { "zoneName": "Egypten" },
-    "EH": { "zoneName": "Västsahara" },
-    "ER": { "zoneName": "Eritrea" },
-    "ES": { "zoneName": "Spanien" },
-    "ES-IB-FO": { "countryName": "Spanien", "zoneName": "Formentera" },
-    "ES-IB-IZ": { "countryName": "Spanien", "zoneName": "Ibiza" },
-    "ES-IB-MA": { "countryName": "Spanien", "zoneName": "Mallorca " },
-    "ES-IB-ME": { "countryName": "Spanien", "zoneName": "Menorca" },
-    "ES-CN-FVLZ": { "countryName": "Spanien", "zoneName": "Fuerteventura/Lanzarote" },
-    "ES-CN-GC": { "countryName": "Spanien", "zoneName": "Gran Canaria" },
-    "ES-CN-HI": { "countryName": "Spanien", "zoneName": "El Hierro" },
-    "ES-CN-IG": { "countryName": "Spanien", "zoneName": "La Gomera" },
-    "ES-CN-LP": { "countryName": "Spanien", "zoneName": "La Palma" },
-    "ES-CN-TE": { "countryName": "Spanien", "zoneName": "Teneriffa" },
-    "ET": { "zoneName": "Etiopien" },
-    "FI": { "zoneName": "Finland" },
-    "FJ": { "zoneName": "Fiji" },
-    "FK": { "zoneName": "Falklandsöarna" },
-    "FM": { "zoneName": "Mikronesien" },
-    "FO": { "zoneName": "Färöarna" },
-    "FR": { "zoneName": "Frankrike" },
-    "FR-COR": { "countryName": "Frankrike", "zoneName": "Korsika" },
-    "GA": { "zoneName": "Gabon" },
-    "GB": { "zoneName": "Storbritannien" },
-    "GB-NIR": { "zoneName": "Nordirland" },
-    "GB-ORK": { "countryName": "Storbritannien", "zoneName": "Orkneyöarna" },
-    "GB-SHI": { "countryName": "Storbritannien", "zoneName": "Shetlandsöarna" },
-    "GB-ZET": { "countryName": "Storbritannien", "zoneName": "Shetlandsöarna" },
-    "GD": { "zoneName": "Grenada" },
-    "GE": { "zoneName": "Georgien" },
-    "GF": { "zoneName": "Franska Guyana" },
-    "GG": { "zoneName": "Guernsey" },
-    "GH": { "zoneName": "Ghana" },
-    "GI": { "zoneName": "Gibraltar" },
-    "GL": { "zoneName": "Grönland" },
-    "GM": { "zoneName": "Gambia" },
-    "GN": { "zoneName": "Guinea" },
-    "GP": { "zoneName": "Guadeloupe" },
-    "GQ": { "zoneName": "Ekvatorialguinea" },
-    "GR": { "zoneName": "Grekland" },
-    "GR-IS": { "countryName": "Grekland", "zoneName": "Egeiska öarna" },
-    "GS": { "zoneName": "Sydgeorgien och Sydsandwichöarna" },
-    "GT": { "zoneName": "Guatemala" },
-    "GU": { "zoneName": "Guam" },
-    "GW": { "zoneName": "Guinea-Bissau" },
-    "GY": { "zoneName": "Guyana" },
-    "HK": { "zoneName": "Hongkong" },
-    "HM": { "zoneName": "Heard- och McDonaldöarna" },
-    "HN": { "zoneName": "Honduras" },
-    "HR": { "zoneName": "Kroatien" },
-    "HT": { "zoneName": "Haiti" },
-    "HU": { "zoneName": "Ungern" },
-    "ID": { "zoneName": "Indonesien" },
-    "IE": { "zoneName": "Irland" },
-    "IL": { "zoneName": "Israel" },
-    "IM": { "zoneName": "Isle of Man" },
-    "IN-AN": { "countryName": "Indien", "zoneName": "Andamanerna och Nikobarerna" },
-    "IN-AP": { "countryName": "Indien", "zoneName": "Andhra Pradesh" },
-    "IN-AR": { "countryName": "Indien", "zoneName": "Arunachal Pradesh" },
-    "IN-AS": { "countryName": "Indien", "zoneName": "Assam" },
-    "IN-BR": { "countryName": "Indien", "zoneName": "Bihar" },
-    "IN-CT": { "countryName": "Indien", "zoneName": "Chhattisgarh" },
-    "IN-DL": { "countryName": "Indien", "zoneName": "Delhi" },
-    "IN-DN": { "countryName": "Indien", "zoneName": "Dadra och Nagar Haveli" },
-    "IN-GA": { "countryName": "Indien", "zoneName": "Goa" },
-    "IN-GJ": { "countryName": "Indien", "zoneName": "Gujarat" },
-    "IN-HP": { "countryName": "Indien", "zoneName": "Himachal Pradesh" },
-    "IN-HR": { "countryName": "Indien", "zoneName": "Haryana" },
-    "IN-JH": { "countryName": "Indien", "zoneName": "Jharkhand" },
-    "IN-JK": { "countryName": "Indien", "zoneName": "Jammu och Kashmir" },
-    "IN-KA": { "countryName": "Indien", "zoneName": "Karnataka" },
-    "IN-KL": { "countryName": "Indien", "zoneName": "Kerala" },
-    "IN-MH": { "countryName": "Indien", "zoneName": "Maharashtra" },
-    "IN-ML": { "countryName": "Indien", "zoneName": "Meghalaya" },
-    "IN-MN": { "countryName": "Indien", "zoneName": "Manipur" },
-    "IN-MP": { "countryName": "Indien", "zoneName": "Madhya Pradesh" },
-    "IN-MZ": { "countryName": "Indien", "zoneName": "Mizoram" },
-    "IN-NL": { "countryName": "Indien", "zoneName": "Nagaland" },
-    "IN-OR": { "countryName": "Indien", "zoneName": "Odisha" },
-    "IN-PB": { "countryName": "Indien", "zoneName": "Punjab" },
-    "IN-PY": { "countryName": "Indien", "zoneName": "Pondicherry" },
-    "IN-RJ": { "countryName": "Indien", "zoneName": "Rajasthan" },
-    "IN-SK": { "countryName": "Indien", "zoneName": "Sikkim" },
-    "IN-TN": { "countryName": "Indien", "zoneName": "Tamil Nadu" },
-    "IN-TR": { "countryName": "Indien", "zoneName": "Tripura" },
-    "IN-UP": { "countryName": "Indien", "zoneName": "Uttar Pradesh" },
-    "IN-UT": { "countryName": "Indien", "zoneName": "Uttarakhand" },
-    "IN-WB": { "countryName": "Indien", "zoneName": "Västbengalen" },
-    "IO": { "zoneName": "Brittiska territoriet i Indiska oceanen" },
-    "IQ": { "zoneName": "Irak" },
-    "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
-    "IR": { "zoneName": "Iran" },
-    "IS": { "zoneName": "Island" },
-    "IT": { "zoneName": "Italien" },
-    "IT-CNO": { "countryName": "Italien", "zoneName": "Centrala norra" },
-    "IT-CSO": { "countryName": "Italien", "zoneName": "Centrala södra" },
-    "IT-NO": { "countryName": "Italien", "zoneName": "Norra" },
-    "IT-SAR": { "countryName": "Italien", "zoneName": "Sardinien" },
-    "IT-SIC": { "countryName": "Italien", "zoneName": "Sicilien" },
-    "IT-SO": { "countryName": "Italien", "zoneName": "Södra" },
-    "JE": { "zoneName": "Jersey" },
-    "JM": { "zoneName": "Jamaica" },
-    "JO": { "zoneName": "Jordanien" },
-    "JP-CB": { "countryName": "Japan", "zoneName": "Chūbu" },
-    "JP-CG": { "countryName": "Japan", "zoneName": "Chūgoku" },
-    "JP-HKD": { "countryName": "Japan", "zoneName": "Hokkaidō" },
-    "JP-HR": { "countryName": "Japan", "zoneName": "Hokuriku" },
-    "JP-KN": { "countryName": "Japan", "zoneName": "Kansai" },
-    "JP-KY": { "countryName": "Japan", "zoneName": "Kyūshū" },
-    "JP-ON": { "countryName": "Japan", "zoneName": "Okinawa" },
-    "JP-SK": { "countryName": "Japan", "zoneName": "Shikoku" },
-    "JP-TH": { "countryName": "Japan", "zoneName": "Tōhoku" },
-    "JP-TK": { "countryName": "Japan", "zoneName": "Tōkyō" },
-    "KE": { "zoneName": "Kenya" },
-    "KG": { "zoneName": "Kirgizistan" },
-    "KH": { "zoneName": "Kambodja" },
-    "KI": { "zoneName": "Kiribati" },
-    "KM": { "zoneName": "Komorerna" },
-    "KN": { "zoneName": "Saint Kitts och Nevis" },
-    "KP": { "zoneName": "Nordkorea" },
-    "KR": { "zoneName": "Sydkorea" },
-    "KW": { "zoneName": "Kuwait" },
-    "KY": { "zoneName": "Caymanöarna" },
-    "KZ": { "zoneName": "Kazakstan" },
-    "LA": { "zoneName": "Laos" },
-    "LB": { "zoneName": "Libanon" },
-    "LC": { "zoneName": "Saint Lucia" },
-    "LI": { "zoneName": "Liechtenstein" },
-    "LK": { "zoneName": "Sri Lanka" },
-    "LR": { "zoneName": "Liberia" },
-    "LS": { "zoneName": "Lesotho" },
-    "LT": { "zoneName": "Litauen" },
-    "LU": { "zoneName": "Luxemburg" },
-    "LV": { "zoneName": "Lettland" },
-    "LY": { "zoneName": "Libyen" },
-    "MA": { "zoneName": "Marocko" },
-    "MC": { "zoneName": "Monaco" },
-    "MD": { "zoneName": "Moldavien" },
-    "ME": { "zoneName": "Montenegro" },
-    "MF": { "countryName": "Saint-Martin", "zoneName": "Franska" },
-    "MG": { "zoneName": "Madagaskar" },
-    "MH": { "zoneName": "Marshallöarna" },
-    "MK": { "zoneName": "Nordmakedonien" },
-    "ML": { "zoneName": "Mali" },
-    "MM": { "zoneName": "Burma" },
-    "MN": { "zoneName": "Mongoliet" },
-    "MO": { "zoneName": "Macao" },
-    "MP": { "zoneName": "Nordmarianerna" },
-    "MQ": { "zoneName": "Martinique" },
-    "MR": { "zoneName": "Mauretanien" },
-    "MS": { "zoneName": "Montserrat" },
-    "MT": { "zoneName": "Malta" },
-    "MU": { "zoneName": "Mauritius" },
-    "MV": { "zoneName": "Maldiverna" },
-    "MW": { "zoneName": "Malawi" },
-    "MX": { "zoneName": "Mexiko" },
-    "MX-BC": { "countryName": "Mexiko", "zoneName": "Baja California" },
-    "MX-CE": { "countryName": "Mexiko", "zoneName": "Centrala" },
-    "MX-NE": { "countryName": "Mexiko", "zoneName": "Nordöstra" },
-    "MX-NO": { "countryName": "Mexiko", "zoneName": "Norra" },
-    "MX-NW": { "countryName": "Mexiko", "zoneName": "Nordvästra" },
-    "MX-OC": { "countryName": "Mexiko", "zoneName": "Occidental" },
-    "MX-OR": { "countryName": "Mexiko", "zoneName": "Oriental" },
-    "MX-PN": { "countryName": "Mexico", "zoneName": "Peninsula" },
-    "MY-EM": { "countryName": "Malaysia", "zoneName": "Borneo" },
-    "MY-WM": { "countryName": "Malaysia", "zoneName": "Västmalaysia" },
-    "MZ": { "zoneName": "Moçambique" },
-    "NA": { "zoneName": "Namibia" },
-    "NC": { "zoneName": "Nya Kaledonien" },
-    "NE": { "zoneName": "Niger" },
-    "NF": { "zoneName": "Norfolkön" },
-    "NG": { "zoneName": "Nigeria" },
-    "NI": { "zoneName": "Nicaragua" },
-    "NKR": { "zoneName": "Nagorno-Karabach" },
-    "NL": { "zoneName": "Nederländerna" },
-    "NO-NO1": { "countryName": "Norge", "zoneName": "Sydöstra Norge" },
-    "NO-NO2": { "countryName": "Norge", "zoneName": "Sydvästra Norge" },
-    "NO-NO3": { "countryName": "Norge", "zoneName": "Mellersta Norge" },
-    "NO-NO4": { "countryName": "Norge", "zoneName": "Norra Norge" },
-    "NO-NO5": { "countryName": "Norge", "zoneName": "Västra Norge" },
-    "NP": { "zoneName": "Nepal" },
-    "NR": { "zoneName": "Nauru" },
-    "NU": { "zoneName": "Niue" },
-    "NZ": { "zoneName": "Nya Zeeland" },
-    "NZ-NZA": { "countryName": "Nya Zeeland", "zoneName": "Aucklandöarna" },
-    "NZ-NZC": { "countryName": "Nya Zeeland", "zoneName": "Chathamöarna" },
-    "NZ-NZST": { "countryName": "Nya Zeeland", "zoneName": "Stewart Island" },
-    "OM": { "zoneName": "Oman" },
-    "PA": { "zoneName": "Panama" },
-    "PE": { "zoneName": "Peru" },
-    "PF": { "zoneName": "Franska Polynesien" },
-    "PG": { "zoneName": "Papua Nya Guinea" },
-    "PH": { "zoneName": "Filippinerna" },
-    "PK": { "zoneName": "Pakistan" },
-    "PL": { "zoneName": "Polen" },
-    "PM": { "zoneName": "Saint-Pierre och Miquelon" },
-    "PN": { "zoneName": "Pitcairnöarna" },
-    "PR": { "zoneName": "Puerto Rico" },
-    "PS": { "zoneName": "Staten Palestina" },
-    "PT": { "zoneName": "Portugal" },
-    "PT-AC": { "countryName": "Portugal", "zoneName": "Azorerna" },
-    "PT-MA": { "countryName": "Portugal", "zoneName": "Madeira" },
-    "PW": { "zoneName": "Palau" },
-    "PY": { "zoneName": "Paraguay" },
-    "QA": { "zoneName": "Qatar" },
-    "RE": { "zoneName": "Réunion" },
-    "RO": { "zoneName": "Rumänien" },
-    "RS": { "zoneName": "Serbien" },
-    "RU": { "zoneName": "Ryssland" },
-    "RU-1": { "countryName": "Ryssland", "zoneName": "Europa-Ural" },
-    "RU-2": { "countryName": "Ryssland", "zoneName": "Sibirien" },
-    "RU-AS": { "countryName": "Ryssland", "zoneName": "Öst" },
-    "RU-EU": { "countryName": "Ryssland", "zoneName": "Arktis" },
-    "RU-FE": { "countryName": "Russia", "zoneName": "Fjärran östern" },
-    "RU-KGD": { "countryName": "Ryssland", "zoneName": "Kaliningrad" },
-    "RW": { "zoneName": "Rwanda" },
-    "SA": { "zoneName": "Saudiarabien" },
-    "SB": { "zoneName": "Salomonöarna" },
-    "SC": { "zoneName": "Seychellerna" },
-    "SD": { "zoneName": "Sudan" },
-    "SE": { "zoneName": "Sverige" },
-    "SG": { "zoneName": "Singapore" },
-    "SH": { "zoneName": "Sankta Helena, Ascension och Tristan da Cunha" },
-    "SI": { "zoneName": "Slovenien" },
-    "SJ": { "zoneName": "Svalbard och Jan Mayen" },
-    "SK": { "zoneName": "Slovakien" },
-    "SL": { "zoneName": "Sierra Leone" },
-    "SM": { "zoneName": "San Marino" },
-    "SN": { "zoneName": "Senegal" },
-    "SO": { "zoneName": "Somalia" },
-    "SR": { "zoneName": "Surinam" },
-    "SS": { "zoneName": "Sydsudan" },
-    "ST": { "zoneName": "São Tomé och Príncipe" },
-    "SV": { "zoneName": "El Salvador" },
-    "SX": { "countryName": "Sint Maarten", "zoneName": "Nederländerna" },
-    "SY": { "zoneName": "Syrien" },
-    "SZ": { "zoneName": "Swaziland" },
-    "TC": { "zoneName": "Turks- och Caicosöarna" },
-    "TD": { "zoneName": "Tchad" },
-    "TF": { "zoneName": "Franska sydterritorierna" },
-    "TG": { "zoneName": "Togo" },
-    "TH": { "zoneName": "Thailand" },
-    "TJ": { "zoneName": "Tadzjikistan" },
-    "TK": { "zoneName": "Tokelau" },
-    "TL": { "zoneName": "Östtimor" },
-    "TM": { "zoneName": "Turkmenistan" },
-    "TN": { "zoneName": "Tunisien" },
-    "TO": { "zoneName": "Tonga" },
-    "TR": { "zoneName": "Turkiet" },
-    "TT": { "zoneName": "Trinidad och Tobago" },
-    "TV": { "zoneName": "Tuvalu" },
-    "TW": { "zoneName": "Taiwan" },
-    "TZ": { "zoneName": "Tanzania" },
-    "UA": { "zoneName": "Ukraina" },
-    "UA-CR": { "countryName": "Ukraina", "zoneName": "Krim" },
-    "UG": { "zoneName": "Uganda" },
-    "UM": { "zoneName": "Förenta staternas mindre öar i Oceanien och Västindien" },
-    "US-HI-HA": { "countryName": "USA", "zoneName": "Hawaii" },
-    "US-HI-KA": { "countryName": "USA", "zoneName": "Kauai" },
-    "US-HI-KH": { "countryName": "USA", "zoneName": "Kahoolawe" },
-    "US-HI-LA": { "countryName": "USA", "zoneName": "Lanai" },
-    "US-HI-MA": { "countryName": "USA", "zoneName": "Maui" },
-    "US-HI-MO": { "countryName": "USA", "zoneName": "Molokai" },
-    "US-HI-NI": { "countryName": "USA", "zoneName": "Niihau" },
-    "US-HI-OA": { "countryName": "USA", "zoneName": "Oahu" },
-    "US-CAL-BANC": { "countryName": "USA", "zoneName": "Balancing Authority Of Northern California" },
-    "US-CAL-CISO": { "countryName": "USA", "zoneName": "California Independent System Operator" },
-    "US-CAL-IID": { "countryName": "USA", "zoneName": "Imperial Irrigation District" },
-    "US-CAL-LDWP": { "countryName": "USA", "zoneName": "Los Angeles Department Of Water And Power" },
-    "US-CAL-TIDC": { "countryName": "USA", "zoneName": "Turlock Irrigation District" },
-    "US-CAR-CPLE": { "countryName": "USA", "zoneName": "Duke Energy Progress East" },
-    "US-CAR-CPLW": { "countryName": "USA", "zoneName": "Duke Energy Progress West" },
-    "US-CAR-DUK": { "countryName": "USA", "zoneName": "Duke Energy Carolinas" },
-    "US-CAR-SC": { "countryName": "USA", "zoneName": "South Carolina Public Service Authority" },
-    "US-CAR-SCEG": { "countryName": "USA", "zoneName": "South Carolina Electric & Gas Company" },
-    "US-CAR-YAD": { "countryName": "USA", "zoneName": "Alcoa Power Generating, Inc. Yadkin Division" },
-    "US-CENT-SPA": { "countryName": "USA", "zoneName": "Southwestern Power Administration" },
-    "US-CENT-SWPP": { "countryName": "USA", "zoneName": "Southwest Power Pool" },
-    "US-FLA-FMPP": { "countryName": "USA", "zoneName": "Florida Municipal Power Pool" },
-    "US-FLA-FPC": { "countryName": "USA", "zoneName": "Duke Energy Florida Inc" },
-    "US-FLA-FPL": { "countryName": "USA", "zoneName": "Florida Power & Light Company" },
-    "US-FLA-GVL": { "countryName": "USA", "zoneName": "Gainesville Regional Utilities" },
-    "US-FLA-HST": { "countryName": "USA", "zoneName": "City Of Homestead" },
-    "US-FLA-JEA": { "countryName": "USA", "zoneName": "Jacksonville Electric Authority" },
-    "US-FLA-NSB": { "countryName": "USA", "zoneName": "Utilities Commission Of New Smyrna Beach" },
-    "US-FLA-SEC": { "countryName": "USA", "zoneName": "Seminole Electric Cooperative" },
-    "US-FLA-TAL": { "countryName": "USA", "zoneName": "City Of Tallahassee" },
-    "US-FLA-TEC": { "countryName": "USA", "zoneName": "Tampa Electric Company" },
-    "US-MIDA-PJM": { "countryName": "USA", "zoneName": "PJM Interconnection, Llc" },
-    "US-MIDW-AECI": { "countryName": "USA", "zoneName": "Associated Electric Cooperative, Inc." },
-    "US-MIDW-GLHB": { "countryName": "USA", "zoneName": "GridLiance" },
+    "AD": {
+      "zoneName": "Andorra"
+    },
+    "AE": {
+      "zoneName": "Förenade Arabemiraten"
+    },
+    "AF": {
+      "zoneName": "Afghanistan"
+    },
+    "AG": {
+      "zoneName": "Antigua och Barbuda"
+    },
+    "AI": {
+      "zoneName": "Anguilla"
+    },
+    "AL": {
+      "zoneName": "Albanien"
+    },
+    "AM": {
+      "zoneName": "Armenien"
+    },
+    "AO": {
+      "zoneName": "Angola"
+    },
+    "AQ": {
+      "zoneName": "Antarktis"
+    },
+    "AR": {
+      "zoneName": "Argentina"
+    },
+    "AS": {
+      "zoneName": "Amerikanska Samoa"
+    },
+    "AT": {
+      "zoneName": "Österrike"
+    },
+    "AUS-NSW": {
+      "countryName": "Australien",
+      "zoneName": "New South Wales"
+    },
+    "AUS-NT": {
+      "countryName": "Australien",
+      "zoneName": "Northern Territory"
+    },
+    "AUS-QLD": {
+      "countryName": "Australien",
+      "zoneName": "Queensland"
+    },
+    "AUS-SA": {
+      "countryName": "Australien",
+      "zoneName": "South Australia"
+    },
+    "AUS-TAS": {
+      "countryName": "Australien",
+      "zoneName": "Tasmanien"
+    },
+    "AUS-TAS-CBI": {
+      "countryName": "Australien",
+      "zoneName": "Cape Barren Island"
+    },
+    "AUS-TAS-KI": {
+      "countryName": "Australien",
+      "zoneName": "King Island"
+    },
+    "AUS-TAS-FI": {
+      "countryName": "Australien",
+      "zoneName": "Flinders Island"
+    },
+    "AUS-VIC": {
+      "countryName": "Australien",
+      "zoneName": "Victoria"
+    },
+    "AUS-WA": {
+      "countryName": "Australien",
+      "zoneName": "Western Australia"
+    },
+    "AUS-WA-RI": {
+      "countryName": "Australien",
+      "zoneName": "Rottnest Island"
+    },
+    "AW": {
+      "zoneName": "Aruba"
+    },
+    "AX": {
+      "zoneName": "Åland"
+    },
+    "AZ": {
+      "zoneName": "Azerbajdzjan"
+    },
+    "BA": {
+      "zoneName": "Bosnien och Hercegovina"
+    },
+    "BB": {
+      "zoneName": "Barbados"
+    },
+    "BD": {
+      "zoneName": "Bangladesh"
+    },
+    "BE": {
+      "zoneName": "Belgien"
+    },
+    "BF": {
+      "zoneName": "Burkina Faso"
+    },
+    "BG": {
+      "zoneName": "Bulgarien"
+    },
+    "BH": {
+      "zoneName": "Bahrain"
+    },
+    "BI": {
+      "zoneName": "Burundi"
+    },
+    "BJ": {
+      "zoneName": "Benin"
+    },
+    "BM": {
+      "zoneName": "Bermuda"
+    },
+    "BN": {
+      "zoneName": "Brunei"
+    },
+    "BO": {
+      "zoneName": "Bolivia"
+    },
+    "BQ": {
+      "zoneName": "Bonaire, Sint Eustatius och Saba"
+    },
+    "BR-CS": {
+      "countryName": "Brasilien",
+      "zoneName": "Centrala Brasilien"
+    },
+    "BR-I": {
+      "countryName": "Brasilien",
+      "zoneName": "Isolerade system"
+    },
+    "BR-N": {
+      "countryName": "Brasilien",
+      "zoneName": "Norra Brasilien"
+    },
+    "BR-NE": {
+      "countryName": "Brasilien",
+      "zoneName": "Nordöstra Brasilien"
+    },
+    "BR-S": {
+      "countryName": "Brasilien",
+      "zoneName": "Södra Brasilien"
+    },
+    "BS": {
+      "zoneName": "Bahamas"
+    },
+    "BT": {
+      "zoneName": "Bhutan"
+    },
+    "BV": {
+      "zoneName": "Bouvetön"
+    },
+    "BW": {
+      "zoneName": "Botswana"
+    },
+    "BY": {
+      "zoneName": "Belarus"
+    },
+    "BZ": {
+      "zoneName": "Belize"
+    },
+    "CA-AB": {
+      "countryName": "Kanada",
+      "zoneName": "Alberta"
+    },
+    "CA-BC": {
+      "countryName": "Kanada",
+      "zoneName": "British Columbia"
+    },
+    "CA-MB": {
+      "countryName": "Kanada",
+      "zoneName": "Manitoba"
+    },
+    "CA-NB": {
+      "countryName": "Kanada",
+      "zoneName": "New Brunswick"
+    },
+    "CA-NL": {
+      "countryName": "Kanada",
+      "zoneName": "Newfoundland och Labrador"
+    },
+    "CA-NL-LB": {
+      "countryName": "Kanada",
+      "zoneName": "Labrador"
+    },
+    "CA-NL-NF": {
+      "countryName": "Kanada",
+      "zoneName": "Newfoundland"
+    },
+    "CA-NS": {
+      "countryName": "Kanada",
+      "zoneName": "Nova Scotia"
+    },
+    "CA-NT": {
+      "countryName": "Kanada",
+      "zoneName": "Northwest Territories"
+    },
+    "CA-NU": {
+      "countryName": "Kanada",
+      "zoneName": "Nunavut"
+    },
+    "CA-ON": {
+      "countryName": "Kanada",
+      "zoneName": "Ontario"
+    },
+    "CA-PE": {
+      "countryName": "Kanada",
+      "zoneName": "Prince Edward Island"
+    },
+    "CA-QC": {
+      "countryName": "Kanada",
+      "zoneName": "Québec"
+    },
+    "CA-SK": {
+      "countryName": "Kanada",
+      "zoneName": "Saskatchewan"
+    },
+    "CA-YT": {
+      "countryName": "Kanada",
+      "zoneName": "Yukon"
+    },
+    "CC": {
+      "zoneName": "Kokosöarna"
+    },
+    "CD": {
+      "zoneName": "Demokratiska republiken Kongo"
+    },
+    "CF": {
+      "zoneName": "Centralafrikanska republiken"
+    },
+    "CG": {
+      "zoneName": "Kongo"
+    },
+    "CH": {
+      "zoneName": "Schweiz"
+    },
+    "CI": {
+      "zoneName": "Elfenbenskusten"
+    },
+    "CK": {
+      "zoneName": "Cooköarna"
+    },
+    "CL-CHP": {
+      "countryName": "Chile",
+      "zoneName": "Påskön"
+    },
+    "CL-SEA": {
+      "countryName": "Chile",
+      "zoneName": "Sistema Eléctrico de Aysén"
+    },
+    "CL-SEM": {
+      "countryName": "Chile",
+      "zoneName": "Sistema Eléctrico de Magallanes"
+    },
+    "CL-SEN": {
+      "countryName": "Chile",
+      "zoneName": "Sistema Eléctrico Nacional"
+    },
+    "CM": {
+      "zoneName": "Kamerun"
+    },
+    "CN": {
+      "zoneName": "Kina"
+    },
+    "CO": {
+      "zoneName": "Colombia"
+    },
+    "CR": {
+      "zoneName": "Costa Rica"
+    },
+    "CU": {
+      "zoneName": "Kuba"
+    },
+    "CV": {
+      "zoneName": "Kap Verde"
+    },
+    "CW": {
+      "zoneName": "Curaçao"
+    },
+    "CX": {
+      "zoneName": "Julön"
+    },
+    "CY": {
+      "zoneName": "Cypern"
+    },
+    "CZ": {
+      "zoneName": "Tjeckien"
+    },
+    "DE": {
+      "zoneName": "Tyskland"
+    },
+    "DJ": {
+      "zoneName": "Djibouti"
+    },
+    "DK": {
+      "zoneName": "Danmark"
+    },
+    "DK-DK1": {
+      "countryName": "Danmark",
+      "zoneName": "Västra Danmark"
+    },
+    "DK-DK2": {
+      "countryName": "Danmark",
+      "zoneName": "Östra Danmark"
+    },
+    "DK-BHM": {
+      "countryName": "Danmark",
+      "zoneName": "Bornholm"
+    },
+    "DM": {
+      "zoneName": "Dominica"
+    },
+    "DO": {
+      "zoneName": "Dominikanska republiken"
+    },
+    "DZ": {
+      "zoneName": "Algeriet"
+    },
+    "EC": {
+      "zoneName": "Ecuador"
+    },
+    "EE": {
+      "zoneName": "Estland"
+    },
+    "EG": {
+      "zoneName": "Egypten"
+    },
+    "EH": {
+      "zoneName": "Västsahara"
+    },
+    "ER": {
+      "zoneName": "Eritrea"
+    },
+    "ES": {
+      "zoneName": "Spanien"
+    },
+    "ES-IB-FO": {
+      "countryName": "Spanien",
+      "zoneName": "Formentera"
+    },
+    "ES-IB-IZ": {
+      "countryName": "Spanien",
+      "zoneName": "Ibiza"
+    },
+    "ES-IB-MA": {
+      "countryName": "Spanien",
+      "zoneName": "Mallorca "
+    },
+    "ES-IB-ME": {
+      "countryName": "Spanien",
+      "zoneName": "Menorca"
+    },
+    "ES-CN-FVLZ": {
+      "countryName": "Spanien",
+      "zoneName": "Fuerteventura/Lanzarote"
+    },
+    "ES-CN-GC": {
+      "countryName": "Spanien",
+      "zoneName": "Gran Canaria"
+    },
+    "ES-CN-HI": {
+      "countryName": "Spanien",
+      "zoneName": "El Hierro"
+    },
+    "ES-CN-IG": {
+      "countryName": "Spanien",
+      "zoneName": "La Gomera"
+    },
+    "ES-CN-LP": {
+      "countryName": "Spanien",
+      "zoneName": "La Palma"
+    },
+    "ES-CN-TE": {
+      "countryName": "Spanien",
+      "zoneName": "Teneriffa"
+    },
+    "ET": {
+      "zoneName": "Etiopien"
+    },
+    "FI": {
+      "zoneName": "Finland"
+    },
+    "FJ": {
+      "zoneName": "Fiji"
+    },
+    "FK": {
+      "zoneName": "Falklandsöarna"
+    },
+    "FM": {
+      "zoneName": "Mikronesien"
+    },
+    "FO": {
+      "zoneName": "Färöarna"
+    },
+    "FR": {
+      "zoneName": "Frankrike"
+    },
+    "FR-COR": {
+      "countryName": "Frankrike",
+      "zoneName": "Korsika"
+    },
+    "GA": {
+      "zoneName": "Gabon"
+    },
+    "GB": {
+      "zoneName": "Storbritannien"
+    },
+    "GB-NIR": {
+      "zoneName": "Nordirland"
+    },
+    "GB-ORK": {
+      "countryName": "Storbritannien",
+      "zoneName": "Orkneyöarna"
+    },
+    "GB-SHI": {
+      "countryName": "Storbritannien",
+      "zoneName": "Shetlandsöarna"
+    },
+    "GB-ZET": {
+      "countryName": "Storbritannien",
+      "zoneName": "Shetlandsöarna"
+    },
+    "GD": {
+      "zoneName": "Grenada"
+    },
+    "GE": {
+      "zoneName": "Georgien"
+    },
+    "GF": {
+      "zoneName": "Franska Guyana"
+    },
+    "GG": {
+      "zoneName": "Guernsey"
+    },
+    "GH": {
+      "zoneName": "Ghana"
+    },
+    "GI": {
+      "zoneName": "Gibraltar"
+    },
+    "GL": {
+      "zoneName": "Grönland"
+    },
+    "GM": {
+      "zoneName": "Gambia"
+    },
+    "GN": {
+      "zoneName": "Guinea"
+    },
+    "GP": {
+      "zoneName": "Guadeloupe"
+    },
+    "GQ": {
+      "zoneName": "Ekvatorialguinea"
+    },
+    "GR": {
+      "zoneName": "Grekland"
+    },
+    "GR-IS": {
+      "countryName": "Grekland",
+      "zoneName": "Egeiska öarna"
+    },
+    "GS": {
+      "zoneName": "Sydgeorgien och Sydsandwichöarna"
+    },
+    "GT": {
+      "zoneName": "Guatemala"
+    },
+    "GU": {
+      "zoneName": "Guam"
+    },
+    "GW": {
+      "zoneName": "Guinea-Bissau"
+    },
+    "GY": {
+      "zoneName": "Guyana"
+    },
+    "HK": {
+      "zoneName": "Hongkong"
+    },
+    "HM": {
+      "zoneName": "Heard- och McDonaldöarna"
+    },
+    "HN": {
+      "zoneName": "Honduras"
+    },
+    "HR": {
+      "zoneName": "Kroatien"
+    },
+    "HT": {
+      "zoneName": "Haiti"
+    },
+    "HU": {
+      "zoneName": "Ungern"
+    },
+    "ID": {
+      "zoneName": "Indonesien"
+    },
+    "IE": {
+      "zoneName": "Irland"
+    },
+    "IL": {
+      "zoneName": "Israel"
+    },
+    "IM": {
+      "zoneName": "Isle of Man"
+    },
+    "IN-AN": {
+      "countryName": "Indien",
+      "zoneName": "Andamanerna och Nikobarerna"
+    },
+    "IN-AP": {
+      "countryName": "Indien",
+      "zoneName": "Andhra Pradesh"
+    },
+    "IN-AR": {
+      "countryName": "Indien",
+      "zoneName": "Arunachal Pradesh"
+    },
+    "IN-AS": {
+      "countryName": "Indien",
+      "zoneName": "Assam"
+    },
+    "IN-BR": {
+      "countryName": "Indien",
+      "zoneName": "Bihar"
+    },
+    "IN-CT": {
+      "countryName": "Indien",
+      "zoneName": "Chhattisgarh"
+    },
+    "IN-DL": {
+      "countryName": "Indien",
+      "zoneName": "Delhi"
+    },
+    "IN-DN": {
+      "countryName": "Indien",
+      "zoneName": "Dadra och Nagar Haveli"
+    },
+    "IN-GA": {
+      "countryName": "Indien",
+      "zoneName": "Goa"
+    },
+    "IN-GJ": {
+      "countryName": "Indien",
+      "zoneName": "Gujarat"
+    },
+    "IN-HP": {
+      "countryName": "Indien",
+      "zoneName": "Himachal Pradesh"
+    },
+    "IN-HR": {
+      "countryName": "Indien",
+      "zoneName": "Haryana"
+    },
+    "IN-JH": {
+      "countryName": "Indien",
+      "zoneName": "Jharkhand"
+    },
+    "IN-JK": {
+      "countryName": "Indien",
+      "zoneName": "Jammu och Kashmir"
+    },
+    "IN-KA": {
+      "countryName": "Indien",
+      "zoneName": "Karnataka"
+    },
+    "IN-KL": {
+      "countryName": "Indien",
+      "zoneName": "Kerala"
+    },
+    "IN-MH": {
+      "countryName": "Indien",
+      "zoneName": "Maharashtra"
+    },
+    "IN-ML": {
+      "countryName": "Indien",
+      "zoneName": "Meghalaya"
+    },
+    "IN-MN": {
+      "countryName": "Indien",
+      "zoneName": "Manipur"
+    },
+    "IN-MP": {
+      "countryName": "Indien",
+      "zoneName": "Madhya Pradesh"
+    },
+    "IN-MZ": {
+      "countryName": "Indien",
+      "zoneName": "Mizoram"
+    },
+    "IN-NL": {
+      "countryName": "Indien",
+      "zoneName": "Nagaland"
+    },
+    "IN-OR": {
+      "countryName": "Indien",
+      "zoneName": "Odisha"
+    },
+    "IN-PB": {
+      "countryName": "Indien",
+      "zoneName": "Punjab"
+    },
+    "IN-PY": {
+      "countryName": "Indien",
+      "zoneName": "Pondicherry"
+    },
+    "IN-RJ": {
+      "countryName": "Indien",
+      "zoneName": "Rajasthan"
+    },
+    "IN-SK": {
+      "countryName": "Indien",
+      "zoneName": "Sikkim"
+    },
+    "IN-TN": {
+      "countryName": "Indien",
+      "zoneName": "Tamil Nadu"
+    },
+    "IN-TR": {
+      "countryName": "Indien",
+      "zoneName": "Tripura"
+    },
+    "IN-UP": {
+      "countryName": "Indien",
+      "zoneName": "Uttar Pradesh"
+    },
+    "IN-UT": {
+      "countryName": "Indien",
+      "zoneName": "Uttarakhand"
+    },
+    "IN-WB": {
+      "countryName": "Indien",
+      "zoneName": "Västbengalen"
+    },
+    "IO": {
+      "zoneName": "Brittiska territoriet i Indiska oceanen"
+    },
+    "IQ": {
+      "zoneName": "Irak"
+    },
+    "IQ-KUR": {
+      "countryName": "Irak",
+      "zoneName": "Kurdistan"
+    },
+    "IR": {
+      "zoneName": "Iran"
+    },
+    "IS": {
+      "zoneName": "Island"
+    },
+    "IT": {
+      "zoneName": "Italien"
+    },
+    "IT-CNO": {
+      "countryName": "Italien",
+      "zoneName": "Centrala norra"
+    },
+    "IT-CSO": {
+      "countryName": "Italien",
+      "zoneName": "Centrala södra"
+    },
+    "IT-NO": {
+      "countryName": "Italien",
+      "zoneName": "Norra"
+    },
+    "IT-SAR": {
+      "countryName": "Italien",
+      "zoneName": "Sardinien"
+    },
+    "IT-SIC": {
+      "countryName": "Italien",
+      "zoneName": "Sicilien"
+    },
+    "IT-SO": {
+      "countryName": "Italien",
+      "zoneName": "Södra"
+    },
+    "JE": {
+      "zoneName": "Jersey"
+    },
+    "JM": {
+      "zoneName": "Jamaica"
+    },
+    "JO": {
+      "zoneName": "Jordanien"
+    },
+    "JP-CB": {
+      "countryName": "Japan",
+      "zoneName": "Chūbu"
+    },
+    "JP-CG": {
+      "countryName": "Japan",
+      "zoneName": "Chūgoku"
+    },
+    "JP-HKD": {
+      "countryName": "Japan",
+      "zoneName": "Hokkaidō"
+    },
+    "JP-HR": {
+      "countryName": "Japan",
+      "zoneName": "Hokuriku"
+    },
+    "JP-KN": {
+      "countryName": "Japan",
+      "zoneName": "Kansai"
+    },
+    "JP-KY": {
+      "countryName": "Japan",
+      "zoneName": "Kyūshū"
+    },
+    "JP-ON": {
+      "countryName": "Japan",
+      "zoneName": "Okinawa"
+    },
+    "JP-SK": {
+      "countryName": "Japan",
+      "zoneName": "Shikoku"
+    },
+    "JP-TH": {
+      "countryName": "Japan",
+      "zoneName": "Tōhoku"
+    },
+    "JP-TK": {
+      "countryName": "Japan",
+      "zoneName": "Tōkyō"
+    },
+    "KE": {
+      "zoneName": "Kenya"
+    },
+    "KG": {
+      "zoneName": "Kirgizistan"
+    },
+    "KH": {
+      "zoneName": "Kambodja"
+    },
+    "KI": {
+      "zoneName": "Kiribati"
+    },
+    "KM": {
+      "zoneName": "Komorerna"
+    },
+    "KN": {
+      "zoneName": "Saint Kitts och Nevis"
+    },
+    "KP": {
+      "zoneName": "Nordkorea"
+    },
+    "KR": {
+      "zoneName": "Sydkorea"
+    },
+    "KW": {
+      "zoneName": "Kuwait"
+    },
+    "KY": {
+      "zoneName": "Caymanöarna"
+    },
+    "KZ": {
+      "zoneName": "Kazakstan"
+    },
+    "LA": {
+      "zoneName": "Laos"
+    },
+    "LB": {
+      "zoneName": "Libanon"
+    },
+    "LC": {
+      "zoneName": "Saint Lucia"
+    },
+    "LI": {
+      "zoneName": "Liechtenstein"
+    },
+    "LK": {
+      "zoneName": "Sri Lanka"
+    },
+    "LR": {
+      "zoneName": "Liberia"
+    },
+    "LS": {
+      "zoneName": "Lesotho"
+    },
+    "LT": {
+      "zoneName": "Litauen"
+    },
+    "LU": {
+      "zoneName": "Luxemburg"
+    },
+    "LV": {
+      "zoneName": "Lettland"
+    },
+    "LY": {
+      "zoneName": "Libyen"
+    },
+    "MA": {
+      "zoneName": "Marocko"
+    },
+    "MC": {
+      "zoneName": "Monaco"
+    },
+    "MD": {
+      "zoneName": "Moldavien"
+    },
+    "ME": {
+      "zoneName": "Montenegro"
+    },
+    "MF": {
+      "countryName": "Saint-Martin",
+      "zoneName": "Franska"
+    },
+    "MG": {
+      "zoneName": "Madagaskar"
+    },
+    "MH": {
+      "zoneName": "Marshallöarna"
+    },
+    "MK": {
+      "zoneName": "Nordmakedonien"
+    },
+    "ML": {
+      "zoneName": "Mali"
+    },
+    "MM": {
+      "zoneName": "Burma"
+    },
+    "MN": {
+      "zoneName": "Mongoliet"
+    },
+    "MO": {
+      "zoneName": "Macao"
+    },
+    "MP": {
+      "zoneName": "Nordmarianerna"
+    },
+    "MQ": {
+      "zoneName": "Martinique"
+    },
+    "MR": {
+      "zoneName": "Mauretanien"
+    },
+    "MS": {
+      "zoneName": "Montserrat"
+    },
+    "MT": {
+      "zoneName": "Malta"
+    },
+    "MU": {
+      "zoneName": "Mauritius"
+    },
+    "MV": {
+      "zoneName": "Maldiverna"
+    },
+    "MW": {
+      "zoneName": "Malawi"
+    },
+    "MX": {
+      "zoneName": "Mexiko"
+    },
+    "MX-BC": {
+      "countryName": "Mexiko",
+      "zoneName": "Baja California"
+    },
+    "MX-CE": {
+      "countryName": "Mexiko",
+      "zoneName": "Centrala"
+    },
+    "MX-NE": {
+      "countryName": "Mexiko",
+      "zoneName": "Nordöstra"
+    },
+    "MX-NO": {
+      "countryName": "Mexiko",
+      "zoneName": "Norra"
+    },
+    "MX-NW": {
+      "countryName": "Mexiko",
+      "zoneName": "Nordvästra"
+    },
+    "MX-OC": {
+      "countryName": "Mexiko",
+      "zoneName": "Occidental"
+    },
+    "MX-OR": {
+      "countryName": "Mexiko",
+      "zoneName": "Oriental"
+    },
+    "MX-PN": {
+      "countryName": "Mexico",
+      "zoneName": "Peninsula"
+    },
+    "MY-EM": {
+      "countryName": "Malaysia",
+      "zoneName": "Borneo"
+    },
+    "MY-WM": {
+      "countryName": "Malaysia",
+      "zoneName": "Västmalaysia"
+    },
+    "MZ": {
+      "zoneName": "Moçambique"
+    },
+    "NA": {
+      "zoneName": "Namibia"
+    },
+    "NC": {
+      "zoneName": "Nya Kaledonien"
+    },
+    "NE": {
+      "zoneName": "Niger"
+    },
+    "NF": {
+      "zoneName": "Norfolkön"
+    },
+    "NG": {
+      "zoneName": "Nigeria"
+    },
+    "NI": {
+      "zoneName": "Nicaragua"
+    },
+    "NKR": {
+      "zoneName": "Nagorno-Karabach"
+    },
+    "NL": {
+      "zoneName": "Nederländerna"
+    },
+    "NO-NO1": {
+      "countryName": "Norge",
+      "zoneName": "Sydöstra Norge"
+    },
+    "NO-NO2": {
+      "countryName": "Norge",
+      "zoneName": "Sydvästra Norge"
+    },
+    "NO-NO3": {
+      "countryName": "Norge",
+      "zoneName": "Mellersta Norge"
+    },
+    "NO-NO4": {
+      "countryName": "Norge",
+      "zoneName": "Norra Norge"
+    },
+    "NO-NO5": {
+      "countryName": "Norge",
+      "zoneName": "Västra Norge"
+    },
+    "NP": {
+      "zoneName": "Nepal"
+    },
+    "NR": {
+      "zoneName": "Nauru"
+    },
+    "NU": {
+      "zoneName": "Niue"
+    },
+    "NZ": {
+      "zoneName": "Nya Zeeland"
+    },
+    "NZ-NZA": {
+      "countryName": "Nya Zeeland",
+      "zoneName": "Aucklandöarna"
+    },
+    "NZ-NZC": {
+      "countryName": "Nya Zeeland",
+      "zoneName": "Chathamöarna"
+    },
+    "NZ-NZST": {
+      "countryName": "Nya Zeeland",
+      "zoneName": "Stewart Island"
+    },
+    "OM": {
+      "zoneName": "Oman"
+    },
+    "PA": {
+      "zoneName": "Panama"
+    },
+    "PE": {
+      "zoneName": "Peru"
+    },
+    "PF": {
+      "zoneName": "Franska Polynesien"
+    },
+    "PG": {
+      "zoneName": "Papua Nya Guinea"
+    },
+    "PH": {
+      "zoneName": "Filippinerna"
+    },
+    "PK": {
+      "zoneName": "Pakistan"
+    },
+    "PL": {
+      "zoneName": "Polen"
+    },
+    "PM": {
+      "zoneName": "Saint-Pierre och Miquelon"
+    },
+    "PN": {
+      "zoneName": "Pitcairnöarna"
+    },
+    "PR": {
+      "zoneName": "Puerto Rico"
+    },
+    "PS": {
+      "zoneName": "Staten Palestina"
+    },
+    "PT": {
+      "zoneName": "Portugal"
+    },
+    "PT-AC": {
+      "countryName": "Portugal",
+      "zoneName": "Azorerna"
+    },
+    "PT-MA": {
+      "countryName": "Portugal",
+      "zoneName": "Madeira"
+    },
+    "PW": {
+      "zoneName": "Palau"
+    },
+    "PY": {
+      "zoneName": "Paraguay"
+    },
+    "QA": {
+      "zoneName": "Qatar"
+    },
+    "RE": {
+      "zoneName": "Réunion"
+    },
+    "RO": {
+      "zoneName": "Rumänien"
+    },
+    "RS": {
+      "zoneName": "Serbien"
+    },
+    "RU": {
+      "zoneName": "Ryssland"
+    },
+    "RU-1": {
+      "countryName": "Ryssland",
+      "zoneName": "Europa-Ural"
+    },
+    "RU-2": {
+      "countryName": "Ryssland",
+      "zoneName": "Sibirien"
+    },
+    "RU-AS": {
+      "countryName": "Ryssland",
+      "zoneName": "Öst"
+    },
+    "RU-EU": {
+      "countryName": "Ryssland",
+      "zoneName": "Arktis"
+    },
+    "RU-FE": {
+      "countryName": "Russia",
+      "zoneName": "Fjärran östern"
+    },
+    "RU-KGD": {
+      "countryName": "Ryssland",
+      "zoneName": "Kaliningrad"
+    },
+    "RW": {
+      "zoneName": "Rwanda"
+    },
+    "SA": {
+      "zoneName": "Saudiarabien"
+    },
+    "SB": {
+      "zoneName": "Salomonöarna"
+    },
+    "SC": {
+      "zoneName": "Seychellerna"
+    },
+    "SD": {
+      "zoneName": "Sudan"
+    },
+    "SE": {
+      "zoneName": "Sverige"
+    },
+    "SG": {
+      "zoneName": "Singapore"
+    },
+    "SH": {
+      "zoneName": "Sankta Helena, Ascension och Tristan da Cunha"
+    },
+    "SI": {
+      "zoneName": "Slovenien"
+    },
+    "SJ": {
+      "zoneName": "Svalbard och Jan Mayen"
+    },
+    "SK": {
+      "zoneName": "Slovakien"
+    },
+    "SL": {
+      "zoneName": "Sierra Leone"
+    },
+    "SM": {
+      "zoneName": "San Marino"
+    },
+    "SN": {
+      "zoneName": "Senegal"
+    },
+    "SO": {
+      "zoneName": "Somalia"
+    },
+    "SR": {
+      "zoneName": "Surinam"
+    },
+    "SS": {
+      "zoneName": "Sydsudan"
+    },
+    "ST": {
+      "zoneName": "São Tomé och Príncipe"
+    },
+    "SV": {
+      "zoneName": "El Salvador"
+    },
+    "SX": {
+      "countryName": "Sint Maarten",
+      "zoneName": "Nederländerna"
+    },
+    "SY": {
+      "zoneName": "Syrien"
+    },
+    "SZ": {
+      "zoneName": "Swaziland"
+    },
+    "TC": {
+      "zoneName": "Turks- och Caicosöarna"
+    },
+    "TD": {
+      "zoneName": "Tchad"
+    },
+    "TF": {
+      "zoneName": "Franska sydterritorierna"
+    },
+    "TG": {
+      "zoneName": "Togo"
+    },
+    "TH": {
+      "zoneName": "Thailand"
+    },
+    "TJ": {
+      "zoneName": "Tadzjikistan"
+    },
+    "TK": {
+      "zoneName": "Tokelau"
+    },
+    "TL": {
+      "zoneName": "Östtimor"
+    },
+    "TM": {
+      "zoneName": "Turkmenistan"
+    },
+    "TN": {
+      "zoneName": "Tunisien"
+    },
+    "TO": {
+      "zoneName": "Tonga"
+    },
+    "TR": {
+      "zoneName": "Turkiet"
+    },
+    "TT": {
+      "zoneName": "Trinidad och Tobago"
+    },
+    "TV": {
+      "zoneName": "Tuvalu"
+    },
+    "TW": {
+      "zoneName": "Taiwan"
+    },
+    "TZ": {
+      "zoneName": "Tanzania"
+    },
+    "UA": {
+      "zoneName": "Ukraina"
+    },
+    "UA-CR": {
+      "countryName": "Ukraina",
+      "zoneName": "Krim"
+    },
+    "UG": {
+      "zoneName": "Uganda"
+    },
+    "UM": {
+      "zoneName": "Förenta staternas mindre öar i Oceanien och Västindien"
+    },
+    "US-HI-HA": {
+      "countryName": "USA",
+      "zoneName": "Hawaii"
+    },
+    "US-HI-KA": {
+      "countryName": "USA",
+      "zoneName": "Kauai"
+    },
+    "US-HI-KH": {
+      "countryName": "USA",
+      "zoneName": "Kahoolawe"
+    },
+    "US-HI-LA": {
+      "countryName": "USA",
+      "zoneName": "Lanai"
+    },
+    "US-HI-MA": {
+      "countryName": "USA",
+      "zoneName": "Maui"
+    },
+    "US-HI-MO": {
+      "countryName": "USA",
+      "zoneName": "Molokai"
+    },
+    "US-HI-NI": {
+      "countryName": "USA",
+      "zoneName": "Niihau"
+    },
+    "US-HI-OA": {
+      "countryName": "USA",
+      "zoneName": "Oahu"
+    },
+    "US-CAL-BANC": {
+      "countryName": "USA",
+      "zoneName": "Balancing Authority Of Northern California"
+    },
+    "US-CAL-CISO": {
+      "countryName": "USA",
+      "zoneName": "California Independent System Operator"
+    },
+    "US-CAL-IID": {
+      "countryName": "USA",
+      "zoneName": "Imperial Irrigation District"
+    },
+    "US-CAL-LDWP": {
+      "countryName": "USA",
+      "zoneName": "Los Angeles Department Of Water And Power"
+    },
+    "US-CAL-TIDC": {
+      "countryName": "USA",
+      "zoneName": "Turlock Irrigation District"
+    },
+    "US-CAR-CPLE": {
+      "countryName": "USA",
+      "zoneName": "Duke Energy Progress East"
+    },
+    "US-CAR-CPLW": {
+      "countryName": "USA",
+      "zoneName": "Duke Energy Progress West"
+    },
+    "US-CAR-DUK": {
+      "countryName": "USA",
+      "zoneName": "Duke Energy Carolinas"
+    },
+    "US-CAR-SC": {
+      "countryName": "USA",
+      "zoneName": "South Carolina Public Service Authority"
+    },
+    "US-CAR-SCEG": {
+      "countryName": "USA",
+      "zoneName": "South Carolina Electric & Gas Company"
+    },
+    "US-CAR-YAD": {
+      "countryName": "USA",
+      "zoneName": "Alcoa Power Generating, Inc. Yadkin Division"
+    },
+    "US-CENT-SPA": {
+      "countryName": "USA",
+      "zoneName": "Southwestern Power Administration"
+    },
+    "US-CENT-SWPP": {
+      "countryName": "USA",
+      "zoneName": "Southwest Power Pool"
+    },
+    "US-FLA-FMPP": {
+      "countryName": "USA",
+      "zoneName": "Florida Municipal Power Pool"
+    },
+    "US-FLA-FPC": {
+      "countryName": "USA",
+      "zoneName": "Duke Energy Florida Inc"
+    },
+    "US-FLA-FPL": {
+      "countryName": "USA",
+      "zoneName": "Florida Power & Light Company"
+    },
+    "US-FLA-GVL": {
+      "countryName": "USA",
+      "zoneName": "Gainesville Regional Utilities"
+    },
+    "US-FLA-HST": {
+      "countryName": "USA",
+      "zoneName": "City Of Homestead"
+    },
+    "US-FLA-JEA": {
+      "countryName": "USA",
+      "zoneName": "Jacksonville Electric Authority"
+    },
+    "US-FLA-NSB": {
+      "countryName": "USA",
+      "zoneName": "Utilities Commission Of New Smyrna Beach"
+    },
+    "US-FLA-SEC": {
+      "countryName": "USA",
+      "zoneName": "Seminole Electric Cooperative"
+    },
+    "US-FLA-TAL": {
+      "countryName": "USA",
+      "zoneName": "City Of Tallahassee"
+    },
+    "US-FLA-TEC": {
+      "countryName": "USA",
+      "zoneName": "Tampa Electric Company"
+    },
+    "US-MIDA-PJM": {
+      "countryName": "USA",
+      "zoneName": "PJM Interconnection, Llc"
+    },
+    "US-MIDW-AECI": {
+      "countryName": "USA",
+      "zoneName": "Associated Electric Cooperative, Inc."
+    },
+    "US-MIDW-GLHB": {
+      "countryName": "USA",
+      "zoneName": "GridLiance"
+    },
     "US-MIDW-LGEE": {
       "countryName": "USA",
       "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"
@@ -660,67 +1608,213 @@
       "countryName": "USA",
       "zoneName": "Midcontinent Independent Transmission System Operator, Inc."
     },
-    "US-NE-ISNE": { "countryName": "USA", "zoneName": "Iso New England Inc." },
-    "US-NW-AVA": { "countryName": "USA", "zoneName": "Avista Corporation" },
-    "US-NW-AVRN": { "countryName": "USA", "zoneName": "Avangrid Renewables Cooperative" },
-    "US-NW-BPAT": { "countryName": "USA", "zoneName": "Bonneville Power Administration" },
-    "US-NW-CHPD": { "countryName": "USA", "zoneName": "PUD No. 1 Of Chelan County" },
-    "US-NW-DOPD": { "countryName": "USA", "zoneName": "PUD No. 1 Of Douglas County" },
-    "US-NW-GCPD": { "countryName": "USA", "zoneName": "PUD No. 2 Of Grant County, Washington" },
-    "US-NW-GRID": { "countryName": "USA", "zoneName": "Gridforce Energy Management, Llc" },
-    "US-NW-GWA": { "countryName": "USA", "zoneName": "Naturener Power Watch, Llc (Gwa)" },
-    "US-NW-IPCO": { "countryName": "USA", "zoneName": "Idaho Power Company" },
-    "US-NW-NEVP": { "countryName": "USA", "zoneName": "Nevada Power Company" },
-    "US-NW-NWMT": { "countryName": "USA", "zoneName": "Northwestern Energy" },
-    "US-NW-PACE": { "countryName": "USA", "zoneName": "Pacificorp East" },
-    "US-NW-PACW": { "countryName": "USA", "zoneName": "Pacificorp West" },
-    "US-NW-PGE": { "countryName": "USA", "zoneName": "Portland General Electric Company" },
-    "US-NW-PSCO": { "countryName": "USA", "zoneName": "Public Service Company Of Colorado" },
-    "US-NW-PSEI": { "countryName": "USA", "zoneName": "Puget Sound Energy" },
-    "US-NW-SCL": { "countryName": "USA", "zoneName": "Seattle City Light" },
+    "US-NE-ISNE": {
+      "countryName": "USA",
+      "zoneName": "Iso New England Inc."
+    },
+    "US-NW-AVA": {
+      "countryName": "USA",
+      "zoneName": "Avista Corporation"
+    },
+    "US-NW-AVRN": {
+      "countryName": "USA",
+      "zoneName": "Avangrid Renewables Cooperative"
+    },
+    "US-NW-BPAT": {
+      "countryName": "USA",
+      "zoneName": "Bonneville Power Administration"
+    },
+    "US-NW-CHPD": {
+      "countryName": "USA",
+      "zoneName": "PUD No. 1 Of Chelan County"
+    },
+    "US-NW-DOPD": {
+      "countryName": "USA",
+      "zoneName": "PUD No. 1 Of Douglas County"
+    },
+    "US-NW-GCPD": {
+      "countryName": "USA",
+      "zoneName": "PUD No. 2 Of Grant County, Washington"
+    },
+    "US-NW-GRID": {
+      "countryName": "USA",
+      "zoneName": "Gridforce Energy Management, Llc"
+    },
+    "US-NW-GWA": {
+      "countryName": "USA",
+      "zoneName": "Naturener Power Watch, Llc (Gwa)"
+    },
+    "US-NW-IPCO": {
+      "countryName": "USA",
+      "zoneName": "Idaho Power Company"
+    },
+    "US-NW-NEVP": {
+      "countryName": "USA",
+      "zoneName": "Nevada Power Company"
+    },
+    "US-NW-NWMT": {
+      "countryName": "USA",
+      "zoneName": "Northwestern Energy"
+    },
+    "US-NW-PACE": {
+      "countryName": "USA",
+      "zoneName": "Pacificorp East"
+    },
+    "US-NW-PACW": {
+      "countryName": "USA",
+      "zoneName": "Pacificorp West"
+    },
+    "US-NW-PGE": {
+      "countryName": "USA",
+      "zoneName": "Portland General Electric Company"
+    },
+    "US-NW-PSCO": {
+      "countryName": "USA",
+      "zoneName": "Public Service Company Of Colorado"
+    },
+    "US-NW-PSEI": {
+      "countryName": "USA",
+      "zoneName": "Puget Sound Energy"
+    },
+    "US-NW-SCL": {
+      "countryName": "USA",
+      "zoneName": "Seattle City Light"
+    },
     "US-NW-TPWR": {
       "countryName": "USA",
       "zoneName": "City Of Tacoma, Department Of Public Utilities, Light Division"
     },
-    "US-NW-WACM": { "countryName": "USA", "zoneName": "Western Area Power Administration - Rocky Mountain Region" },
-    "US-NW-WAUW": { "countryName": "USA", "zoneName": "Western Area Power Administration UGP West" },
-    "US-NW-WWA": { "countryName": "USA", "zoneName": "Naturener Wind Watch, Llc" },
-    "US-NY-NYIS": { "countryName": "USA", "zoneName": "New York Independent System Operator" },
-    "US-SE-AEC": { "countryName": "USA", "zoneName": "Powersouth Energy Cooperative" },
-    "US-SE-SEPA": { "countryName": "USA", "zoneName": "Southeastern Power Administration" },
-    "US-SE-SOCO": { "countryName": "USA", "zoneName": "Southern Company Services, Inc. - Trans" },
-    "US-SW-AZPS": { "countryName": "USA", "zoneName": "Arizona Public Service Company" },
-    "US-SW-DEAA": { "countryName": "USA", "zoneName": "Arlington Valley, LLC" },
-    "US-SW-EPE": { "countryName": "USA", "zoneName": "El Paso Electric Company" },
-    "US-SW-GRIF": { "countryName": "USA", "zoneName": "Griffith Energy, LLC" },
-    "US-SW-GRMA": { "countryName": "USA", "zoneName": "Gila River Power, LLC" },
-    "US-SW-HGMA": { "countryName": "USA", "zoneName": "New Harquahala Generating Company, LLC" },
-    "US-SW-PNM": { "countryName": "USA", "zoneName": "Public Service Company Of New Mexico" },
-    "US-SW-SRP": { "countryName": "USA", "zoneName": "Salt River Project" },
-    "US-SW-TEPC": { "countryName": "USA", "zoneName": "Tucson Electric Power Company" },
+    "US-NW-WACM": {
+      "countryName": "USA",
+      "zoneName": "Western Area Power Administration - Rocky Mountain Region"
+    },
+    "US-NW-WAUW": {
+      "countryName": "USA",
+      "zoneName": "Western Area Power Administration UGP West"
+    },
+    "US-NW-WWA": {
+      "countryName": "USA",
+      "zoneName": "Naturener Wind Watch, Llc"
+    },
+    "US-NY-NYIS": {
+      "countryName": "USA",
+      "zoneName": "New York Independent System Operator"
+    },
+    "US-SE-AEC": {
+      "countryName": "USA",
+      "zoneName": "Powersouth Energy Cooperative"
+    },
+    "US-SE-SEPA": {
+      "countryName": "USA",
+      "zoneName": "Southeastern Power Administration"
+    },
+    "US-SE-SOCO": {
+      "countryName": "USA",
+      "zoneName": "Southern Company Services, Inc. - Trans"
+    },
+    "US-SW-AZPS": {
+      "countryName": "USA",
+      "zoneName": "Arizona Public Service Company"
+    },
+    "US-SW-DEAA": {
+      "countryName": "USA",
+      "zoneName": "Arlington Valley, LLC"
+    },
+    "US-SW-EPE": {
+      "countryName": "USA",
+      "zoneName": "El Paso Electric Company"
+    },
+    "US-SW-GRIF": {
+      "countryName": "USA",
+      "zoneName": "Griffith Energy, LLC"
+    },
+    "US-SW-GRMA": {
+      "countryName": "USA",
+      "zoneName": "Gila River Power, LLC"
+    },
+    "US-SW-HGMA": {
+      "countryName": "USA",
+      "zoneName": "New Harquahala Generating Company, LLC"
+    },
+    "US-SW-PNM": {
+      "countryName": "USA",
+      "zoneName": "Public Service Company Of New Mexico"
+    },
+    "US-SW-SRP": {
+      "countryName": "USA",
+      "zoneName": "Salt River Project"
+    },
+    "US-SW-TEPC": {
+      "countryName": "USA",
+      "zoneName": "Tucson Electric Power Company"
+    },
     "US-SW-WALC": {
       "countryName": "USA",
       "zoneName": "Western Area Power Administration - Desert Southwest Region"
     },
-    "US-TEN-TVA": { "countryName": "USA", "zoneName": "Tennessee Valley Authority" },
-    "US-TEX-ERCO": { "countryName": "USA", "zoneName": "Electric Reliability Council Of Texas, Inc." },
-    "UY": { "zoneName": "Uruguay" },
-    "UZ": { "zoneName": "Uzbekistan" },
-    "VA": { "zoneName": "Vatikanstaten" },
-    "VC": { "zoneName": "Saint Vincent och Grenadinerna" },
-    "VE": { "zoneName": "Venezuela" },
-    "VG": { "countryName": "Jungfruöarna", "zoneName": "Brittiska" },
-    "VI": { "countryName": "Jungfruöarna", "zoneName": "Amerikanska" },
-    "VN": { "zoneName": "Vietnam" },
-    "VU": { "zoneName": "Vanuatu" },
-    "WF": { "zoneName": "Wallis- och Futunaöarna" },
-    "WS": { "zoneName": "Samoa" },
-    "XK": { "zoneName": "Kosovo" },
-    "XX": { "zoneName": "Nordcypern" },
-    "YE": { "zoneName": "Jemen" },
-    "YT": { "zoneName": "Mayotte" },
-    "ZA": { "zoneName": "Sydafrika" },
-    "ZM": { "zoneName": "Zambia" },
-    "ZW": { "zoneName": "Zimbabwe" }
+    "US-TEN-TVA": {
+      "countryName": "USA",
+      "zoneName": "Tennessee Valley Authority"
+    },
+    "US-TEX-ERCO": {
+      "countryName": "USA",
+      "zoneName": "Electric Reliability Council Of Texas, Inc."
+    },
+    "UY": {
+      "zoneName": "Uruguay"
+    },
+    "UZ": {
+      "zoneName": "Uzbekistan"
+    },
+    "VA": {
+      "zoneName": "Vatikanstaten"
+    },
+    "VC": {
+      "zoneName": "Saint Vincent och Grenadinerna"
+    },
+    "VE": {
+      "zoneName": "Venezuela"
+    },
+    "VG": {
+      "countryName": "Jungfruöarna",
+      "zoneName": "Brittiska"
+    },
+    "VI": {
+      "countryName": "Jungfruöarna",
+      "zoneName": "Amerikanska"
+    },
+    "VN": {
+      "zoneName": "Vietnam"
+    },
+    "VU": {
+      "zoneName": "Vanuatu"
+    },
+    "WF": {
+      "zoneName": "Wallis- och Futunaöarna"
+    },
+    "WS": {
+      "zoneName": "Samoa"
+    },
+    "XK": {
+      "zoneName": "Kosovo"
+    },
+    "XX": {
+      "zoneName": "Nordcypern"
+    },
+    "YE": {
+      "zoneName": "Jemen"
+    },
+    "YT": {
+      "zoneName": "Mayotte"
+    },
+    "ZA": {
+      "zoneName": "Sydafrika"
+    },
+    "ZM": {
+      "zoneName": "Zambia"
+    },
+    "ZW": {
+      "zoneName": "Zimbabwe"
+    }
   }
 }

--- a/web/src/layout/leftpanel/countrypanel.jsx
+++ b/web/src/layout/leftpanel/countrypanel.jsx
@@ -123,6 +123,7 @@ const BySource = styled.div`
   font-size: smaller;
   position: relative;
   top: 0.8rem;
+  margin-bottom: 5px;
 `;
 
 const LoadingText = styled.p`
@@ -323,7 +324,9 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
       <CountryPanelWrap>
         {hasParser ? (
           <React.Fragment>
-            <BySource>{__('country-panel.bysource')}</BySource>
+            <BySource>
+              {__(timeAggregate != TIME.HOURLY ? 'country-panel.averagebysource' : 'country-panel.bysource')}
+            </BySource>
 
             <CountryTable />
 

--- a/web/src/layout/leftpanel/countrypanel.jsx
+++ b/web/src/layout/leftpanel/countrypanel.jsx
@@ -325,7 +325,7 @@ const CountryPanel = ({ electricityMixMode, isMobile, tableDisplayEmissions, zon
         {hasParser ? (
           <React.Fragment>
             <BySource>
-              {__(timeAggregate != TIME.HOURLY ? 'country-panel.averagebysource' : 'country-panel.bysource')}
+              {__(timeAggregate !== TIME.HOURLY ? 'country-panel.averagebysource' : 'country-panel.bysource')}
             </BySource>
 
             <CountryTable />


### PR DESCRIPTION
Small UI change that makes it clearer that the aggregate time periods (day, month and year) is a average by source.

Before:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/30777521/180426928-4f6ce215-dad5-4dce-a794-8ac4679722a6.png">
<sup>Note I used the live website for this screenshot.</sup>
After:
<img width="312" alt="image" src="https://user-images.githubusercontent.com/30777521/180426967-ab64328e-f7df-46d4-b6d6-19d56d15dd0a.png">

PS: The huge diff in the `sv.json` file is probably because I used the `translation-helper.js` instead of editing it directly but it only contains one new string. (same as `en.json`)