### PR TITLE
Fixed elexon parser

### DIFF
--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -60,8 +60,6 @@ EXCHANGES = {
 }
 
 
-
-
 def query_ELEXON(report, session: Session, params):
     params["APIKey"] = get_token("ELEXON_TOKEN")
     return session.get(ELEXON_ENDPOINT.format(report), params=params)

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -59,7 +59,7 @@ EXCHANGES = {
     "GB->NO-NO2": [10],  # North Sea Link
 }
 
-FETCH_WIND_FROM_FUELINST = True
+
 
 
 def query_ELEXON(report, session: Session, params):
@@ -330,6 +330,7 @@ def fetch_production(
     # At times B1620 has had poor quality data for wind so fetch from FUELINST
     # But that source is unavailable prior to cutout date
     HISTORICAL_WIND_CUTOUT = "2016-03-01"
+    FETCH_WIND_FROM_FUELINST = True
     if target_datetime < arrow.get(HISTORICAL_WIND_CUTOUT).datetime:
         FETCH_WIND_FROM_FUELINST = False
     if FETCH_WIND_FROM_FUELINST:


### PR DESCRIPTION
Fixes #4413

```
Traceback (most recent call last):
  File "test_parser.py", line 123, in <module>
    print(test_parser())
  File "/Users/felix/Projects/tmrow/electricitymap/contrib/.venv/lib/python3.8/site-packages/click/core.py", line 1134, in __call__
    return self.main(*args, **kwargs)
  File "/Users/felix/Projects/tmrow/electricitymap/contrib/.venv/lib/python3.8/site-packages/click/core.py", line 1059, in main
    rv = self.invoke(ctx)
  File "/Users/felix/Projects/tmrow/electricitymap/contrib/.venv/lib/python3.8/site-packages/click/core.py", line 1401, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/felix/Projects/tmrow/electricitymap/contrib/.venv/lib/python3.8/site-packages/click/core.py", line 767, in invoke
    return __callback(*args, **kwargs)
  File "test_parser.py", line 60, in test_parser
    res = parser(*args, target_datetime=target_datetime, logger=getLogger(__name__))
  File "/Users/felix/Projects/tmrow/electricitymap/contrib/parsers/lib/config.py", line 15, in wrapped_f
    result = f(*args, **kwargs)
  File "/Users/felix/Projects/tmrow/electricitymap/contrib/parsers/ELEXON.py", line 335, in fetch_production
    if FETCH_WIND_FROM_FUELINST:
UnboundLocalError: local variable 'FETCH_WIND_FROM_FUELINST' referenced before assignment
```

We referenced `FETCH_WIND_FROM_FUELINST` before assignment because it wasn't a global variable. I moved it into the function as we don't need it as a global variable.