### PR TITLE
refactor(parsers): replace `RuntimeError` with `ParserException` for better error message

### DIFF
--- a/parsers/AW.py
+++ b/parsers/AW.py
@@ -5,6 +5,8 @@ import datetime
 import arrow
 import requests
 
+from .lib.exceptions import ParserException
+
 
 def fetch_production(zone_key="AW", session=None, target_datetime=None, logger=None):
     if target_datetime:
@@ -37,8 +39,10 @@ def fetch_production(zone_key="AW", session=None, target_datetime=None, logger=N
     )
 
     if (sources_total / reported_total) > 1.1:
-        raise RuntimeError(
-            f"AW parser reports fuel sources add up to {sources_total} but total generation {reported_total} is lower"
+        raise ParserException(
+            "AW.py",
+            f"AW parser reports fuel sources add up to {sources_total} but total generation {reported_total} is lower",
+            zone_key,
         )
 
     missing_from_total = reported_total - sources_total

--- a/parsers/BD.py
+++ b/parsers/BD.py
@@ -8,6 +8,8 @@ from datetime import datetime
 import arrow
 import pandas as pd
 
+from .lib.exceptions import ParserException
+
 GENERATION_MAPPING = {
     "Gas (Public)": "gas_public",
     "Gas (Private)": "gas_private",
@@ -70,8 +72,8 @@ def new_format_converter(df, logger):
     try:
         time_index = df.index.get_loc("24:00")
     except KeyError:
-        raise RuntimeError(
-            "Structure of xlsm file for BD has altered, unable to parse."
+        raise ParserException(
+            "BD.py", "Structure of xlsm file for BD has altered, unable to parse.", "BD"
         )
 
     df = df.iloc[: time_index + 1]

--- a/parsers/CL.py
+++ b/parsers/CL.py
@@ -12,6 +12,7 @@ import requests
 
 from parsers.lib.config import refetch_frequency
 
+from .lib.exceptions import ParserException
 from .lib.validation import validate
 
 # Historical API
@@ -55,15 +56,19 @@ def production_processor_live(json_tot, json_ren):
     if json_ren["data"][1]["key"] == "ENERGÍA SOLAR":
         rawgen_sol = json_ren["data"][1]["values"]
     else:
-        raise RuntimeError(
-            f"Unexpected data label. Expected 'ENERGÍA SOLAR' and got {json_ren['data'][1]['key']}"
+        raise ParserException(
+            "CL.py",
+            f"Unexpected data label. Expected 'ENERGÍA SOLAR' and got {json_ren['data'][1]['key']}",
+            "CL",
         )
 
     if json_ren["data"][0]["key"] == "ENERGÍA EÓLICA":
         rawgen_wind = json_ren["data"][0]["values"]
     else:
-        raise RuntimeError(
-            f"Unexpected data label. Expected 'ENERGÍA EÓLICA' and got {json_ren['data'][0]['key']}"
+        raise ParserException(
+            "CL.py",
+            f"Unexpected data label. Expected 'ENERGÍA EÓLICA' and got {json_ren['data'][0]['key']}",
+            "CL",
         )
 
     mapped_totals = []

--- a/parsers/FO.py
+++ b/parsers/FO.py
@@ -6,6 +6,7 @@ from logging import getLogger
 import arrow
 import requests
 
+from .lib.exceptions import ParserException
 from .lib.validation import validate
 
 MAP_GENERATION = {
@@ -66,7 +67,9 @@ def fetch_production(
             raw_generation_type = key.replace("Sev_E", "")
             generation_type = map_generation_type(raw_generation_type)
             if not generation_type:
-                raise RuntimeError(f"Unknown generation type: {raw_generation_type}")
+                raise ParserException(
+                    "FO.py", f"Unknown generation type: {raw_generation_type}", "FO"
+                )
             # Power (MW)
             value = float(value.replace(",", "."))
             data["production"][generation_type] = (

--- a/parsers/occtonet.py
+++ b/parsers/occtonet.py
@@ -9,6 +9,8 @@ import arrow
 import pandas as pd
 import requests
 
+from .lib.exceptions import ParserException
+
 # Abbreviations:
 # JP-HKD : Hokkaido
 # JP-TH  : Tohoku (incl. Niigata)
@@ -165,10 +167,11 @@ def get_form_data(
     response_content = r.json()
 
     if response_content["root"]["errMessage"]:
-        raise RuntimeError(
+        raise ParserException(
+            "occtonet.py",
             "Headers not available due to {}".format(
                 response_content["root"]["errMessage"]
-            )
+            ),
         )
     else:
         form_data["msgArea"] = response_content["root"]["bizRoot"]["header"]["msgArea"][
@@ -192,10 +195,11 @@ def get_form_data(
     response_content = r.json()
 
     if response_content["root"]["errFields"]:
-        raise RuntimeError(
+        raise ParserException(
+            "occtonet.py",
             "Request token not available due to {}".format(
                 response_content["root"]["errFields"]
-            )
+            ),
         )
     else:
         form_data["downloadKey"] = response_content["root"]["bizRoot"]["header"][


### PR DESCRIPTION
This PR removes the basic `RuntimeError` from all parsers and replaces them with `ParserException`, expecting to help to understand errors during debugging.

ref. https://github.com/electricitymap/electricitymap-contrib/pull/4364#issuecomment-1198126288