### PR TITLE
Update US-HI-OA generation capacities

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -370,19 +370,19 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Turkey: [TEIAS](https://www.teias.gov.tr/tr-TR/kurulu-guc-raporlari)
 - Ukraine: [UKRENERGO](https://ua.energy/vstanovlena-potuzhnist-energosystemy-ukrayiny/)
 - United Arab Emirates: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)
-- United States of America
+- United States of America:
   - Federal: [EIA](https://www.eia.gov/electricity/data.cfm#gencapacity)
   - Balancing Authorities: [EIA](https://www.eia.gov/electricity/data/eia860M/)
   - States: [EIA](https://www.eia.gov/electricity/data/state/)
-    - Hawaii
-      - Battery storage: https://www.kapoleienergystorage.com/
-      - Coal: [https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)
-      - Other: https://www.eia.gov/electricity/data/eia860M/
   - BPA: [BPA](https://transmission.bpa.gov/business/operations/Wind/baltwg.aspx)
-  - CAISO
+  - CAISO:
     - CEC: [CEC](https://ww2.energy.ca.gov/almanac/electricity_data/electric_generation_capacity.html)
     - Renewables: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
     - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Diablo_Canyon_Power_Plant)
+  - Hawaii:
+      - Battery storage: https://www.kapoleienergystorage.com/
+      - Coal: [https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)
+      - Other: https://www.eia.gov/electricity/data/eia860M/
   - NYISO: [NYISO Gold Book](https://www.nyiso.com/documents/20142/2226333/2021-Gold-Book-Final-Public.pdf)
   - PJM: [PJM](http://www.pjm.com/-/media/markets-ops/ops-analysis/capacity-by-fuel-type-2019.ashx?la=en)
   - SPP: [SPP](https://www.spp.org/about-us/fast-facts/)

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -374,6 +374,10 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Federal: [EIA](https://www.eia.gov/electricity/data.cfm#gencapacity)
   - Balancing Authorities: [EIA](https://www.eia.gov/electricity/data/eia860M/)
   - States: [EIA](https://www.eia.gov/electricity/data/state/)
+    - Hawaii
+      - Battery storage: https://www.kapoleienergystorage.com/
+      - Coal: [https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)
+      - Other: https://www.eia.gov/electricity/data/eia860M/
   - BPA: [BPA](https://transmission.bpa.gov/business/operations/Wind/baltwg.aspx)
   - CAISO
     - CEC: [CEC](https://ww2.energy.ca.gov/almanac/electricity_data/electric_generation_capacity.html)

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -380,9 +380,9 @@ For many European countries, data is available from [ENTSO-E](https://transparen
     - Renewables: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
     - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Diablo_Canyon_Power_Plant)
   - Hawaii
-      - Battery storage: [Kapolei Energy Storage Project](https://www.kapoleienergystorage.com/)
-      - Coal: [The Guardian: Hawaii to close its only coal power plant in a step toward renewable energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)
-      - Other: [EIA](https://www.eia.gov/electricity/data/eia860M/)
+    - Battery storage: [Kapolei Energy Storage Project](https://www.kapoleienergystorage.com/)
+    - Coal: [The Guardian: Hawaii to close its only coal power plant in a step toward renewable energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)
+    - Other: [EIA](https://www.eia.gov/electricity/data/eia860M/)
   - NYISO: [NYISO Gold Book](https://www.nyiso.com/documents/20142/2226333/2021-Gold-Book-Final-Public.pdf)
   - PJM: [PJM](http://www.pjm.com/-/media/markets-ops/ops-analysis/capacity-by-fuel-type-2019.ashx?la=en)
   - SPP: [SPP](https://www.spp.org/about-us/fast-facts/)

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -380,9 +380,9 @@ For many European countries, data is available from [ENTSO-E](https://transparen
     - Renewables: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
     - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Diablo_Canyon_Power_Plant)
   - Hawaii
-      - Battery storage: https://www.kapoleienergystorage.com/
-      - Coal: [https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)
-      - Other: https://www.eia.gov/electricity/data/eia860M/
+      - Battery storage: [Kapolei Energy Storage Project](https://www.kapoleienergystorage.com/)
+      - Coal: [The Guardian: Hawaii to close its only coal power plant in a step toward renewable energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)
+      - Other: [EIA](https://www.eia.gov/electricity/data/eia860M/)
   - NYISO: [NYISO Gold Book](https://www.nyiso.com/documents/20142/2226333/2021-Gold-Book-Final-Public.pdf)
   - PJM: [PJM](http://www.pjm.com/-/media/markets-ops/ops-analysis/capacity-by-fuel-type-2019.ashx?la=en)
   - SPP: [SPP](https://www.spp.org/about-us/fast-facts/)

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -370,16 +370,16 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Turkey: [TEIAS](https://www.teias.gov.tr/tr-TR/kurulu-guc-raporlari)
 - Ukraine: [UKRENERGO](https://ua.energy/vstanovlena-potuzhnist-energosystemy-ukrayiny/)
 - United Arab Emirates: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)
-- United States of America:
+- United States of America
   - Federal: [EIA](https://www.eia.gov/electricity/data.cfm#gencapacity)
   - Balancing Authorities: [EIA](https://www.eia.gov/electricity/data/eia860M/)
   - States: [EIA](https://www.eia.gov/electricity/data/state/)
   - BPA: [BPA](https://transmission.bpa.gov/business/operations/Wind/baltwg.aspx)
-  - CAISO:
+  - CAISO
     - CEC: [CEC](https://ww2.energy.ca.gov/almanac/electricity_data/electric_generation_capacity.html)
     - Renewables: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
     - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Diablo_Canyon_Power_Plant)
-  - Hawaii:
+  - Hawaii
       - Battery storage: https://www.kapoleienergystorage.com/
       - Coal: [https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)
       - Other: https://www.eia.gov/electricity/data/eia860M/

--- a/config/zones.json
+++ b/config/zones.json
@@ -5428,7 +5428,7 @@
       "unknown": 0,
       "wind": 126.6
     },
-    "contributors": ["kepiej", "systemcatch", "KabelWlan", "danielmatsuda"],
+    "contributors": ["kepiej", "systemcatch", "KabelWlan", "danielmatsuda", "brandongalbraith"],
     "flag_file_name": "us.png",
     "parsers": {
       "production": "US_HI.fetch_production"

--- a/config/zones.json
+++ b/config/zones.json
@@ -5417,9 +5417,9 @@
       [-157.14716739499988, 22.209850429000085]
     ],
     "capacity": {
-      "battery storage": 1,
+      "battery storage": 186,
       "biomass": 157.7,
-      "coal": 203,
+      "coal": 0,
       "gas": 0,
       "geothermal": 0,
       "hydro": 0,


### PR DESCRIPTION
Oahu [1] (Hawaii) has decommissioned its last coal fired power plant [2]; battery storage has been increased by size specified by the project [3] intended to replace the coal fired generator.

[1] https://app.electricitymaps.com/zone/US-HI-OA?wind=false&solar=false

[2] https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy

[3] https://www.kapoleienergystorage.com/