### PR TITLE
Use static.electricitymap.org

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -149,7 +149,7 @@ app.use('/', (req, res) => {
           : (relativePath) =>
               // Note we here point to static hosting in order to make
               // sure we can serve older bundle versions
-              `https://static.electricitymaps.com/public_web/${relativePath}`,
+              `https://static.electricitymap.org/public_web/${relativePath}`,
       canonicalUrl,
       supportedLocales: locales,
       FBLocale: localeToFacebookLocale[locale || 'en'],
@@ -161,7 +161,7 @@ app.use('/', (req, res) => {
 if (isProduction) {
   app.get('/*', (req, res) =>
     // Redirect all requests except root to static
-    res.redirect(`https://static.electricitymaps.com/public_web${req.originalUrl}`)
+    res.redirect(`https://static.electricitymap.org/public_web${req.originalUrl}`)
   );
 }
 


### PR DESCRIPTION
The new URL might be working now, but we'll roll it out after getting the map back to static.electricitymaps.com