### PR TITLE
Return if source not loaded yet

### DIFF
--- a/web/src/components/zonemap.jsx
+++ b/web/src/components/zonemap.jsx
@@ -133,20 +133,23 @@ const ZoneMap = ({
   useEffect(() => {
     if (!ReactMapGL.supported()) {
       setIsSupported(false);
-      onMapError('WebGL not supported');
+      onMapError({ error: 'WebGL not supported' });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useMemo(() => {
     if (isLoaded) {
       const map = ref.current.getMap();
+      const isSourceLoaded = map.getSource('zones-clickable') != null;
+      // An issue on ios where the map has not loaded source yet causing map errors
+      if (!isSourceLoaded) {
+        return;
+      }
       zoneValues.forEach((zone, i) => {
         const zoneData = zone[selectedTimeAggregate].overviews[selectedZoneTimeIndex];
         const co2intensity = zoneData ? getCO2IntensityByMode(zoneData, electricityMixMode) : null;
         const fillColor = co2ColorScale(co2intensity);
-
         const existingColor = map.getFeatureState({ source: 'zones-clickable', id: i }, 'color')?.color;
-
         if (fillColor !== existingColor) {
           map.setFeatureState(
             {

--- a/web/src/layout/map.jsx
+++ b/web/src/layout/map.jsx
@@ -85,8 +85,10 @@ export default () => {
     dispatchApplication('isLoadingMap', false);
 
     // Disable the map and redirect to zones ranking.
-    dispatchApplication('webGLSupported', false);
-    history.push({ pathname: '/ranking', search: location.search });
+    if (e.error === 'WebGL not supported') {
+      dispatchApplication('webGLSupported', false);
+      history.push({ pathname: '/ranking', search: location.search });
+    }
   };
 
   const handleMouseMove = useMemo(


### PR DESCRIPTION
## Issue
There's an ongoing issue when visiting the app via Safari

![image](https://user-images.githubusercontent.com/45588799/186679978-f9845d0e-26ad-40bc-b3eb-6e3b6c361ca7.png)

## Description

It's a bit tricky. I believe this is some kind of race condition which happens because we initially load in the mapstyle with an empty sources object. On our first call to the useMemo we then don't have the sources yet and the code fails.

There might be a more elegant way to fix this but not that i can think of right now.

It was also a bit extreme IMO that every error is treated as webGLnotsupported, so I've changed that.

