### PR TITLE
Fix "new version available" cache issue

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -77,6 +77,11 @@ app.all('/dist/*.map', (req, res, next) => {
   return next();
 });
 
+app.use('/client-version.json', (req, res, next) => {
+  res.header('Cache-Control', 'no-cache,max-age=0');
+  next();
+});
+
 // Static files
 app.use(express.static(STATIC_PATH, { etag: true, maxAge: isProduction ? '24h' : '0' }));
 

--- a/web/src/layout/main.jsx
+++ b/web/src/layout/main.jsx
@@ -88,6 +88,7 @@ const Main = ({ electricityMixMode }) => {
   // Poll solar data if the toggle is enabled.
   useConditionalSolarDataPolling();
 
+  // Note: we could also query static.electricitymap.org/public_web/client-version.json instead
   const { data: clientVersionData } = useSWR('/client-version.json', fetcher, {
     refreshInterval: CLIENT_VERSION_CHECK_INTERVAL,
   });
@@ -100,7 +101,7 @@ const Main = ({ electricityMixMode }) => {
   }
 
   if (isClientVersionOutdated) {
-    console.warn(`Current client version: ${clientVersion} is outdated`);
+    console.warn(`New client version available: ${clientVersion}`);
   }
 
   return (


### PR DESCRIPTION
## Issue
This screen was often visible when a new deployment was made

<img width="797" alt="image" src="https://user-images.githubusercontent.com/1655848/187910977-c231853f-df4c-47d5-b229-4c452ae1f838.png">


It turns out the HTTP call used to check the new version is actually cached in the browser:

<img width="271" alt="image" src="https://user-images.githubusercontent.com/1655848/187911068-9aa5d0b5-cbf2-4b92-b042-1e4354c27e7f.png">


Cache duration: 24h

<img width="274" alt="image" src="https://user-images.githubusercontent.com/1655848/187911133-75005443-e6b5-40c9-a955-4b4bae3d5258.png">

There are two ways to fix this, as it turns out the client-version.json file can be served by two systems:
1. call the static.electricitymap.org version, which has the right cache headers
2. update server.js to override cache values

I opted for option 2 for now.