### PR TITLE
use .org for api

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -28,7 +28,7 @@
     <meta name="theme-color" content="#ffffff" />
 
     <!-- Pre-connect to improve performances -->
-    <link rel="preconnect" href="https://app-backend.electricitymaps.com/" />
+    <link rel="preconnect" href="https://app-backend.electricitymap.org/" />
 
     <!-- Bundle -->
     <script type="module" src="/dist/index.js"></script>

--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -27,7 +27,7 @@ function isUsingLocalEndpoint() {
 }
 
 export function getEndpoint() {
-  return isUsingLocalEndpoint() ? 'http://localhost:8001' : 'https://app-backend.electricitymaps.com';
+  return isUsingLocalEndpoint() ? 'http://localhost:8001' : 'https://app-backend.electricitymap.org';
 }
 
 export function protectedJsonRequest(path) {


### PR DESCRIPTION
We should still use the old .org. Will look into getting it into the new domain soon.