### PR TITLE
Add PL locales for country panel and time controller

### DIFF
--- a/web/public/locales/pl.json
+++ b/web/public/locales/pl.json
@@ -36,12 +36,18 @@
     "noDataAtTimestamp": "Dla wybranego okresu dane są tymczasowo niedostępne",
     "noLiveData": "Dane na żywo są tymczasowo niedostępne dla tego obszaru",
     "noParserInfo": "Nie posiadamy jeszcze żadnych informacji o tym obszarze.<br/> Chcesz pomóc? Możesz to zrobić <a href=\"%s\" target=\"_blank\">dodając dane dla obszaru</a>.",
+    "estimated": "szacowane",
+    "estimatedTooltip": "Dane czasu rzeczywistego dla tego obszaru zostały oszacowane na podstawie danych źródłowych i przyjętych założeń modelu.",
+    "dataIsEstimated": "Niektóre dane dla tego obszaru zostały oszacowane. Przeczytaj więcej o naszej metodologii szacowania <a href=\"https://github.com/electricityMap/electricitymap-contrib/wiki/Estimation-methods\" target=\"_blank\">tutaj</a>.",
     "now": "Obecnie"
   },
   "left-panel": {
     "zone-list-header-title": "Wpływ na klimat według obszaru",
     "zone-list-header-subtitle": "według emisji CO₂ poprzez wytwarzanie energii elektrycznej (gCO₂eq/kWh)",
     "search": "Szukaj"
+  },
+  "time-controller": {
+    "title": "Wyświetl dane historyczne"
   },
   "country-history": {
     "Getdata": "Uzyskaj dane godzinowe, bieżące oraz prognozy za pomocą API Electricity Maps",


### PR DESCRIPTION
Hi,
Thanks for doing an awesome job by delivering electricity map!

## Issue

When browsing through the app, I have found couple of missing locales for PL.

## Description

This PR adds couple of missing translations for country panel (when it is estimated values) and adds header for time controller panel.
