### PR TITLE
Fix zone neighbours generation

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -201,6 +201,25 @@ class ConfigTestcase(unittest.TestCase):
             {"SE-SE1": ["SE-SE2"], "SE-SE2": ["SE-SE1"]},
         )
 
+    def test_generate_zone_neighbours_GB(self):
+        # That's an interesting case as GB has islands, which are not subzones
+        # It means that GB->GB-NIR are valid exchanges and that
+        # GB and GB-NIR are neighbours
+        exchanges = {
+            "GB->GB-NIR": {},
+            "GB->GB-ORK": {},
+        }
+        zones = {
+            "GB": {},
+            "GB-NIR": {},
+            "GB-ORK": {},
+        }
+        zone_neighbours = config.generate_zone_neighbours(exchanges, zones)
+        self.assertDictEqual(
+            zone_neighbours,
+            {"GB": ["GB-NIR", "GB-ORK"], "GB-NIR": ["GB"], "GB-ORK": ["GB"]},
+        )
+
     def test_ZONE_NEIGHBOURS(self):
         self.assertIn("DK-DK1", config.ZONE_NEIGHBOURS.keys())
         dk_neighbours = config.ZONE_NEIGHBOURS["DK-DK1"]


### PR DESCRIPTION
## Issue

I had forgotten an edge case for the generation of the `ZONE_NEIGHOURS` dict.

Example: `GB->GB-NIR` is an exchange and `GB-NIR` is not a subzone of `GB`. Currently `GB` was not getting `GB-NIR` as its neighbour.

## Description

Fixes that issue by refining the `_can_zones_be_neighbours` check

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
