### PR TITLE
Add data issue form and issue config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "Electricity Maps Slack Channel"
+    url: https://slack.electricitymap.org/
+    about: |
+      The Electricity Maps Slack Channel is a community for sharing and discussing Electricity Map data.
+      You can use this channel for general questions about Electricity Map.

--- a/.github/ISSUE_TEMPLATE/data-issue.yml
+++ b/.github/ISSUE_TEMPLATE/data-issue.yml
@@ -29,11 +29,29 @@ body:
     validations:
       required: false
   - type: textarea
+    id: when-did-this-happen
+    attributes:
+      label: When did this happen?
+      description: Please provide the date and time when the problem happened.
+      placeholder: e.g. "2018-01-01 12:00"
+    validations:
+      required: false
+  - type: textarea
+    id: what-zones-are-affected
+    attributes:
+      label: What zones are affected?
+      description: Please provide the zones affected.
+      placeholder: e.g. "Dk-DK1, DK-DK2, SE-SE4"
+    validations:
+      required: true
+  - type: textarea
     id: what-is-the-problem
     attributes:
       label: What is the problem?
       description: |
         What appears to be the problem with the data?
         Please provide as much detail as possible.
+        You can also add screenshots here if you have them.
+      placeholder: e.g. "The data for biomass is not being displayed even though it's available at the source."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/data-issue.yml
+++ b/.github/ISSUE_TEMPLATE/data-issue.yml
@@ -1,0 +1,39 @@
+name: Data Issue
+description: Use this form if you believe there is a issue with the data on the app.
+title: "[Data Issue]: "
+labels: ["data", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file this issue.
+  - type: dropdown
+    id: where-is-the-problem
+    attributes:
+      label: On what platform are you seeing the problem?
+      description: Please select the platforms where the problem is seen.
+      multiple: true
+      options:
+        - "Android"
+        - "iOS"
+        - "Web"
+        - "Other"
+    validations:
+      required: true
+  - type: textarea
+    id: if-other-platform
+    attributes:
+      label: If other, please specify
+      description: Please specify the other platform.
+      placeholder: e.g. "Web App or Android TV"
+    validations:
+      required: false
+  - type: textarea
+    id: what-is-the-problem
+    attributes:
+      label: What is the problem?
+      description: |
+        What appears to be the problem with the data?
+        Please provide as much detail as possible.
+    validations:
+      required: true


### PR DESCRIPTION
This PR add a new issue template as a issue form for data issues as well as a config for issues with a contact link to the Slack channel.

Not sure there is any way to test this other than just merging it and see how it works.
