### PR TITLE
SEO index .com instead of .org

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -90,7 +90,7 @@ app.use('/', (req, res) => {
   // redirect everyone except the Facebook crawler,
   // else, we will lose all likes
   if (!isStaging && isProduction && isNonAppDomain && !isFacebookRobot) {
-    res.redirect(301, `https://app.electricitymap.org${req.originalUrl}`);
+    res.redirect(301, `https://app.electricitymaps.com${req.originalUrl}`);
   } else {
     // Set locale if facebook requests it
     if (req.query.fb_locale) {
@@ -100,7 +100,7 @@ app.use('/', (req, res) => {
       res.setLocale(lr[0]);
     }
     const { locale } = res;
-    let canonicalUrl = `https://app.electricitymap.org${req.baseUrl + req.path}`;
+    let canonicalUrl = `https://app.electricitymaps.com${req.baseUrl + req.path}`;
     if (req.query.lang) {
       canonicalUrl += `?lang=${req.query.lang}`;
     }


### PR DESCRIPTION
This PR makes sure that the canonical url is using the .com domain.
This will ensure Google and other search engines index the .com instead of the .com