### PR TITLE
Add estimation method to ZA

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -6809,7 +6809,8 @@
       [15.969981316000087, -47.46575286299992],
       [38.47779381600009, -21.626451924999927]
     ],
-    "timezone": null
+    "timezone": null,
+    "estimation_method": "RECONSTRUCT_BREAKDOWN"
   },
   "ZM": {
     "bounding_box": [

--- a/config/zones.json
+++ b/config/zones.json
@@ -6809,7 +6809,7 @@
       [15.969981316000087, -47.46575286299992],
       [38.47779381600009, -21.626451924999927]
     ],
-    "timezone": null,
+    "timezone": "Africa/Johannesburg",
     "estimation_method": "ESTIMATED_TIME_SLICER_AVERAGE"
   },
   "ZM": {

--- a/config/zones.json
+++ b/config/zones.json
@@ -6810,7 +6810,7 @@
       [38.47779381600009, -21.626451924999927]
     ],
     "timezone": null,
-    "estimation_method": "RECONSTRUCT_BREAKDOWN"
+    "estimation_method": "ESTIMATED_TIME_SLICER_AVERAGE"
   },
   "ZM": {
     "bounding_box": [


### PR DESCRIPTION
South Africa was not properly displayed because there was no parser and no estimation method available. 

For now, I've added time slicer as the estimation method

<img width="989" alt="image" src="https://user-images.githubusercontent.com/45588799/180994934-c5965ace-8335-4cdd-be9b-998f2479df6e.png">
