### PR TITLE
Ensure data contains netflow for AX

### DIFF
--- a/parsers/AX.py
+++ b/parsers/AX.py
@@ -1091,6 +1091,8 @@ def fetch_exchange(
     #  AX is before both FI and SE
     if net_flow:
         data["netFlow"] = round(-1 * net_flow, 1)
+    else:
+        data["netFlow"] = None
 
     return data
 


### PR DESCRIPTION
poetry run test_parser "AX->FI" exchange


Parser result:
{'datetime': datetime.datetime(2022, 8, 11, 15, 51, 23, tzinfo=tzfile('/usr/share/zoneinfo/Europe/Mariehamn')),
 'netFlow': None,
 'sortedZoneKeys': 'AX->FI',
 'source': 'kraftnat.ax'}