### PR TITLE
Update ENTSO-E REST API endpoint

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -30,7 +30,7 @@ from parsers.lib.config import refetch_frequency
 from .lib.utils import get_token, sum_production_dicts
 from .lib.validation import validate
 
-ENTSOE_ENDPOINT = "https://transparency.entsoe.eu/api"
+ENTSOE_ENDPOINT = "https://web-api.tp.entsoe.eu/api"
 ENTSOE_PARAMETER_DESC = {
     "B01": "Biomass",
     "B02": "Fossil Brown coal/Lignite",


### PR DESCRIPTION
As per a ENTSO-E news bulletin the transparency platform has a new REST API endpoint:
>Dear Users,
>
>
>
>We are happy to announce that new REST API endpoints are available.
>
> 
>
>The new endpoints are:
>
> 
>
>https://web-api.tp.entsoe.eu/api for Production
>https://web-api.tp-iop.entsoe.eu/api for IOP (used only for testing purpose)
> 
>
>Important: the existing endpoints https://transparency.entsoe.eu/api and https://iop.transparency.entsoe.eu/api will be no longer available starting from 15.11.2022!  
>
> 
>
>Best regards,
>Transparency Platform team

So this PR updates the ENTSOE.py parser to use the new endpoint.