### PR TITLE
Authorise LU not to have any fossil production

### DIFF
--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -126,6 +126,7 @@ def validate_production(obj: Dict[str, Any], zone_key: ZoneKey) -> None:
             "US-NW-GWA",
             "US-NW-DOPD",
             "US-NW-AVRN",
+            "LU"
         ]
     ):
         raise ValidationError(

--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -126,7 +126,7 @@ def validate_production(obj: Dict[str, Any], zone_key: ZoneKey) -> None:
             "US-NW-GWA",
             "US-NW-DOPD",
             "US-NW-AVRN",
-            "LU"
+            "LU",
         ]
     ):
         raise ValidationError(

--- a/validators/zone_specific_checks.py
+++ b/validators/zone_specific_checks.py
@@ -21,7 +21,7 @@ from validators.lib.config import validator
         "US-NW-GWA",
         "US-NW-DOPD",
         "US-NW-AVRN",
-        "LU"
+        "LU",
     ],
 )
 def validate_production_has_fossil_fuel(events: pd.DataFrame) -> pd.Series:

--- a/validators/zone_specific_checks.py
+++ b/validators/zone_specific_checks.py
@@ -21,6 +21,7 @@ from validators.lib.config import validator
         "US-NW-GWA",
         "US-NW-DOPD",
         "US-NW-AVRN",
+        "LU"
     ],
 )
 def validate_production_has_fossil_fuel(events: pd.DataFrame) -> pd.Series:


### PR DESCRIPTION
### Description

LU production is not parsed because we deem necessary to have fossil production. 

Fossil capacity is very small though, so I suggest we should accept these data points. 

