### PR TITLE
fix(TH): fix `fetch_consumption()` return type error

### DIFF
--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -64,11 +64,10 @@ def fetch_consumption(
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
-    """all mapped to unknown as there is no available breakdown"""
     return {
         "zoneKey": zone_key,
         "datetime": arrow.now(TZ).datetime,
-        "consumption": {"unknown": float(fetch_EGAT())},
+        "consumption": float(fetch_EGAT()),
         "source": EGAT_URL,
     }
 

--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -12,9 +12,9 @@ TZ = "Asia/Bangkok"
 
 
 def fetch_EGAT() -> str:
-    """Pull from Min. of Energy for now as I didn't wanted to write a parser for websocket yet"""
-    """The website took around 15s to load, unlike the websocket ver."""
-    """Consumption = Production + Import(the latter is done separately)"""
+    # Pull from Min. of Energy for now as I didn't want to write a parser for websocket yet.
+    # The website took around 15s to load, unlike the websocket ver.
+    # Consumption = Production + Import (the latter is done separately)
     with get(EGAT_GENERATION) as response:
         EGAT_soup = BeautifulSoup(response.content, "lxml")
 
@@ -26,11 +26,11 @@ def fetch_price(zone_key="TH", session=None, target_datetime=None, logger=None) 
     if target_datetime is not None:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
-    """Fetch price from MEA table."""
+    # Fetch price from MEA table.
     with get(MEA_PRICE) as response:
         MEA_soup = BeautifulSoup(response.content, "lxml")
 
-    """'Over 400 kWh (up from 401st)' from Table 1.1"""
+    # 'Over 400 kWh (up from 401st)' from Table 1.1
     unit_price_table = MEA_soup.find_all("table")[1]
     price = unit_price_table.find_all("td")[19]
 
@@ -49,7 +49,7 @@ def fetch_production(
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
-    """All mapped to unknown as there is no available breakdown"""
+    # All mapped to unknown as there is no available breakdown
     return {
         "zoneKey": zone_key,
         "datetime": arrow.now(TZ).datetime,


### PR DESCRIPTION
This PR fixes the error where `fetch_consumption()` returns a wrong data structure. Essentially, this is the same error as #4364.

**execution log**

```py
'<' not supported between instances of 'dict' and 'int'

  File "/home/contrib/electricitymap/contrib/parsers/lib/quality.py", line 33, in validate_consumption
    if (obj.get("consumption") or 0) < 0:       
```

This will fix the issue itself. However, I wonder if the consumption value is correct. Because the comment in `fetch_EGAT()` says "Consumption = Production + Import" but the current implementation only uses the same value as the production and ignores import value.