### PR TITLE
Add validation rule for ensuring that the netFlow key is present in the parser event

### DIFF
--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -55,6 +55,8 @@ def validate_exchange(item, k) -> None:
     if type(item["datetime"]) != datetime:
         raise ValidationError("datetime %s is not valid for %s" % (item["datetime"], k))
     validate_reasonable_time(item, k)
+    if "netFlow" not in item:
+        raise ValidationError("netFlow was not returned for %s" % k)
     # Verify that the exchange flow is not greater than the interconnector
     # capacity and has physical sense (no exchange should exceed 100GW)
     # Use https://github.com/tmrowco/electricitymap-contrib/blob/master/parsers/example.py for expected format


### PR DESCRIPTION
### Description

Enforces the presence of `netFlow` in any exchange parser event