### PR TITLE
fix(GCCIA): fix consumption data fetch for AE, BH, OM, QA, and SA

### DIFF
--- a/parsers/GCCIA.py
+++ b/parsers/GCCIA.py
@@ -48,7 +48,7 @@ def fetch_consumption(zone_key, session=None, target_datetime=None, logger=None)
     url = "https://www.gccia.com.sa/"
     response = r.get(url)
 
-    pattern = COUNTRY_CODE_MAPPING[zone_key] + '-mw-val">\s*(\d+)'
+    pattern = COUNTRY_CODE_MAPPING[zone_key] + r'-mw-val">\s*(\d+)'
 
     match = re.findall(pattern, response.text)
     if not match:

--- a/parsers/GCCIA.py
+++ b/parsers/GCCIA.py
@@ -18,6 +18,8 @@ from sys import stderr
 import arrow
 import requests
 
+from .lib.exceptions import ParserException
+
 COUNTRY_CODE_MAPPING = {
     "AE": "uae",
     "BH": "bah",
@@ -51,7 +53,9 @@ def fetch_consumption(zone_key, session=None, target_datetime=None, logger=None)
     match = re.findall(pattern, response.text)
     if not match:
         # if no data, the text becomes " - "
-        raise RuntimeError(f"{zone_key} data is currently not available")
+        raise ParserException(
+            "GCCIA.py", "data is currently not available", zone_key=zone_key
+        )
     consumption = int(match[0])
 
     datapoint = {

--- a/parsers/GCCIA.py
+++ b/parsers/GCCIA.py
@@ -48,10 +48,11 @@ def fetch_consumption(zone_key, session=None, target_datetime=None, logger=None)
 
     pattern = COUNTRY_CODE_MAPPING[zone_key] + '-mw-val">\s*(\d+)'
 
-    load = re.findall(pattern, response.text)
-    load = int(load[0])
-    consumption = {}
-    consumption["unknown"] = load
+    match = re.findall(pattern, response.text)
+    if not match:
+        # if no data, the text becomes " - "
+        raise RuntimeError(f"{zone_key} data is currently not available")
+    consumption = int(match[0])
 
     datapoint = {
         "zoneKey": zone_key,
@@ -73,4 +74,4 @@ if __name__ == "__main__":
         except IndexError as error:
             print("Could not fetch consumption data for {0}".format(i), file=stderr)
             print(type(error), ":", error, file=stderr)
-        print("\n")
+        print()


### PR DESCRIPTION
These countries using `parsers/GCCIA.py` had the same errors:

```py
'<' not supported between instances of 'dict' and 'int'
  File "/home/contrib/electricitymap/contrib/parsers/lib/quality.py", line 33, in validate_consumption
    if (obj.get("consumption") or 0) < 0:
```

ref. https://storage.googleapis.com/electricitymap-parser-logs/AE.html

This was because `fetch_consumption()` returned dictionary as a consumption (i.e. `{"unknown": 123}`). I guess it was confused with `fetch_production()`. This PR fixes the function to return int value as a consumption value.

Also, SA is currently showing  " - " instead of a value like "123 MW". I added a check if the value is currently available and made it raise `RuntimeError`. Is it OK to raise `RuntimeError` to handle a case like this?

ref. https://storage.googleapis.com/electricitymap-parser-logs/SA.html