### PR TITLE
Ignore ISSUE_TEMPLATE in prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,5 @@ web/public/dist/
 web/public/images/
 
 mockserver/public
+
+.github/ISSUE_TEMPLATE/


### PR DESCRIPTION
I think it's OK if we ignore the issue templates. I would often like to use the web editor for small changes 