### PR TITLE
fix(BY): fix a typo in the base URL to fix the `BY->RU-1` exchange

### DIFF
--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -16,7 +16,7 @@ import requests
 
 # http://br.so-ups.ru is not available outside Russia (sometimes?), use a reverse proxy in Russia
 HOST = "https://858127-cc16935.tmweb.ru"
-BASE_EXCHANGE_URL = f"${HOST}/webapi/api/flowDiagramm/GetData?"
+BASE_EXCHANGE_URL = f"{HOST}/webapi/api/flowDiagramm/GetData?"
 
 MAP_GENERATION_1 = {
     "P_AES": "nuclear",


### PR DESCRIPTION
There are two errors in BY parsers. This PR fixes the one for exchange.

**Log**

```py
2022-07-28T12:43:05	ERROR     	BY->RU-1  	No connection adapters were found for '$https://858127-cc16935.tmweb.ru/webapi/api/flowDiagramm/GetData?Date=2022-07-28&Hour=12'

File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 771, in get
  raise self._value
File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 125, in worker
  result = (True, func(*args, **kwds))
File "/home/contrib/parsers/RU.py", line 284, in fetch_exchange
  response = r.get(url, verify=False)
File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 555, in get
  return self.request('GET', url, **kwargs)
File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 542, in request
  resp = self.send(prep, **send_kwargs)
File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 649, in send
  adapter = self.get_adapter(url=request.url)
File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 742, in get_adapter
  raise InvalidSchema("No connection adapters were found for {!r}".format(url))
```

from https://storage.googleapis.com/electricitymap-parser-logs/BY.html

The cause was just an additional `$` string in the base URL.