### PR TITLE
Fix link formatting for Israel and South Africa

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -263,8 +263,8 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Renewable: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)
   - Non-Renewable [ESDM](https://www.esdm.go.id/assets/media/content/content-laporan-kinerja-ditjen-ketenagalistrikan-2020.pdf)
 - Israel
-  - [Irena] (https://pxweb.irena.org/pxweb/en/IRENASTAT)
-  - [GEM] (https://globalenergymonitor.org/projects/global-gas-plant-tracker/tracker-map/)
+  - [Irena](https://pxweb.irena.org/pxweb/en/IRENASTAT)
+  - [GEM](https://globalenergymonitor.org/projects/global-gas-plant-tracker/tracker-map/)
 - Italy
   - Coal and Oil: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedCapacityPerProductionUnit/show)
   - Other: [Terna](https://www.terna.it/it/sistema-elettrico/statistiche/pubblicazioni-statistiche)
@@ -336,7 +336,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Other: [SEPS](https://www.sepsas.sk/media/4951/rocenka-sed-2020.pdf)
 - Slovenia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - South Africa:
-  - [Eskom] (https://www.eskom.co.za/wp-content/uploads/2021/08/2021IntegratedReport.pdf)
+  - [Eskom](https://www.eskom.co.za/wp-content/uploads/2021/08/2021IntegratedReport.pdf)
 - South Korea:
   - [KHNP](http://cms.khnp.co.kr/content/163/main.do?mnCd=FN05040101)
   - [EPSIS](http://epsis.kpx.or.kr/epsisnew/selectEkpoBftChart.do?menuId=020100)


### PR DESCRIPTION
Hyperlinks in the section called [sources by region](https://github.com/electricitymap/electricitymap-contrib/blob/master/DATA_SOURCES.md#sources-by-region) had [source] (url). Changed to [source](url).

Thank you for the super interesting map!